### PR TITLE
Ask on package rebuild

### DIFF
--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -22,6 +22,14 @@
 
 set -euo pipefail
 
+NONINTERACTIVE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --noninteractive) NONINTERACTIVE=1; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
 # SLASH root
 cd "$(dirname "$0")/.."
 
@@ -32,7 +40,7 @@ export DPKG_ARCH="$(dpkg --print-architecture)"
 export DPKG_PARSED_VERSION="$(dpkg-parsechangelog -SVersion)"
 
 # Warn before overwriting an existing build
-if [[ -d "${ARTIFACTS_DIR}" ]] && [[ -t 0 ]]; then
+if [[ -d "${ARTIFACTS_DIR}" ]] && [[ -t 0 ]] && [[ "${NONINTERACTIVE}" -eq 0 ]]; then
     echo "WARNING: A previous .deb build already exists." >&2
     echo "Proceeding will remove the following directories and restart the build from scratch:" >&2
     echo "  ${ARTIFACTS_DIR}  (built .deb packages)" >&2

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-set -euxo pipefail
+set -euo pipefail
 
 # SLASH root
 cd "$(dirname "$0")/.."
@@ -30,6 +30,47 @@ VERSION="$(tr -d '[:space:]' < packaging/version)"
 export ARTIFACTS_DIR="${ARTIFACTS_DIR:-"$(pwd)"/deb}"
 export DPKG_ARCH="$(dpkg --print-architecture)"
 export DPKG_PARSED_VERSION="$(dpkg-parsechangelog -SVersion)"
+
+# Warn before overwriting an existing build
+if [[ -d "${ARTIFACTS_DIR}" ]] && [[ -t 0 ]]; then
+    echo "WARNING: A previous .deb build already exists." >&2
+    echo "Proceeding will remove the following directories and restart the build from scratch:" >&2
+    echo "  ${ARTIFACTS_DIR}  (built .deb packages)" >&2
+    echo "  pbuild/           (CMake build tree)" >&2
+    echo "  debian/           (generated packaging metadata)" >&2
+    echo "  linker/src/install.prj" >&2
+    echo "  linker/resources/abstract_shell" >&2
+    echo "This includes the static shell, which can take several hours to rebuild." >&2
+    read -r -p "Overwrite existing build and start from scratch? [y/N] " _answer </dev/tty
+    case "${_answer}" in
+        [yY]|[yY][eE][sS]) ;;
+        *) echo "Aborted." >&2; exit 1 ;;
+    esac
+fi
+
+# Check build prerequisites
+_prereq_ok=1
+
+if ! command -v v++ > /dev/null 2>&1; then
+    echo "ERROR: v++ not found in PATH. Source Vitis 2025.1 before building:" >&2
+    echo "  source <path-to-vitis>/settings64.sh" >&2
+    echo "See docs/tutorials/admin/platform-setup.rst for details." >&2
+    _prereq_ok=0
+fi
+
+if ! compgen -G 'linker/resources/base/iprepo/smbus*/' > /dev/null 2>&1; then
+    echo "ERROR: SMBus IP (xilinx.com:ip:smbus:1.1) not found in linker/resources/base/iprepo/." >&2
+    echo "Download it from https://www.xilinx.com/member/v80.html and place the IP" >&2
+    echo "directory into linker/resources/base/iprepo/ before building." >&2
+    echo "See docs/tutorials/admin/platform-setup.rst for details." >&2
+    _prereq_ok=0
+fi
+
+if [[ "${_prereq_ok}" -eq 0 ]]; then
+    exit 1
+fi
+
+set -x
 
 # Clean build
 rm -rf deb

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-set -euxo pipefail
+set -euo pipefail
 
 # SLASH root
 cd "$(dirname "$0")/.."
@@ -29,7 +29,48 @@ VERSION="$(tr -d '[:space:]' < packaging/version)"
 TOPDIR="$(pwd)/rpmbuild"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-$(pwd)/rpm}"
 
-rm -rf "${TOPDIR}" "${ARTIFACTS_DIR}"
+# Warn before overwriting an existing build
+if { [[ -d "${TOPDIR}" ]] || [[ -d "${ARTIFACTS_DIR}" ]] || [[ -d pbuild ]]; } && [[ -t 0 ]]; then
+    echo "WARNING: A previous .rpm build already exists." >&2
+    echo "Proceeding will remove the following directories and restart the build from scratch:" >&2
+    [[ -d "${TOPDIR}" ]]        && echo "  ${TOPDIR}  (rpmbuild tree)" >&2
+    [[ -d "${ARTIFACTS_DIR}" ]] && echo "  ${ARTIFACTS_DIR}  (built .rpm packages)" >&2
+    [[ -d pbuild ]]             && echo "  pbuild/  (CMake build tree)" >&2
+    echo "  linker/src/install.prj" >&2
+    echo "  linker/resources/abstract_shell" >&2
+    echo "This includes the static shell, which can take several hours to rebuild." >&2
+    read -r -p "Overwrite existing build and start from scratch? [y/N] " _answer </dev/tty
+    case "${_answer}" in
+        [yY]|[yY][eE][sS]) ;;
+        *) echo "Aborted." >&2; exit 1 ;;
+    esac
+fi
+
+# Check build prerequisites
+_prereq_ok=1
+
+if ! command -v v++ > /dev/null 2>&1; then
+    echo "ERROR: v++ not found in PATH. Source Vitis 2025.1 before building:" >&2
+    echo "  source <path-to-vitis>/settings64.sh" >&2
+    echo "See docs/tutorials/admin/platform-setup.rst for details." >&2
+    _prereq_ok=0
+fi
+
+if ! compgen -G 'linker/resources/base/iprepo/smbus*/' > /dev/null 2>&1; then
+    echo "ERROR: SMBus IP (xilinx.com:ip:smbus:1.1) not found in linker/resources/base/iprepo/." >&2
+    echo "Download it from https://www.xilinx.com/member/v80.html and place the IP" >&2
+    echo "directory into linker/resources/base/iprepo/ before building." >&2
+    echo "See docs/tutorials/admin/platform-setup.rst for details." >&2
+    _prereq_ok=0
+fi
+
+if [[ "${_prereq_ok}" -eq 0 ]]; then
+    exit 1
+fi
+
+set -x
+
+rm -rf "${TOPDIR}" "${ARTIFACTS_DIR}" pbuild
 mkdir -p "${TOPDIR}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 mkdir -p "${ARTIFACTS_DIR}"
 

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -22,6 +22,14 @@
 
 set -euo pipefail
 
+NONINTERACTIVE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --noninteractive) NONINTERACTIVE=1; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
 # SLASH root
 cd "$(dirname "$0")/.."
 
@@ -30,7 +38,7 @@ TOPDIR="$(pwd)/rpmbuild"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-$(pwd)/rpm}"
 
 # Warn before overwriting an existing build
-if { [[ -d "${TOPDIR}" ]] || [[ -d "${ARTIFACTS_DIR}" ]] || [[ -d pbuild ]]; } && [[ -t 0 ]]; then
+if [[ -d "${ARTIFACTS_DIR}" ]] && [[ -t 0 ]] && [[ "${NONINTERACTIVE}" -eq 0 ]]; then
     echo "WARNING: A previous .rpm build already exists." >&2
     echo "Proceeding will remove the following directories and restart the build from scratch:" >&2
     [[ -d "${TOPDIR}" ]]        && echo "  ${TOPDIR}  (rpmbuild tree)" >&2


### PR DESCRIPTION
The package-deb.sh and package-rpm.sh scripts run a full clean build, including the static shell, starting by removing any previous build.

This patch asks the user if they really want to run the rebuild, to prevent accidental removals.

If the script is run non-interactively (stdin is not a terminal), this question is skipped.

This patch also adds early checks for v++ in path (Vivado/Vitis sourced) and for the smbus, so that the build fails early with descriptive errors if the user has not satisfied the prerequisites for build.