### PR TITLE
Fixing the evaluating of HLS metadata for simulation

### DIFF
--- a/.github/workflows/vrt-unit-test.yml
+++ b/.github/workflows/vrt-unit-test.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt upgrade -y
           sudo apt install -y cmake pkg-config ninja-build \
           libxml2-dev libzmq3-dev libjsoncpp-dev zlib1g-dev \
           libsystemd-dev libinih-dev libcli11-dev lcov python3-zmq

--- a/linker/src/emit/sim/tcl_gen.py
+++ b/linker/src/emit/sim/tcl_gen.py
@@ -231,7 +231,6 @@ def generate_sim_tcl(config: LinkerConfiguration) -> None:
         kernel.name: kernel.hls_data_path for kernel in config.kernels}
 
     kernel_sim_meta: dict[str, dict] = {}
-    kernel_hls_by_type: dict[str, Path] = {}
     for kernel in config.kernels:
         kpath = kernel.component_xml_path
 


### PR DESCRIPTION
`generate_sim_tcl` was overwriting its `kernel_hls_by_type` mapping with an empty dict immediately after building it, so `build_system_map_context` received no HLS metadata and silently fell back to the register-stem heuristic in `_build_functional_args_fallback`.

The user-visible effect: for simulation builds, buffer-typed `<arg>` entries in `system_map.xml` were emitted **without the `port=` attribute** (the fallback has no access to the `hwRefs` interface info needed to resolve the AXI4FULL port), and arg `name` attributes were derived from register stems rather than the original HLS argument name. Emulation builds were unaffected because `generate_emu_tcl` populates the dict correctly.

**Reproduction**

Build `examples/00_axilite` for both emulation and simulation and diff the two `system_map.xml` files. Before this fix, the `increment_0` buffer arg appears as:

```xml
<!-- emu (correct) -->
<arg idx="1" name="in_r" type="buffer" offset="0x18" range="64" r="0" w="1" port="m_axi_gmem0" />

<!-- sim (broken) -->
<arg idx="1" name="input_r" type="buffer" offset="0x18" range="64" r="0" w="1" />
```

**Fix**

Drop the stray `kernel_hls_by_type: dict[str, Path] = {}` re-declaration in `linker/v80pp/emit/sim/tcl_gen.py` so the populated mapping survives into `build_system_map_context`. With HLS metadata available, the existing logic at `system_map_ctx.py:249-271` correctly resolves and emits the `port=` attribute, and arg names come from the HLS `Args` rather than register stems.