### PR TITLE
Hotfix: Fix RHEL patch for C11 non-RHEL builds

### DIFF
--- a/scripts/package-ami.sh
+++ b/scripts/package-ami.sh
@@ -53,8 +53,44 @@ sed -i "s/DIST_ID_CENTOS, DIST_ID_REDHAT, DIST_ID_REDHAT2, DIST_ID_RHEL\]/DIST_I
 # void-arg form is also picked up on RHEL 9.5+, which is when Red Hat
 # backported the upstream 6.8 eventfd_signal() simplification into the
 # 5.14-based kernel.
+#
 # Stopgap: revert once upstream AVED carries an equivalent fix.
-sed -i 's@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)$@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || (defined(RHEL_RELEASE_CODE) \&\& RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))@' "${AMI_PROGRAM_C}"
+patch --no-backup-if-mismatch -p1 -d "${AVED_DIR}" <<'EOF'
+--- a/sw/AMI/driver/ami_program.c
++++ b/sw/AMI/driver/ami_program.c
+@@ -94,7 +94,15 @@
+ 				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+ 					eventfd_signal(efd_ctx);
+ 				#else
++				# ifdef RHEL_RELEASE_CODE
++				#  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
++					eventfd_signal(efd_ctx);
++				#  else
++					eventfd_signal(efd_ctx, bytes_to_write);
++				#  endif
++				# else
+ 					eventfd_signal(efd_ctx, bytes_to_write);
++				# endif
+ 				#endif
+ 			}
+ 		} else {
+@@ -153,7 +161,15 @@
+ 		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+ 			eventfd_signal(efd_ctx);
+ 		#else
++		# ifdef RHEL_RELEASE_CODE
++		#  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
++			eventfd_signal(efd_ctx);
++		#  else
++			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
++		#  endif
++		# else
+ 			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
++		# endif
+ 		#endif
+ 	}
+ 
+EOF
 
 cd "${AMI_DIR}"
 # --no_driver skips a pre-flight driver compilation check (build+clean) only;


### PR DESCRIPTION
## Summary

`scripts/package-ami.sh` rewrites the `eventfd_signal()` version gate in `submodules/AVED/sw/AMI/driver/ami_program.c` so the void-arg form is also selected on RHEL 9.5+, where Red Hat backported the upstream 6.8 simplification into the 5.14-based kernel.

The current rewrite uses a single composite `#if`:

    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) \
     || (defined(RHEL_RELEASE_CODE) \
         && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))

This works on RHEL but breaks the build on other distros with kernel >= 5.18 (Ubuntu 24.04, Ubuntu 22.04 HWE), if the kernel is compiled under C11 (`-std=gnu11`, the default since v5.18).

## Why it breaks

Per C11, in a `#if` controlling expression all identifiers remaining after macro expansion (other than the operand of `defined`) are replaced with the pp-number `0`, including function-like macro *names*. On a non-RHEL kernel `RHEL_RELEASE_VERSION` is undefined, so the preprocessor ends up parsing:

    ... || (0 && 0 >= 0(9, 5))
                       ^^^^^^^ syntax error

i.e. `MACRO(a, b)` becomes `0(a, b)`, which is not a valid constant expression. The `defined(RHEL_RELEASE_CODE)` short-circuit doesn't help, the rule applies during expression *parsing*, before evaluation.

## Fix

Replace the `sed` rewrite with a `patch` that guards the RHEL check behind `#ifdef RHEL_RELEASE_CODE`, so non-RHEL translation units never tokenize `RHEL_RELEASE_VERSION` in a `#if` at all:

    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
        eventfd_signal(efd_ctx);
    #else
    # ifdef RHEL_RELEASE_CODE
    #  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
        eventfd_signal(efd_ctx);
    #  else
        eventfd_signal(efd_ctx, <count>);
    #  endif
    # else
        eventfd_signal(efd_ctx, <count>);
    # endif
    #endif

Applied via `patch --no-backup-if-mismatch -p1 -d "${AVED_DIR}"`; the existing `trap` already `git checkout`s `ami_program.c` on exit, so revert semantics are unchanged.