### PR TITLE
Make slash kernel module follow versioning

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -15,7 +15,11 @@
 
 MODULE      := slash
 
+ifneq ($(KERNELDIR),)
+KDIR        ?= $(KERNELDIR)
+else
 KDIR        ?= /lib/modules/$(shell uname -r)/build
+endif
 PWD         := $(shell pwd)
 
 # Driver version. Priority:

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -18,6 +18,15 @@ MODULE      := slash
 KDIR        ?= /lib/modules/$(shell uname -r)/build
 PWD         := $(shell pwd)
 
+# Driver version. Priority:
+#   1. SLASH_VERSION passed in (e.g. from DKMS MAKE[0]).
+#   2. packaging/version file (in-tree builds).
+#   3. "unknown" fallback (DKMS install tree has no packaging/version).
+SLASH_VERSION ?= $(strip $(shell cat $(src)/../packaging/version 2>/dev/null))
+ifeq ($(SLASH_VERSION),)
+SLASH_VERSION := unknown
+endif
+
 # This exists when installed for dkms
 LIBQDMA_LOCAL_DIR := ./libqdma
 # This exists when building from tree
@@ -50,7 +59,8 @@ ccflags-y += \
 	-I$(src)/$(LIBQDMA_PATH)/qdma_access/qdma_soft_access \
 	\
 	-DTANDEM_BOOT_SUPPORTED=1 \
-	-DSLASH_QDMA_OP_DEBUG=$(SLASH_QDMA_OP_DEBUG)
+	-DSLASH_QDMA_OP_DEBUG=$(SLASH_QDMA_OP_DEBUG) \
+	-DSLASH_VERSION_STR=\"$(SLASH_VERSION)\"
 
 
 LIBQDMA_OBJS := \

--- a/driver/slash_main.c
+++ b/driver/slash_main.c
@@ -55,6 +55,10 @@
 #include "slash_hotplug_driver.h"
 #include "slash_qdma.h"
 
+#ifndef SLASH_VERSION_STR
+#define SLASH_VERSION_STR "unknown"
+#endif
+
 /** Number of worker threads for libqdma's internal processing. */
 static unsigned int qdma_num_threads = 8;
 /** Optional debugfs mount path for libqdma diagnostics (unused). */
@@ -126,7 +130,7 @@ MODULE_PARM_DESC(qdma_debugfs_path, "debugfs mount path for libqdma (default: di
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("AMD Inc.");
 MODULE_DESCRIPTION("SLASH/VRT module");
-MODULE_VERSION("1.0");
+MODULE_VERSION(SLASH_VERSION_STR);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 MODULE_IMPORT_NS("DMA_BUF");
 #else

--- a/packaging/debian/slash-dkms.dkms
+++ b/packaging/debian/slash-dkms.dkms
@@ -26,5 +26,5 @@ BUILT_MODULE_LOCATION[0]="driver"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="yes"
 
-MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
-CLEAN="make -C driver clean"
+MAKE[0]="make -C driver KDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
+CLEAN="make -C driver KDIR=/lib/modules/${kernelver}/build clean"

--- a/packaging/debian/slash-dkms.dkms
+++ b/packaging/debian/slash-dkms.dkms
@@ -19,12 +19,12 @@
 # ##################################################################################################
 
 PACKAGE_NAME="slash"
-PACKAGE_VERSION="0.1"
+PACKAGE_VERSION="@VERSION@"
 
 BUILT_MODULE_NAME[0]="slash"
 BUILT_MODULE_LOCATION[0]="driver"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="yes"
 
-MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build"
+MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
 CLEAN="make -C driver clean"

--- a/packaging/debian/slash-dkms.install
+++ b/packaging/debian/slash-dkms.install
@@ -18,9 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-driver/*.c            usr/src/slash-0.1/driver/
-driver/*.h            usr/src/slash-0.1/driver/
-driver/Makefile       usr/src/slash-0.1/driver/
-driver/libslash/include/slash/uapi  usr/src/slash-0.1/driver/libslash/include/slash/
+driver/*.c            usr/src/slash-@VERSION@/driver/
+driver/*.h            usr/src/slash-@VERSION@/driver/
+driver/Makefile       usr/src/slash-@VERSION@/driver/
+driver/libslash/include/slash/uapi  usr/src/slash-@VERSION@/driver/libslash/include/slash/
 
-submodules/qdma_drv/QDMA/linux-kernel/driver/libqdma/   usr/src/slash-0.1/driver/
+submodules/qdma_drv/QDMA/linux-kernel/driver/libqdma/   usr/src/slash-@VERSION@/driver/

--- a/packaging/rpm/slash.spec
+++ b/packaging/rpm/slash.spec
@@ -225,8 +225,8 @@ BUILT_MODULE_LOCATION[0]="driver"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="yes"
 
-MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
-CLEAN="make -C driver clean"
+MAKE[0]="make -C driver KDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
+CLEAN="make -C driver KDIR=/lib/modules/${kernelver}/build clean"
 EOF
 
 # ---- File lists ----

--- a/packaging/rpm/slash.spec
+++ b/packaging/rpm/slash.spec
@@ -20,7 +20,7 @@
 
 %global debug_package %{nil}
 %global dkms_name slash
-%global dkms_version 0.1
+%global dkms_version %{version}
 
 Name:           slash
 Version:        %{_version}
@@ -218,14 +218,14 @@ cp -a submodules/qdma_drv/QDMA/linux-kernel/driver/libqdma \
 # DKMS config (equivalent to debian/slash-dkms.dkms)
 cat > %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/dkms.conf << 'EOF'
 PACKAGE_NAME="slash"
-PACKAGE_VERSION="0.1"
+PACKAGE_VERSION="%{dkms_version}"
 
 BUILT_MODULE_NAME[0]="slash"
 BUILT_MODULE_LOCATION[0]="driver"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="yes"
 
-MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build"
+MAKE[0]="make -C driver KERNELDIR=/lib/modules/${kernelver}/build SLASH_VERSION=${PACKAGE_VERSION}"
 CLEAN="make -C driver clean"
 EOF
 

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -90,6 +90,11 @@ rsync -a packaging/debian/ ./debian/
 
 sed -i "1s/(UNRELEASED) UNRELEASED;/(${VERSION}) unstable;/" debian/changelog
 
+# Substitute the packaging version into DKMS metadata files.
+sed -i "s/@VERSION@/${VERSION}/g" \
+    debian/slash-dkms.dkms \
+    debian/slash-dkms.install
+
 rsync vrt/vrtd/systemd/vrtd.service debian/vrtd.service
 rsync vrt/vrtd/systemd/vrtd.socket  debian/vrtd.socket
 rsync vrt/vrtd/udev/99-vrtd.rules   debian/vrtd.udev


### PR DESCRIPTION
The slash kernel module still has some hardcoded versions.

This patch makes it follow packaging/version. It will use the version in packaging/version even when built from source, outside the package flow.