### PR TITLE
Fix setFrequency

### DIFF
--- a/vrt/src/api/device.cpp
+++ b/vrt/src/api/device.cpp
@@ -337,7 +337,7 @@ void Device::setFrequency(uint64_t freq) {
                                "Setting frequency {}, which is higher than max frequency {}", freq,
                                clockFreq);
         }
-        clkWiz.setRateHz(200000000);
+        clkWiz.setRateHz(freq);
     }
 }
 


### PR DESCRIPTION
Update `Device::setFrequency()` to use the user-provided freq parameter instead of the currently hardcoded 200MHz value.