### PR TITLE
[Driver] Fixing the user_size-based versioning of ioctl argument structs

### DIFF
--- a/driver/slash_ctldev.c
+++ b/driver/slash_ctldev.c
@@ -645,9 +645,6 @@ static long slash_ctldev_fop_ioctl(struct file *file, unsigned int op, unsigned 
             return -EFAULT;
         }
 
-        if (!user_size || user_size > sizeof(info))
-            user_size = sizeof(info);
-
         memset(&info, 0, sizeof(info));
         info.size = sizeof(info);
 
@@ -661,6 +658,15 @@ static long slash_ctldev_fop_ioctl(struct file *file, unsigned int op, unsigned 
         if (copy_to_user((void __user *)arg, &info, copy_size)) {
             dev_err(&pdev->dev, "ctldev: SLASH_CTLDEV_IOCTL_GET_DEVICE_INFO copy_to_user failed\n");
             return -EFAULT;
+        }
+        if (user_size > sizeof(info)) {
+            size_t extra = user_size - sizeof(info);
+            void __user *dst = (void __user *)((unsigned long)arg + sizeof(info));
+
+            if (clear_user(dst, extra)) {
+                dev_err(&pdev->dev, "ctldev: SLASH_CTLDEV_IOCTL_GET_DEVICE_INFO clear_user failed\n");
+                return -EFAULT;
+            }
         }
 
         return 0;

--- a/driver/slash_qdma.c
+++ b/driver/slash_qdma.c
@@ -1338,10 +1338,6 @@ static int slash_qdma_ioctl_info_w(struct miscdevice *misc,
     if (copy_from_user(&user_size, uarg, sizeof(user_size)))
         return -EFAULT;
 
-    if (!user_size || user_size > sizeof(info))
-        user_size = sizeof(info);
-
-
     memset(&info, 0, sizeof(info));
     info.size = sizeof(info);
 
@@ -1356,6 +1352,11 @@ static int slash_qdma_ioctl_info_w(struct miscdevice *misc,
     copy_size = min_t(size_t, user_size, sizeof(info));
     if (copy_to_user(uarg, &info, copy_size))
         return -EFAULT;
+    if (user_size > sizeof(info)) {
+        if (clear_user((void __user *)((unsigned long)uarg + sizeof(info)),
+                       user_size - sizeof(info)))
+            return -EFAULT;
+    }
 
     return 0;
 }
@@ -1419,12 +1420,9 @@ static int slash_qdma_ioctl_qpair_add_w(struct miscdevice *misc,
     if (copy_from_user(&user_size, uarg, sizeof(user_size)))
         return -EFAULT;
 
-    if (!user_size || user_size > sizeof(req))
-        user_size = sizeof(req);
-
     memset(&req, 0, sizeof(req));
 
-    if (copy_from_user(&req, uarg, user_size))
+    if (copy_from_user(&req, uarg, min_t(size_t, user_size, sizeof(req))))
         return -EFAULT;
 
     /* Validate direction mask: must be non-zero and contain only known bits. */
@@ -1464,6 +1462,11 @@ static int slash_qdma_ioctl_qpair_add_w(struct miscdevice *misc,
     copy_size = min_t(size_t, user_size, sizeof(req));
     if (copy_to_user(uarg, &req, copy_size))
         return -EFAULT;
+    if (user_size > sizeof(req)) {
+        if (clear_user((void __user *)((unsigned long)uarg + sizeof(req)),
+                       user_size - sizeof(req)))
+            return -EFAULT;
+    }
 
     return err;
 }
@@ -1756,12 +1759,9 @@ static int slash_qdma_ioctl_qpair_op_w(struct miscdevice *misc,
     if (copy_from_user(&user_size, uarg, sizeof(user_size)))
         return -EFAULT;
 
-    if (!user_size || user_size > sizeof(req))
-        user_size = sizeof(req);
-
     memset(&req, 0, sizeof(req));
 
-    if (copy_from_user(&req, uarg, user_size))
+    if (copy_from_user(&req, uarg, min_t(size_t, user_size, sizeof(req))))
         return -EFAULT;
 
     if (req.op > SLASH_QDMA_QUEUE_OP_DEL)
@@ -1787,6 +1787,11 @@ static int slash_qdma_ioctl_qpair_op_w(struct miscdevice *misc,
     copy_size = min_t(size_t, user_size, sizeof(req));
     if (copy_to_user(uarg, &req, copy_size))
         return -EFAULT;
+    if (user_size > sizeof(req)) {
+        if (clear_user((void __user *)((unsigned long)uarg + sizeof(req)),
+                       user_size - sizeof(req)))
+            return -EFAULT;
+    }
 
     return ret;
 }
@@ -2355,12 +2360,9 @@ static int slash_qdma_ioctl_qpair_get_fd_w(struct miscdevice *misc,
     if (copy_from_user(&user_size, uarg, sizeof(user_size)))
         return -EFAULT;
 
-    if (!user_size || user_size > sizeof(req))
-        user_size = sizeof(req);
-
     memset(&req, 0, sizeof(req));
 
-    if (copy_from_user(&req, uarg, user_size))
+    if (copy_from_user(&req, uarg, min_t(size_t, user_size, sizeof(req))))
         return -EFAULT;
 
     /* Only O_CLOEXEC is a valid flag. */
@@ -2430,6 +2432,14 @@ static int slash_qdma_ioctl_qpair_get_fd_w(struct miscdevice *misc,
         put_unused_fd(fd);
         fput(file); /* triggers slash_qdma_qpair_release -> drops entry/dev refs, frees ctx */
         return -EFAULT;
+    }
+    if (user_size > sizeof(req)) {
+        if (clear_user((void __user *)((unsigned long)uarg + sizeof(req)),
+                       user_size - sizeof(req))) {
+            put_unused_fd(fd);
+            fput(file);
+            return -EFAULT;
+        }
     }
 
     /*


### PR DESCRIPTION
Five ioctl wrapper functions in the driver contained the following pattern:

```c
if (!user_size || user_size > sizeof(req))
    user_size = sizeof(req);
```

This condition is wrong in two independent ways:

**1. The `!user_size` branch violates the ABI contract.**
When userspace passes `size = 0`, the kernel silently inflated `user_size` to `sizeof(req)` and then wrote that many bytes back into the user's buffer — past whatever the caller actually allocated. The kernel must never write beyond what the caller offered.

**2. The `user_size > sizeof(req)` branch breaks forward compatibility.**
When a newer userspace with a larger struct talks to an older kernel, the correct behaviour (per the size-versioning protocol used consistently in `GET_BAR_INFO` and `GET_BAR_FD`) is to write the kernel's fields and zero-fill the remaining tail via `clear_user()`, so userspace can safely assume unknown fields read as zero. The clamping silently skipped that zero-fill, leaving stale memory in the tail and making it impossible to add new fields to any of the affected structs without breaking older-kernel deployments.

The affected ioctls were:
- `SLASH_CTLDEV_IOCTL_GET_DEVICE_INFO` (`slash_ctldev.c`)
- `SLASH_QDMA_IOCTL_INFO` (`slash_qdma.c`)
- `SLASH_QDMA_IOCTL_QPAIR_ADD` (`slash_qdma.c`)
- `SLASH_QDMA_IOCTL_Q_OP` (`slash_qdma.c`)
- `SLASH_QDMA_IOCTL_QPAIR_GET_FD` (`slash_qdma.c`)

## Fix

- Remove the clamping condition entirely from all five sites.
- For ioctls that copy the struct body in from userspace (`QPAIR_ADD`, `Q_OP`, `QPAIR_GET_FD`), bound `copy_from_user` with `min_t(size_t, user_size, sizeof(req))` to prevent reading past the kernel struct.
- After each `copy_to_user`, add a `clear_user()` call for the tail when `user_size > sizeof(req)`, matching the pattern already used correctly by `GET_BAR_INFO` and `GET_BAR_FD`.

`libslash` is unaffected: every call site already sets `size = sizeof(...)` explicitly.

## Review

@serbuvlad (I can't add you as a reviewer yet)