### PR TITLE
Initialize previously uninitialized variables in vrt::Kernel

### DIFF
--- a/vrt/include/vrt/kernel.hpp
+++ b/vrt/include/vrt/kernel.hpp
@@ -74,13 +74,13 @@ struct FunctionalArg {
 class Kernel {
     uint8_t bar = 0;                                          ///< Base Address Register (BAR)
     std::string name;                                         ///< Name of the kernel
-    uint64_t baseAddr;                                        ///< Base address of the kernel
-    uint64_t range;                                           ///< Address range of the kernel
+    uint64_t baseAddr = 0;                                    ///< Base address of the kernel
+    uint64_t range = 0;                                       ///< Address range of the kernel
     std::vector<Register> registers;                          ///< List of registers in the kernel
     std::vector<FunctionalArg> functionalArgs;                ///< Parsed function arguments from system_map.xml
     size_t currentArgIndex = 0;                               ///< Current call argument index
     std::string deviceBdf;                     ///< BDF of the device
-    Platform platform;                         ///< Platform of the device
+    Platform platform = Platform::UNKNOWN;     ///< Platform of the device
     std::shared_ptr<ZmqServer> server;         ///< Pointer to ZeroMQ server for communication
     std::map<uint32_t, uint32_t> registerMap;  ///< Map of register offsets to values
     std::map<uint32_t, uint64_t> setArgValues; ///< Values assigned through setArg(idx/name, value)


### PR DESCRIPTION
Some variables in vrt::Kernel were mistakenly left uninitialized, causing some tests to fail intermittently, depending on the values they obtained.

An example occurred in https://github.com/amd-vserbu/SLASH/actions/runs/25912530127/job/76160998621

```
 78/141 Test  #78: KernelArgValidationTest.EnsureSetArgValuesComplete ...........................................***Failed    0.01 sec
Running main() from /home/runner/work/SLASH/SLASH/vrt/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = KernelArgValidationTest.EnsureSetArgValuesComplete
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from KernelArgValidationTest
[ RUN      ] KernelArgValidationTest.EnsureSetArgValuesComplete
/home/runner/work/SLASH/SLASH/vrt/tests/kernel_test.cpp:131: Failure
Expected: k.call() doesn't throw an exception.
  Actual: it throws std::runtime_error with description "vrtd BAR handle not initialized".

[  FAILED  ] KernelArgValidationTest.EnsureSetArgValuesComplete (1 ms)
[----------] 1 test from KernelArgValidationTest (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] KernelArgValidationTest.EnsureSetArgValuesComplete

 1 FAILED TEST
 ```
 
 This patch fixes this issue.