### PR TITLE
Small fixes addressing C/C++ warnings

### DIFF
--- a/vrt/src/allocator/allocator.cpp
+++ b/vrt/src/allocator/allocator.cpp
@@ -25,6 +25,9 @@
 
 #include <vrt/allocator/allocator.hpp>
 
+#include <cstdlib>
+
+#include <vrt/utils/logger.hpp>
 #include <vrtd/device.hpp>
 
 namespace vrt {
@@ -193,7 +196,9 @@ LargeBlockSuperblock::LargeBlockSuperblock(vrtd::Device& device, BufferAllocType
 
 LargeBlockSuperblock::~LargeBlockSuperblock() {
     if (!isFree()) {
-        throw std::runtime_error("Cannot destroy LargeBlockSuperblock: not all memory has been deallocated");
+        utils::Logger::log(utils::LogLevel::ERROR, __PRETTY_FUNCTION__,
+            "LargeBlockSuperblock destroyed while not all memory was deallocated");
+        std::abort();
     }
 }
 
@@ -220,7 +225,9 @@ MediumBlockSuperblock::MediumBlockSuperblock(LargeBlockSuperblock *backingSuperb
 
 MediumBlockSuperblock::~MediumBlockSuperblock() {
     if (!isFree()) {
-        throw std::runtime_error("Cannot destroy MediumBlockSuperblock: not all memory has been deallocated");
+        utils::Logger::log(utils::LogLevel::ERROR, __PRETTY_FUNCTION__,
+            "MediumBlockSuperblock destroyed while not all memory was deallocated");
+        std::abort();
     }
 }
 

--- a/vrt/src/device.cpp
+++ b/vrt/src/device.cpp
@@ -267,7 +267,13 @@ Device::Device(const std::string& bdf, const std::string& vrtbinPath, bool progr
         }
 
         const std::string emuCommand = makeExecFromBinaryDirCommand(emulationExecPath);
-        runtimeThread = std::thread([emuCommand]() { std::system(emuCommand.c_str()); });
+        runtimeThread = std::thread([emuCommand]() {
+            int rc = std::system(emuCommand.c_str());
+            if (rc != 0) {
+                utils::Logger::log(utils::LogLevel::WARN, __PRETTY_FUNCTION__,
+                    "Emulation process exited with code {}", rc);
+            }
+        });
 
     } else {
         parseSystemMap();
@@ -281,7 +287,13 @@ Device::Device(const std::string& bdf, const std::string& vrtbinPath, bool progr
         }
 
         const std::string simCommand = makeExecFromBinaryDirCommand(simulationExecPath);
-        runtimeThread = std::thread([simCommand]() { std::system(simCommand.c_str()); });
+        runtimeThread = std::thread([simCommand]() {
+            int rc = std::system(simCommand.c_str());
+            if (rc != 0) {
+                utils::Logger::log(utils::LogLevel::WARN, __PRETTY_FUNCTION__,
+                    "Simulation process exited with code {}", rc);
+            }
+        });
         Json::Value command;
         command["command"] = "start";
         zmqServer->sendCommand(command);

--- a/vrt/src/utils/zmq_server.cpp
+++ b/vrt/src/utils/zmq_server.cpp
@@ -42,7 +42,10 @@ void ZmqServer::sendBuffer(const std::string& name, const std::vector<uint8_t>& 
     socket.send(data, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in sendBuffer");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 }
 
@@ -54,7 +57,10 @@ void ZmqServer::sendCommand(const Json::Value& command) {
     memcpy(request.data(), commandStr.data(), commandStr.size());
     socket.send(request, zmq::send_flags::none);
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in sendCommand");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
     if (replyStr != "OK") {
         throw std::runtime_error("ZMQ command failed: " + replyStr);
@@ -83,7 +89,10 @@ uint32_t ZmqServer::fetchScalar(const std::string& function, const std::string& 
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in fetchScalar");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 
     Json::Value response;
@@ -114,7 +123,10 @@ uint32_t ZmqServer::readRegister(const std::string& function, uint32_t offset) {
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in readRegister");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 
     Json::Value response;
@@ -152,7 +164,10 @@ std::vector<uint8_t> ZmqServer::fetchBuffer(const std::string& name) {
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in fetchBuffer");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 
     Json::Value response;
@@ -181,7 +196,10 @@ void ZmqServer::sendStream(const std::string& name, const std::vector<uint8_t>& 
     socket.send(data, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in sendStream");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 }
 
@@ -199,7 +217,10 @@ std::vector<uint8_t> ZmqServer::fetchStream(const std::string& name, size_t size
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in fetchStream");
+    }
     std::vector<uint8_t> buffer(reply.size());
     memcpy(buffer.data(), reply.data(), reply.size());
     return buffer;
@@ -222,7 +243,10 @@ void ZmqServer::fetchBufferSim(uint64_t addr, uint64_t size, std::vector<uint8_t
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in fetchBufferSim");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 
     Json::Value response;
@@ -248,7 +272,10 @@ uint32_t ZmqServer::fetchScalarSim(uint64_t addr) {
     socket.send(request, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in fetchScalarSim");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 
     Json::Value response;
@@ -270,7 +297,10 @@ void ZmqServer::sendBufferSim(uint64_t addr, const std::vector<uint8_t>& buffer)
     socket.send(dataMsg, zmq::send_flags::none);
 
     zmq::message_t reply;
-    socket.recv(reply);
+    auto recvResult = socket.recv(reply);
+    if (!recvResult) {
+        throw std::runtime_error("ZMQ recv failed in sendBufferSim");
+    }
     std::string replyStr(static_cast<char*>(reply.data()), reply.size());
 }
 

--- a/vrt/vrtd/src/serve.c
+++ b/vrt/vrtd/src/serve.c
@@ -1643,10 +1643,13 @@ static uint16_t client_handle_request_qdma_get_info(
         return VRTD_RET_NOEXIST;
     }
 
-    if (slash_qdma_info_read(d->qdma, &resp_body->info) != 0) {
+    /* resp_body is packed; libslash expects a normally-aligned pointer. */
+    struct slash_qdma_info info;
+    if (slash_qdma_info_read(d->qdma, &info) != 0) {
         LOG(LOG_WARNING, "qdma_get_info: failed to read info for device %u: %m", (unsigned int)req_body->dev_number);
         return VRTD_RET_INTERNAL_ERROR;
     }
+    memcpy(&resp_body->info, &info, sizeof(info));
 
     *resp_size = sizeof(*resp_body);
 
@@ -1710,18 +1713,19 @@ static uint16_t client_handle_request_qdma_qpair_add(
         return VRTD_RET_NOEXIST;
     }
 
-    /* Copy request parameters into resp_body->add; the kernel fills in qid. */
-    resp_body->add = req_body->add;
+    /* resp_body is packed; libslash expects a normally-aligned pointer. */
+    struct slash_qdma_qpair_add add = req_body->add;
 
-    if (slash_qdma_qpair_add(d->qdma, &resp_body->add) != 0) {
+    if (slash_qdma_qpair_add(d->qdma, &add) != 0) {
         LOG(LOG_WARNING, "qdma_qpair_add: failed for device %u: %m", (unsigned int)req_body->dev_number);
         return VRTD_RET_INTERNAL_ERROR;
     }
+    memcpy(&resp_body->add, &add, sizeof(add));
 
     *resp_size = sizeof(*resp_body);
 
     LOG(LOG_DEBUG, "qdma_qpair_add: dev=%u qid=%u uid=%u conn_id=%llu",
-        (unsigned int)req_body->dev_number, (unsigned int)resp_body->add.qid,
+        (unsigned int)req_body->dev_number, (unsigned int)add.qid,
         (unsigned int)client->uid, (unsigned long long)client->conn_id);
 
     return VRTD_RET_OK;


### PR DESCRIPTION
The C/C++ code should compile without warnings after this patch.

The fixes are:

* aborting instead of throwing in a destructor on an error
* checking return values
* using a temporary variable instead of a potentially unaligned pointer