### PR TITLE
Exit early when a sourced Tcl script fails

### DIFF
--- a/linker/slashkit/resources/base/scripts/create_project.tcl
+++ b/linker/slashkit/resources/base/scripts/create_project.tcl
@@ -71,6 +71,14 @@ puts "IP REPOS:       $iprepos"
 puts "ACTION:         $action"
 puts "BUILD DIR:      $cwd"
 
+proc safe_source {tcl_path} {
+  puts "INFO: Sourcing $tcl_path ..."
+  catch {source $tcl_path} result
+  if {[string is integer -strict $result] && $result != 0} {
+    puts "EXIT: '$tcl_path' returned $result"
+    exit 1
+  }
+}
 
 set proj_exists [file normalize [file join $cwd "${design_name}.xpr"]]
 if {![file exists $proj_exists]} {
@@ -84,14 +92,14 @@ if {![file exists $proj_exists]} {
   update_ip_catalog
 
   # Base shell / containers
-  source [file normalize [file join $src_dir "slash_base.tcl"]]
-  source [file normalize [file join $src_dir "service_layer.tcl"]]
-  source [file normalize [file join $src_dir "top.tcl"]]
-  source [file normalize [file join $src_dir "enable_dfx_bdc.tcl"]]
+  safe_source [file normalize [file join $src_dir "slash_base.tcl"]]
+  safe_source [file normalize [file join $src_dir "service_layer.tcl"]]
+  safe_source [file normalize [file join $src_dir "top.tcl"]]
+  safe_source [file normalize [file join $src_dir "enable_dfx_bdc.tcl"]]
 
   # Wrapper / XDC / build
-  source [file normalize [file join $src_dir "make_wrapper.tcl"]]
-  source [file normalize [file join $src_dir "add_constraints.tcl"]]
+  safe_source [file normalize [file join $src_dir "make_wrapper.tcl"]]
+  safe_source [file normalize [file join $src_dir "add_constraints.tcl"]]
 } else {
   puts "INFO: Project already exists; opening '$proj_exists'."
   open_project [file normalize [file join $cwd "slash.xpr"]]
@@ -105,7 +113,7 @@ if {![file exists $proj_exists]} {
 }
 
 if {$do_build} {
-  source [file normalize [file join $src_dir "build_project.tcl"]]
+  safe_source [file normalize [file join $src_dir "build_project.tcl"]]
   build_project $project_name
   puts "INFO: Project build complete."
 } elseif {$do_create} {


### PR DESCRIPTION


Currently, when `create_project.tcl` sources sub-scripts (like `slash_base.tcl`, etc), any failures within those scripts, for example, 
``` tcl
if { $bCheckIPsPassed != 1 } {
  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
  return 3
}
```
are silently ignored. The main script continues executing, which can lead to incomplete builds or hard-to-debug cascading errors.

This PR introduces a `safe_source` helper procedure that wraps the standard Tcl `source` command in a `catch` block. If a sourced script fails, it terminates execution immediately.
