### PR TITLE
Small fixes to allow service layer builds

### DIFF
--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -233,16 +233,19 @@ class RM_KIND(Enum):
 
 
 def _run_rm_build(config: LinkerConfiguration, rm_kind: RM_KIND) -> None:
-    # Copy all base IP cores into the ip repository
-    config.ip_repository.mkdir(parents=True)
-    export_package("slashkit.resources.base.iprepo",
-                   config.ip_repository / "slash_base")
-
     if rm_kind == RM_KIND.SLASH_PROJECT:
+        # Copy all base IP cores into the ip repository
+        config.ip_repository.mkdir(parents=True)
+        export_package("slashkit.resources.base.iprepo",
+                    config.ip_repository / "slash_base")
+        
         # Copy all user kernels into the ip repository
         for kernel in config.kernels:
             shutil.copytree(kernel.component_xml_path.parent,
                             config.ip_repository / kernel.name)
+    elif rm_kind == RM_KIND.SERVICE_LAYER and not config.ip_repository.is_dir():
+        raise RuntimeError("The IP repository is missing, the user region has to be built before the service layer.\n" \
+        "This is a bug, please report it at https://github.com/Xilinx/SLASH")
 
     logs_dir = config.build_dir / "logs"
     image_out_dir = config.build_dir / "images"

--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -237,15 +237,15 @@ def _run_rm_build(config: LinkerConfiguration, rm_kind: RM_KIND) -> None:
         # Copy all base IP cores into the ip repository
         config.ip_repository.mkdir(parents=True)
         export_package("slashkit.resources.base.iprepo",
-                    config.ip_repository / "slash_base")
-        
+                       config.ip_repository / "slash_base")
+
         # Copy all user kernels into the ip repository
         for kernel in config.kernels:
             shutil.copytree(kernel.component_xml_path.parent,
                             config.ip_repository / kernel.name)
     elif rm_kind == RM_KIND.SERVICE_LAYER and not config.ip_repository.is_dir():
-        raise RuntimeError("The IP repository is missing, the user region has to be built before the service layer.\n" \
-        "This is a bug, please report it at https://github.com/Xilinx/SLASH")
+        raise RuntimeError("The IP repository is missing, the user region has to be built before the service layer.\n"
+                           "This is a bug, please report it at https://github.com/Xilinx/SLASH")
 
     logs_dir = config.build_dir / "logs"
     image_out_dir = config.build_dir / "images"

--- a/linker/slashkit/emit/hw/tcl_gen.py
+++ b/linker/slashkit/emit/hw/tcl_gen.py
@@ -340,7 +340,8 @@ def generate_tcl(config: LinkerConfiguration) -> None:
     svc_out = config.build_dir / "service_layer.tcl"
 
     dcmac_dir = config.build_dir / "dcmac"
-    export_package("slashkit.resources.dcmac", dcmac_dir)
+    if not dcmac_dir.is_dir():
+        export_package("slashkit.resources.dcmac", dcmac_dir)
 
     svc_ctx.update(dcmac_paths(dcmac_dir))
     render_template(


### PR DESCRIPTION
This PR fixes small issues that prevented the build of new service layers, especially for example 06_dcmac.

The first one is that the procedure to build either the user region or the service layer unconditionally tries to create the user IP repository. However, it already exists when building the service layer, which lead to an error. The fix is just to not create the IP repository if it already exists.

The other one is that, again, a resource folder is exported unconditionally. Now, it's only exported if it doesn't exist yet.