### PR TITLE
Add AMI eventfd_signal patch for RHEL 9.5+

### DIFF
--- a/scripts/package-ami.sh
+++ b/scripts/package-ami.sh
@@ -35,18 +35,26 @@ AVED_DIR="$(pwd)/submodules/AVED"
 AMI_DIR="${AVED_DIR}/sw/AMI"
 PKG_PY="${AMI_DIR}/scripts/package_data/pkg.py"
 GEN_PKG_PY="${AMI_DIR}/scripts/gen_package.py"
+AMI_PROGRAM_C="${AMI_DIR}/driver/ami_program.c"
 
 rm -rf "${AMI_BUILD_DIR}"
 mkdir -p "${ARTIFACTS_DIR}"
 
 # Restore submodule files and clean up build directory on exit
-trap 'git -C "${AVED_DIR}" checkout -- sw/AMI/scripts/package_data/pkg.py sw/AMI/scripts/gen_package.py; rm -rf "${AMI_BUILD_DIR}"' EXIT
+trap 'git -C "${AVED_DIR}" checkout -- sw/AMI/scripts/package_data/pkg.py sw/AMI/scripts/gen_package.py sw/AMI/driver/ami_program.c; rm -rf "${AMI_BUILD_DIR}"' EXIT
 
 # Patch in Rocky Linux support (RHEL-compatible, RPM-based)
 sed -i "/^DIST_ID_RHEL /a DIST_ID_ROCKY   = 'rocky'" "${PKG_PY}"
 sed -i "/^    DIST_ID_RHEL,$/a\\    DIST_ID_ROCKY," "${PKG_PY}"
 sed -i "s/DIST_RPM = \[DIST_ID_CENTOS, DIST_ID_REDHAT, DIST_ID_REDHAT2, DIST_ID_SLES, DIST_ID_RHEL\]/DIST_RPM = [DIST_ID_CENTOS, DIST_ID_REDHAT, DIST_ID_REDHAT2, DIST_ID_SLES, DIST_ID_RHEL, DIST_ID_ROCKY]/" "${PKG_PY}"
 sed -i "s/DIST_ID_CENTOS, DIST_ID_REDHAT, DIST_ID_REDHAT2, DIST_ID_RHEL\]/DIST_ID_CENTOS, DIST_ID_REDHAT, DIST_ID_REDHAT2, DIST_ID_RHEL, DIST_ID_ROCKY]/" "${GEN_PKG_PY}"
+
+# Extend the eventfd_signal() version gate in ami_program.c so the
+# void-arg form is also picked up on RHEL 9.5+, which is when Red Hat
+# backported the upstream 6.8 eventfd_signal() simplification into the
+# 5.14-based kernel.
+# Stopgap: revert once upstream AVED carries an equivalent fix.
+sed -i 's@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)$@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || (defined(RHEL_RELEASE_CODE) \&\& RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))@' "${AMI_PROGRAM_C}"
 
 cd "${AMI_DIR}"
 # --no_driver skips a pre-flight driver compilation check (build+clean) only;


### PR DESCRIPTION
## Summary

Extend the `eventfd_signal()` version gate in `submodules/AVED/sw/AMI/driver/ami_program.c` so the void-arg form is also picked up on RHEL 9.5+ kernels, which is when Red Hat backported the upstream 6.8 `eventfd_signal()` simplification into the 5.14-based RHEL kernel.

The packaging script already applies a couple of Rocky Linux distro tweaks via `sed`; this adds one more `sed` in the same style and extends the EXIT-trap restore to cover `ami_program.c`.

## Why

On RHEL 9.5+ / Rocky 9.5+ the AMI driver fails to build out of the box because `LINUX_VERSION_CODE` is still `5.14.x` but
`include/linux/eventfd.h` already has the new `void eventfd_signal(ctx)` signature. The patched gate becomes:

```c
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
```

`RHEL_RELEASE_CODE` and `RHEL_RELEASE_VERSION()` are only defined on RHEL-family kernels, so the RHS is short-circuited on upstream and other distro kernels.

This should be reverted once upstream AVED carries an equivalent fix.

### Consistent with how AMI already handles RHEL backports

This is the same pattern AMI uses elsewhere in the driver to deal with RHEL backports. See `submodules/AVED/sw/AMI/driver/ami_cdev.c`:

- `devnode()` signature change (upstream 6.2, backported into RHEL 9):
  ```c
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
      static char *devnode(const struct device *dev, umode_t *mode)
  #elif defined(RHEL_RELEASE_VERSION) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
      static char *devnode(const struct device *dev, umode_t *mode)
  #else
      static char *devnode(struct device *dev, umode_t *mode)
  #endif
  ```
- `class_create()` losing its `THIS_MODULE` arg (upstream 6.4, also backported into RHEL 9):
  ```c
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
      drv_cdev->dev_class = class_create(drv_cdev->drv_cls_str);
  #elif defined(RHEL_RELEASE_VERSION) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
      drv_cdev->dev_class = class_create(drv_cdev->drv_cls_str);
  #else
      drv_cdev->dev_class = class_create(THIS_MODULE, drv_cdev->drv_cls_str);
  #endif
  ```
  
Our patch follows the same idiom but uses `RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)` instead of "any RHEL 9.x" because the `eventfd_signal()` backport specifically lands at 9.5. `9.0`–`9.4` still ship the legacy `__u64` form and must take the else branch.