### PR TITLE
Optimize HLS IP builds by adding dependency tracking to Makefiles

### DIFF
--- a/linker/slashkit/resources/base/iprepo/hbm_bandwidth/Makefile
+++ b/linker/slashkit/resources/base/iprepo/hbm_bandwidth/Makefile
@@ -1,16 +1,16 @@
 # ##################################################################################################
 #  The MIT License (MIT)
 #  Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
-# 
+#
 #  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 #  and associated documentation files (the "Software"), to deal in the Software without restriction,
 #  including without limitation the rights to use, copy, modify, merge, publish, distribute,
 #  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 #  furnished to do so, subject to the following conditions:
-# 
+#
 #  The above copyright notice and this permission notice shall be included in all copies or
 #  substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
 # NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -18,11 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-.PHONY: all clean
+all: ip/hbm_bandwidth.zip
 
-all:
+ip/hbm_bandwidth.zip: $(wildcard *.cpp) $(wildcard *.cfg)
 	v++ -c --mode hls --config hbm_bandwidth.cfg --work_dir ip
 	vitis-run --mode hls --package --config hbm_bandwidth.cfg --work_dir ip
 
+.PHONY: clean
 clean:
 	rm -rf ip/ .Xil *.json

--- a/linker/slashkit/resources/base/iprepo/traffic_producer/Makefile
+++ b/linker/slashkit/resources/base/iprepo/traffic_producer/Makefile
@@ -1,16 +1,16 @@
 # ##################################################################################################
 #  The MIT License (MIT)
 #  Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
-# 
+#
 #  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 #  and associated documentation files (the "Software"), to deal in the Software without restriction,
 #  including without limitation the rights to use, copy, modify, merge, publish, distribute,
 #  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 #  furnished to do so, subject to the following conditions:
-# 
+#
 #  The above copyright notice and this permission notice shall be included in all copies or
 #  substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
 # NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -18,11 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-.PHONY: all clean
+all: ip/traffic_producer.zip
 
-all:
+ip/traffic_producer.zip: $(wildcard *.cpp) $(wildcard *.cfg)
 	v++ -c --mode hls --config traffic_producer.cfg --work_dir ip
 	vitis-run --mode hls --package --config traffic_producer.cfg --work_dir ip
 
+.PHONY: clean
 clean:
 	rm -rf ip/ .Xil *.json


### PR DESCRIPTION

Improves build efficiency for `hbm_bandwidth` and `traffic_producer` HLS IPs by enabling proper dependency tracking in their Makefiles.

### Changes
* Replaced phony `all` targets with explicit `ip/*.zip` file targets.
* Added `*.cpp` and `*.cfg` as prerequisites so Make only rebuilds when sources actually change.

This prevents redundant, time-consuming HLS compilations during local development and CI runs.