### PR TITLE
Added slash_compat.h force include and fix from_timer backport issue …

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -82,6 +82,11 @@ ifeq ($(SLASH_HAVE_MODULE_IMPORT_NS_TOKEN),y)
 ccflags-y += -DSLASH_HAVE_MODULE_IMPORT_NS_TOKEN
 endif
 
+# Force-include the compat header into every TU (including the pinned libqdma
+# submodule sources we don't modify) so kernel-API shims such as from_timer()
+# reach third-party code too. Safe on all kernels: the shims are guarded.
+ccflags-y += -include $(src)/slash_compat.h
+
 
 LIBQDMA_OBJS := \
 	$(LIBQDMA_PATH)/qdma_mbox.o \

--- a/driver/slash_compat.h
+++ b/driver/slash_compat.h
@@ -17,6 +17,7 @@
 
 #include <linux/mm.h>
 #include <linux/module.h>
+#include <linux/timer.h>
 
 /*
  * Compat shims selected by the kcompat probes in driver/kcompat/.
@@ -51,6 +52,29 @@ static inline void slash_vm_flags_set(struct vm_area_struct *vma, vm_flags_t fla
 #define SLASH_MODULE_IMPORT_NS(ns) MODULE_IMPORT_NS(ns)
 #else
 #define SLASH_MODULE_IMPORT_NS(ns) MODULE_IMPORT_NS(#ns)
+#endif
+
+/*
+ * from_timer() was renamed to timer_container_of() upstream in v6.16
+ * (commit 41cb08555c41) and backported by RHEL/CentOS 9.8 (kernel
+ * 5.14.0-687; 9.7 / 5.14.0-611 and earlier still ship from_timer) into the
+ * 5.14 baseline, so a LINUX_VERSION_CODE / RHEL_RELEASE_CODE check is
+ * unreliable across the 9.x rebuilds. Both names are typeof()-based macros,
+ * so detect them directly and prefer the kernel's own API:
+ *   1. kernel still defines from_timer()          -> use it as-is (no redefine)
+ *   2. kernel renamed it to timer_container_of()  -> delegate to that
+ *   3. neither exists                             -> hand-roll the historical body
+ * <linux/timer.h> is included above so the guard sees whichever name the
+ * kernel defines, regardless of -include ordering.
+ */
+#ifndef from_timer
+#  ifdef timer_container_of
+#    define from_timer(var, callback_timer, timer_fieldname) \
+	timer_container_of(var, callback_timer, timer_fieldname)
+#  else
+#    define from_timer(var, callback_timer, timer_fieldname) \
+	container_of(callback_timer, typeof(*var), timer_fieldname)
+#  endif
 #endif
 
 #endif /* SLASH_COMPAT_H */


### PR DESCRIPTION
## Summary

On RHEL/Rocky 9.8 the kernel module fails to build because the pinned libqdma submodule calls the `from_timer()` macro, which no longer exists on those kernels:

    qdma_mbox.c:435: error: implicit declaration of function 'from_timer';
    did you mean 'mod_timer'? [-Werror=implicit-function-declaration]

This PR adds a small, presence-detected `from_timer` compat shim in `driver/slash_compat.h` and force-includes that header into every translation unit so the shim also reaches the third-party libqdma sources we don't modify.

## Root cause

Upstream Linux 6.16 renamed `from_timer()` to `timer_container_of()` (commit `41cb08555c41`, "treewide, timers: Rename from_timer() to timer_container_of()"). RHEL/CentOS backported this into their 5.14-based 9.7/9.8 kernels (e.g. `5.14.0-687.10.1.el9_8`), so `from_timer` is gone while `LINUX_VERSION_CODE` still reports `5.14.0`.

libqdma gates the call purely on kernel version:

    #if KERNEL_VERSION(4, 15, 0) <= LINUX_VERSION_CODE
        struct qdma_mbox *mbox = from_timer(mbox, t, timer);

Since `5.14 >= 4.15`, the now-broken branch is taken and `-Werror` makes it fatal. This is the only `from_timer` use in libqdma; `del_timer` (same file) still compiles on these kernels, so only `from_timer` needs shimming.

## The fix

`driver/slash_compat.h` — include `<linux/timer.h>` and add a three-tier, preprocessor-detected shim that always defers to whatever the kernel provides:

```c
#ifndef from_timer
#  ifdef timer_container_of
#    define from_timer(var, callback_timer, timer_fieldname) \
        timer_container_of(var, callback_timer, timer_fieldname)
#  else
#    define from_timer(var, callback_timer, timer_fieldname) \
        container_of(callback_timer, typeof(*var), timer_fieldname)
#  endif
#endif
```

`driver/Makefile` — force-include the compat header into every object so the shim reaches the libqdma submodule sources (which never include `slash_compat.h`):

    ccflags-y += -include $(src)/slash_compat.h