### PR TITLE
Properly find_package-ing the CLI11 dependency of v80-smi

### DIFF
--- a/smi/CMakeLists.txt
+++ b/smi/CMakeLists.txt
@@ -55,6 +55,8 @@ if(NOT TARGET vrt::vrt)
     "Build and install vrt first (cmake --install), then configure smi again.")
 endif()
 
+find_package(CLI11 CONFIG REQUIRED)
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in"
     "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp"

--- a/smi/src/CMakeLists.txt
+++ b/smi/src/CMakeLists.txt
@@ -46,4 +46,5 @@ target_link_libraries(
     PRIVATE
 
     vrt::vrt
+    CLI11::CLI11
 )


### PR DESCRIPTION
This is just a small fix for a small issue, but the CMakeLists.txt for v80-smi didn't properly look up a dependency of this application. 