### PR TITLE
Change to kcompat system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ __pycache__/
 *.pyc
 .venv/
 
+# Kernel module kcompat probe scratch (driver/kcompat/probe.sh)
+driver/kcompat/.scratch/
+
 # Build files for package
 /pbuild/
 /rpmbuild/

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -44,6 +44,14 @@ endif
 
 SLASH_QDMA_OP_DEBUG ?= 0
 
+# Kcompat feature flags. Defaults are "n"; the all: recipe runs
+# driver/kcompat/probe.sh against $(KDIR) to detect the actual values
+# and passes them into the kbuild recursion. Each pair (modern API +
+# legacy fallback) is covered by one probe — if the modern form is
+# absent, the legacy form is the unconditional fallback in slash_compat.h.
+SLASH_HAVE_VM_FLAGS_SET ?= n
+SLASH_HAVE_MODULE_IMPORT_NS_TOKEN ?= n
+
 # Set GCOV=1 to instrument the module for kernel gcov coverage.
 # Not set by default — never enable this in production builds.
 ifdef GCOV
@@ -65,6 +73,14 @@ ccflags-y += \
 	-DTANDEM_BOOT_SUPPORTED=1 \
 	-DSLASH_QDMA_OP_DEBUG=$(SLASH_QDMA_OP_DEBUG) \
 	-DSLASH_VERSION_STR=\"$(SLASH_VERSION)\"
+
+ifeq ($(SLASH_HAVE_VM_FLAGS_SET),y)
+ccflags-y += -DSLASH_HAVE_VM_FLAGS_SET
+endif
+
+ifeq ($(SLASH_HAVE_MODULE_IMPORT_NS_TOKEN),y)
+ccflags-y += -DSLASH_HAVE_MODULE_IMPORT_NS_TOKEN
+endif
 
 
 LIBQDMA_OBJS := \
@@ -102,11 +118,16 @@ QDMA_ACCESS_OBJS := \
 $(MODULE)-objs += $(LIBQDMA_OBJS) $(QDMA_ACCESS_OBJS)
 
 
+KCOMPAT := "$(SHELL)" "$(PWD)/kcompat/probe.sh"
+
 all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+	@flags="$$($(KCOMPAT) "$(KDIR)" | tr '\n' ' ')"; \
+	echo "slash: kcompat: $$flags"; \
+	$(MAKE) -C "$(KDIR)" M="$(PWD)" $$flags modules
 
 clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(MAKE) -C "$(KDIR)" M="$(PWD)" clean
+	rm -rf "$(PWD)/kcompat/.scratch"
 
 install: all
 	sudo install -d -m 755 /lib/modules/$(shell uname -r)/extra

--- a/driver/kcompat/module_import_ns_token.c
+++ b/driver/kcompat/module_import_ns_token.c
@@ -1,3 +1,17 @@
+/**
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
 /*
  * Token-form MODULE_IMPORT_NS probe.
  *

--- a/driver/kcompat/module_import_ns_token.c
+++ b/driver/kcompat/module_import_ns_token.c
@@ -1,0 +1,30 @@
+/*
+ * Token-form MODULE_IMPORT_NS probe.
+ *
+ * Pre-6.13:  MODULE_IMPORT_NS(ns) = MODULE_INFO(import_ns, __stringify(ns))
+ *            -> token form is the documented usage.
+ * 6.13+:     MODULE_IMPORT_NS(ns) = MODULE_INFO(import_ns, ns)
+ *            -> token form fails to compile (DMA_BUF undefined).
+ *
+ * So this probe succeeds iff the token form is the right one to use.
+ * Compile success on a pre-6.13 kernel that still accepts the string
+ * form silently produces the wrong namespace string at runtime, which
+ * is why we probe the token form (precise) instead of the string form
+ * (ambiguous on older kernels).
+ */
+#include <linux/init.h>
+#include <linux/module.h>
+
+static int __init conftest_init(void)
+{
+    return 0;
+}
+
+static void __exit conftest_exit(void)
+{
+}
+
+MODULE_LICENSE("GPL");
+MODULE_IMPORT_NS(DMA_BUF);
+module_init(conftest_init);
+module_exit(conftest_exit);

--- a/driver/kcompat/probe.sh
+++ b/driver/kcompat/probe.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Probe the kernel build at $1 for SLASH API compatibility features.
+#
+# Each *.c file in this directory is built as a tiny standalone module
+# against the target kernel headers; a successful build means the
+# feature is available. One make-style assignment per feature is
+# printed to stdout, e.g.:
+#
+#     SLASH_HAVE_VM_FLAGS_SET=y
+#     SLASH_HAVE_MODULE_IMPORT_NS_STRING=n
+#
+# To add a new probe, drop another conftest .c file into this directory.
+# The macro name is derived from the file basename (uppercased).
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <kernel-build-dir>" >&2
+    exit 2
+fi
+
+kdir="$1"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -d "$kdir" ]; then
+    echo "$0: kernel build dir '$kdir' not found" >&2
+    exit 1
+fi
+
+scratch="$here/.scratch"
+cleanup() { rm -rf "$scratch"; }
+trap cleanup EXIT HUP INT TERM
+
+# Conftest builds must actually compile to be meaningful. Drop any
+# flags the parent make may have set (notably -n / --dry-run, which
+# would make every probe look successful but produce no real result).
+unset MAKEFLAGS MFLAGS MAKEOVERRIDES
+
+rm -rf "$scratch"
+mkdir -p "$scratch"
+printf 'obj-m := conftest.o\n' > "$scratch/Makefile"
+
+for src in "$here"/*.c; do
+    [ -f "$src" ] || continue
+    feat=$(basename "$src" .c)
+    cp "$src" "$scratch/conftest.c"
+    if "${MAKE:-make}" -s -C "$kdir" M="$scratch" modules >/dev/null 2>&1; then
+        ans=y
+    else
+        ans=n
+    fi
+    printf 'SLASH_HAVE_%s=%s\n' "$(printf '%s' "$feat" | tr '[:lower:]' '[:upper:]')" "$ans"
+done

--- a/driver/kcompat/probe.sh
+++ b/driver/kcompat/probe.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+#/**
+# * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# * This program is free software; you can redistribute it and/or modify it under the terms of the
+# * GNU General Public License as published by the Free Software Foundation; version 2.
+# *
+# * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# * General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License along with this program; if
+# * not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# * 02110-1301, USA.
+# */
+
 # Probe the kernel build at $1 for SLASH API compatibility features.
 #
 # Each *.c file in this directory is built as a tiny standalone module

--- a/driver/kcompat/vm_flags_set.c
+++ b/driver/kcompat/vm_flags_set.c
@@ -1,0 +1,19 @@
+#include <linux/init.h>
+#include <linux/mm.h>
+#include <linux/module.h>
+
+static int __init conftest_init(void)
+{
+    struct vm_area_struct *vma = NULL;
+
+    vm_flags_set(vma, (vm_flags_t)0);
+    return 0;
+}
+
+static void __exit conftest_exit(void)
+{
+}
+
+MODULE_LICENSE("GPL");
+module_init(conftest_init);
+module_exit(conftest_exit);

--- a/driver/kcompat/vm_flags_set.c
+++ b/driver/kcompat/vm_flags_set.c
@@ -1,3 +1,17 @@
+/**
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
 #include <linux/init.h>
 #include <linux/mm.h>
 #include <linux/module.h>

--- a/driver/slash_compat.h
+++ b/driver/slash_compat.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SLASH_COMPAT_H
+#define SLASH_COMPAT_H
+
+#include <linux/mm.h>
+#include <linux/module.h>
+
+/*
+ * Compat shims selected by the kcompat probes in driver/kcompat/.
+ * If the modern form is detected (SLASH_HAVE_*), use it; otherwise
+ * fall back to the legacy form. The probes are exhaustive, so no
+ * #error path is needed.
+ */
+
+static inline void slash_vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
+{
+#if defined(SLASH_HAVE_VM_FLAGS_SET)
+    vm_flags_set(vma, flags);
+#else
+    vma->vm_flags |= flags;
+#endif
+}
+
+/*
+ * MODULE_IMPORT_NS argument form.
+ *
+ * Pre-6.13: bare token, e.g. MODULE_IMPORT_NS(DMA_BUF). The kernel
+ *           macro internally __stringify()s the argument, so passing a
+ *           string literal would produce a runtime namespace mismatch.
+ * 6.13+:    string literal, e.g. MODULE_IMPORT_NS("DMA_BUF"). The
+ *           kernel macro stopped stringifying, so passing a bare token
+ *           fails to compile.
+ *
+ * We probe the token form (precise cutover at 6.13) and stringify here
+ * when it's no longer accepted.
+ */
+#if defined(SLASH_HAVE_MODULE_IMPORT_NS_TOKEN)
+#define SLASH_MODULE_IMPORT_NS(ns) MODULE_IMPORT_NS(ns)
+#else
+#define SLASH_MODULE_IMPORT_NS(ns) MODULE_IMPORT_NS(#ns)
+#endif
+
+#endif /* SLASH_COMPAT_H */

--- a/driver/slash_ctldev.c
+++ b/driver/slash_ctldev.c
@@ -41,7 +41,6 @@
 #include <linux/stddef.h>
 #include <linux/string.h>
 #include <linux/uaccess.h>
-#include <linux/version.h>
 
 #include "slash.h"
 #include "slash_dmabuf.h"

--- a/driver/slash_dmabuf.c
+++ b/driver/slash_dmabuf.c
@@ -39,13 +39,13 @@
 #include "slash_dmabuf.h"
 
 #include "slash.h"
+#include "slash_compat.h"
 
 #include <linux/err.h>
 #include <linux/mm.h>
 #include <linux/pci.h>
 #include <linux/printk.h>
 #include <linux/slab.h>
-#include <linux/version.h>
 
 /**
  * struct slash_bar_dmabuf_data - Private data attached to each BAR dma-buf.
@@ -181,13 +181,8 @@ static int slash_bar_dmabuf_mmap(struct dma_buf *dmabuf, struct vm_area_struct *
      * VM_DONTCOPY  — do not inherit across fork(); BAR register
      *                mappings should not be silently shared with children.
      */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
-    vm_flags_set(vma, VM_PFNMAP | VM_IO | VM_DONTDUMP |
-                      VM_DONTEXPAND | VM_DONTCOPY);
-#else
-    vma->vm_flags |= VM_PFNMAP | VM_IO | VM_DONTDUMP |
-                     VM_DONTEXPAND | VM_DONTCOPY;
-#endif
+    slash_vm_flags_set(vma, VM_PFNMAP | VM_IO | VM_DONTDUMP |
+                            VM_DONTEXPAND | VM_DONTCOPY);
 
     wc = !!(pci_resource_flags(priv->pdev, priv->bar_number) & IORESOURCE_PREFETCH);
     vma->vm_page_prot = wc ? pgprot_writecombine(vma->vm_page_prot)

--- a/driver/slash_main.c
+++ b/driver/slash_main.c
@@ -44,12 +44,12 @@
  */
 
 #include "slash.h"
+#include "slash_compat.h"
 
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/printk.h>
-#include <linux/version.h>
 
 #include "slash_pcie.h"
 #include "slash_hotplug_driver.h"
@@ -131,8 +131,4 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("AMD Inc.");
 MODULE_DESCRIPTION("SLASH/VRT module");
 MODULE_VERSION(SLASH_VERSION_STR);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
-MODULE_IMPORT_NS("DMA_BUF");
-#else
-MODULE_IMPORT_NS(DMA_BUF);
-#endif
+SLASH_MODULE_IMPORT_NS(DMA_BUF);

--- a/packaging/debian/slash-dkms.install
+++ b/packaging/debian/slash-dkms.install
@@ -21,6 +21,7 @@
 driver/*.c            usr/src/slash-@VERSION@/driver/
 driver/*.h            usr/src/slash-@VERSION@/driver/
 driver/Makefile       usr/src/slash-@VERSION@/driver/
+driver/kcompat        usr/src/slash-@VERSION@/driver/
 driver/libslash/include/slash/uapi  usr/src/slash-@VERSION@/driver/libslash/include/slash/
 
 submodules/qdma_drv/QDMA/linux-kernel/driver/libqdma/   usr/src/slash-@VERSION@/driver/

--- a/packaging/rpm/slash.spec
+++ b/packaging/rpm/slash.spec
@@ -209,6 +209,8 @@ install -m 0644 driver/*.c      %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_versi
 install -m 0644 driver/*.h      %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/driver/
 install -m 0644 driver/Makefile %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/driver/
 
+cp -a driver/kcompat %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/driver/
+
 cp -a driver/libslash/include/slash/uapi \
     %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/driver/libslash/include/slash/
 


### PR DESCRIPTION
## Summary

Replace the `LINUX_VERSION_CODE` gates in the SLASH kernel module with a small build-time feature-probe system. The driver Makefile now runs `driver/kcompat/probe.sh` against `$(KDIR)`, which compiles one conftest `.c` per feature against the target kernel and prints `SLASH_HAVE_<FEAT>=y|n`. The results are passed back into the kbuild recursion as both `make` variables and `-DSLASH_HAVE_<FEAT>` ccflags, and `driver/slash_compat.h` selects the modern or legacy API form based on those defines.

## Why

This replaces the existing `LINUX_VERSION_CODE >= KERNEL_VERSION(...)` checks in the driver, which is brittle on distro kernels that backport features from newer upstreams (e.g. RHEL 9.x) and breaks the moment a new LTS picks up another behavior change. Conftest probes give us the actual ground truth for the kernel we are building against.

## Feature flags

Two features are probed today:

- `SLASH_HAVE_VM_FLAGS_SET` -- `vm_flags_set()` was added in 6.3. Old kernels fall back to `vma->vm_flags |= flags`. New kernels cannot use the old form because `vma->vm_flags` is now const/read-only.
- `SLASH_HAVE_MODULE_IMPORT_NS_TOKEN` -- `MODULE_IMPORT_NS()` switched from bare-token to string-literal in 6.13. The probe checks the token form directly, so the result is precise across the cutover (the string form silently produces the wrong namespace on older kernels and is not safe to probe).