### PR TITLE
Added a way to add dcmac code

### DIFF
--- a/submodules/v80-vitis-flow/resources/create_design.tcl
+++ b/submodules/v80-vitis-flow/resources/create_design.tcl
@@ -1,0 +1,74 @@
+# (c) Copyright 2024, Advanced Micro Devices, Inc.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a 
+# copy of this software and associated documentation files (the "Software"), 
+# to deal in the Software without restriction, including without limitation 
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+# and/or sell copies of the Software, and to permit persons to whom the 
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in 
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+# DEALINGS IN THE SOFTWARE.
+############################################################
+
+set src_dir        [file dirname [file normalize [info script]]]
+set cwd            [pwd]
+set design_name     "amd_v80_gen5x8_24.1"
+set bd_name         "top"
+
+proc do_aved_create_design { } { 
+  global bd_name
+  global src_dir
+  global design_name
+  # Create the project targeting its part
+  create_project prj "[pwd]/build" -part xcv80-lsva4737-2MHP-e-S -force
+
+
+  # Set project IP repositories
+  set_property ip_repo_paths "${src_dir}/iprepo" [current_project]
+  update_ip_catalog
+
+  # Create block diagram
+  create_bd_design  ${bd_name}
+  current_bd_design ${bd_name}
+
+  # Add base to block diagram
+  source "$src_dir/bd/create_bd_design.tcl"
+  create_root_design ""
+
+  # Add DCMAC
+  source "$src_dir/dcmac/tcl/dcmac.tcl"
+
+  # Add custom logic to AVED block design
+  source "$src_dir/run_pre.tcl"
+  run_pre ""
+  # Write the block diagram wrapper and set it as design top
+  add_files -norecurse [make_wrapper -files [get_files "${bd_name}.bd"] -top]
+  update_compile_order -fileset sources_1
+  update_compile_order -fileset sim_1
+  set_property top top_wrapper [current_fileset]
+
+  # Add constraint and hook files
+  import_files -fileset constrs_1 -norecurse "$src_dir/constraints/impl.xdc"
+  import_files -fileset constrs_1 -norecurse "$src_dir/constraints/impl.pins.xdc"
+  import_files -fileset utils_1   -norecurse "$src_dir/constraints/opt.post.tcl"
+  import_files -fileset utils_1   -norecurse "$src_dir/constraints/place.pre.tcl"
+  import_files -fileset utils_1   -norecurse "$src_dir/constraints/write_device_image.pre.tcl"
+
+  set_property -dict { used_in_synthesis false    processing_order NORMAL } [get_files *impl.xdc]
+  set_property -dict { used_in_synthesis false    processing_order NORMAL } [get_files *impl.pins.xdc]
+
+  set_property STEPS.OPT_DESIGN.TCL.POST         [get_files *opt.post.tcl]                [get_runs impl_1]
+  set_property STEPS.PLACE_DESIGN.TCL.PRE        [get_files *place.pre.tcl]               [get_runs impl_1]
+  set_property STEPS.WRITE_DEVICE_IMAGE.TCL.PRE  [get_files *write_device_image.pre.tcl]  [get_runs impl_1]
+}
+
+do_aved_create_design

--- a/submodules/v80-vitis-flow/resources/dcmac/tcl/dcmac.tcl
+++ b/submodules/v80-vitis-flow/resources/dcmac/tcl/dcmac.tcl
@@ -1,0 +1,26 @@
+# ##################################################################################################
+#  The MIT License (MIT)
+#  Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+#  and associated documentation files (the "Software"), to deal in the Software without restriction,
+#  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+#  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all copies or
+#  substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+# NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ##################################################################################################
+
+# hdl files from resources will be available in this script when running at "$src_dir/dcmac/hdl/..."
+proc add_dcmac {} {
+
+}
+
+add_dcmac

--- a/submodules/v80-vitis-flow/scripts/v80++
+++ b/submodules/v80-vitis-flow/scripts/v80++
@@ -131,7 +131,9 @@ pushd ${BUILD_DIR}
     if [ "$PLATFORM" = "hw" ]; then
         cp run_pre.tcl $AVED_DIR/hw/amd_v80_gen5x8_24.1/src/run_pre.tcl
         cp dcmac_config.tcl $AVED_DIR/hw/amd_v80_gen5x8_24.1/src/dcmac_config.tcl
+        cp -r ../resources/dcmac $AVED_DIR/hw/amd_v80_gen5x8_24.1/src/dcmac
         cp ../resources/run_post.tcl $AVED_DIR/hw/amd_v80_gen5x8_24.1/src/run_post.tcl
+        cp ../resources/create_design.tcl $AVED_DIR/hw/amd_v80_gen5x8_24.1/src/create_design.tcl
     fi
     if [ "$PLATFORM" = "emu" ]; then
         cpp_files="tb.cpp "


### PR DESCRIPTION
This pull request creates a way to add DCMAC code to the design creation process.

The create_design.tcl file from AVED is now copied in resources (`submodules/v80-vitis-flow/resources/`) and managed here.

A new directory in resources (`submodules/v80-vitis-flow/resources/dcmac/`) was created for dcmac code.

The function `add_dcmac` from `submodules/v80-vitis-flow/resources/dcmac/tcl/dcmac.tcl` is run on design creation. This function can reference hdl sources from `submodules/v80-vitis-flow/resources/dcmac/hdl/`