### PR TITLE
Update ami_tool flash path in documentation

### DIFF
--- a/docs/tutorials/admin/platform-setup.rst
+++ b/docs/tutorials/admin/platform-setup.rst
@@ -353,7 +353,7 @@ from ``lspci -d 10ee:``, e.g. ``03:00``):
       .. code-block:: bash
 
          sudo ami_tool cfgmem_program -d <BDF> -t primary -p 0 \
-            -i /usr/lib/python3.10/site-packages/slashkit/resources/static_shell/amd_v80_gen5x8_25.1.pdi
+            -i /usr/lib/python3.10/dist-packages/slashkit/resources/static_shell/amd_v80_gen5x8_25.1.pdi
 
    .. tab-item:: RHEL 9 / Rocky Linux 9 / AlmaLinux 9
 

--- a/docs/tutorials/admin/platform-setup.rst
+++ b/docs/tutorials/admin/platform-setup.rst
@@ -346,10 +346,28 @@ operations — SLASH reads from flash but never writes to it during regular use.
 Program the primary flash partition (replace ``<BDF>`` with the bus address
 from ``lspci -d 10ee:``, e.g. ``03:00``):
 
-.. code-block:: bash
+.. tab-set::
 
-   sudo ami_tool cfgmem_program -d <BDF> -t primary -p 0 \
-       -i /usr/share/slashkit/static_shell/amd_v80_gen5x8_25.1.pdi
+   .. tab-item:: Ubuntu
+
+      .. code-block:: bash
+
+         sudo ami_tool cfgmem_program -d <BDF> -t primary -p 0 \
+            -i /usr/lib/python3.10/site-packages/slashkit/resources/static_shell/amd_v80_gen5x8_25.1.pdi
+
+   .. tab-item:: RHEL 9 / Rocky Linux 9 / AlmaLinux 9
+
+      .. code-block:: bash
+
+         sudo ami_tool cfgmem_program -d <BDF> -t primary -p 0 \
+            -i /usr/lib/python3.9/site-packages/slashkit/resources/static_shell/amd_v80_gen5x8_25.1.pdi
+
+   .. tab-item:: RHEL 10 / Rocky Linux 10 / AlmaLinux 10
+
+      .. code-block:: bash
+
+         sudo ami_tool cfgmem_program -d <BDF> -t primary -p 0 \
+            -i /usr/lib/python3.12/site-packages/slashkit/resources/static_shell/amd_v80_gen5x8_25.1.pdi
 
 After programming completes, reboot the system for the new flash contents
 to take effect:


### PR DESCRIPTION
Update ami_tool flash path in documentation to match new changes after python3 dist-packages packaging changes.