### PR TITLE
Enable compilation of module for Ubuntu 22.04 HWE kernels

### DIFF
--- a/driver/slash_dmabuf.c
+++ b/driver/slash_dmabuf.c
@@ -45,6 +45,7 @@
 #include <linux/pci.h>
 #include <linux/printk.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 /**
  * struct slash_bar_dmabuf_data - Private data attached to each BAR dma-buf.
@@ -180,8 +181,13 @@ static int slash_bar_dmabuf_mmap(struct dma_buf *dmabuf, struct vm_area_struct *
      * VM_DONTCOPY  — do not inherit across fork(); BAR register
      *                mappings should not be silently shared with children.
      */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+    vm_flags_set(vma, VM_PFNMAP | VM_IO | VM_DONTDUMP |
+                      VM_DONTEXPAND | VM_DONTCOPY);
+#else
     vma->vm_flags |= VM_PFNMAP | VM_IO | VM_DONTDUMP |
                      VM_DONTEXPAND | VM_DONTCOPY;
+#endif
 
     wc = !!(pci_resource_flags(priv->pdev, priv->bar_number) & IORESOURCE_PREFETCH);
     vma->vm_page_prot = wc ? pgprot_writecombine(vma->vm_page_prot)

--- a/driver/slash_main.c
+++ b/driver/slash_main.c
@@ -49,6 +49,7 @@
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/printk.h>
+#include <linux/version.h>
 
 #include "slash_pcie.h"
 #include "slash_hotplug_driver.h"
@@ -126,4 +127,8 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("AMD Inc.");
 MODULE_DESCRIPTION("SLASH/VRT module");
 MODULE_VERSION("1.0");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
 MODULE_IMPORT_NS(DMA_BUF);
+#endif

--- a/driver/slash_qdma.c
+++ b/driver/slash_qdma.c
@@ -819,7 +819,7 @@ err_exit_libqdma:
  * (which triggers slash_qdma_remove() for each probed device) and then
  * shuts down the libqdma library.
  */
-void __exit slash_qdma_exit(void)
+void slash_qdma_exit(void)
 {
     SLASH_QDMA_OP_LOG("exit start\n");
 

--- a/driver/slash_qdma.h
+++ b/driver/slash_qdma.h
@@ -59,6 +59,6 @@ int __init slash_qdma_init(unsigned int num_threads, char *debugfs);
  * Must be called after slash_pcie_exit() to ensure the control
  * function is cleaned up before the QDMA function.
  */
-void __exit slash_qdma_exit(void);
+void slash_qdma_exit(void);
 
 #endif /* SLASH_QDMA_H */


### PR DESCRIPTION
These small fixes enable building the slash kernel module for newer Linux kernel versions.

Ubuntu 22.04 HWE uses kernel 6.8.

These fixes enable compilation for kernels up to and including 6.14.

Unfortunately, libqdma uses an API dropped in 6.15, so we cannot cover Ubuntu 24.04 HWE (6.17).