### PR TITLE
Enabling tests in the unit testing GHA workflow

### DIFF
--- a/.github/workflows/vrt-unit-test.yml
+++ b/.github/workflows/vrt-unit-test.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir vrt/build
           cd vrt/build
-          cmake -DVRT_INCLUDE_VRTD=1 -DVRTD_INCLUDE_LIBSLASH=1 -DENABLE_COVERAGE=1 ..
+          cmake -DVRT_INCLUDE_VRTD=1 -DVRTD_INCLUDE_LIBSLASH=1 -DVRT_BUILD_TESTS=1 -DENABLE_COVERAGE=1 ..
           make unit_tests -j$(nproc)
           cd tests && ctest --output-on-failure
 


### PR DESCRIPTION
Commit 2d35a31939acccbf2893c360550f8494cff6fd26 has gated the VRT unit tests behind a cmake option. However, I have missed to add this option to the GitHub Actions workflow that's supposed to build and run the unit tests. This PR fixes that.