### PR TITLE
Insert AXI Firewalls in RM on AXILite path

### DIFF
--- a/linker/slashkit/emit/hw/service_region/service_layer_ctx.py
+++ b/linker/slashkit/emit/hw/service_region/service_layer_ctx.py
@@ -106,7 +106,7 @@ def build_service_axilite_ctx(net) -> Dict[str, Any]:
 
         # wiring
         # top-level service_layer AXI-Lite interface
-        "sl_si_src_if": "axi_noc_0/M00_AXI",
+        "sl_si_src_if": "axilite_firewall_0/M_AXI",
         "sl_clk0": "service_clk",            # service_layer clock pins
         "sl_rstn": "ilreduced_logic_0/Res",
 

--- a/linker/slashkit/emit/hw/user_region/smartconnect_ctx.py
+++ b/linker/slashkit/emit/hw/user_region/smartconnect_ctx.py
@@ -28,7 +28,7 @@ from slashkit.core.port import BusType
 def build_axilite_smartconnect_context(
     instances: Dict[str, KernelInstance],
     *,
-    si_bd_port: str = "axi_noc_0/M00_AXI",
+    si_bd_port: str = "axilite_firewall_0/M_AXI",
     max_mi: int = 16,
     chain_slot: int = 15,
     base_name: str = "smartconnect",

--- a/linker/slashkit/resources/base/scripts/top.tcl
+++ b/linker/slashkit/resources/base/scripts/top.tcl
@@ -144,6 +144,7 @@ xilinx.com:ip:dfx_decoupler:1.0\
 xilinx.com:ip:versal_cips:3.4\
 xilinx.com:ip:axis_noc:1.0\
 xilinx.com:ip:smartconnect:1.0\
+xilinx.com:ip:axi_firewall:1.2\
 xilinx.com:inline_hdl:ilreduced_logic:1.0\
 xilinx.com:ip:c_shift_ram:12.0\
 xilinx.com:ip:hw_discovery:1.0\

--- a/linker/slashkit/resources/templates/service_layer.tcl
+++ b/linker/slashkit/resources/templates/service_layer.tcl
@@ -1167,7 +1167,19 @@ import_files -fileset sources_1 -norecurse [file normalize "{{ vf }}"]
   # Ethernet disabled; no DCMAC hierarchy created.
 {% endif %}
 
-# === AXI-Lite SmartConnect for service_layer control ===
+# === AXI Firewall on AXI-Lite ingress (post-INI NoC, pre-SmartConnect) ===
+set axilite_firewall_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.2 axilite_firewall_0 ]
+set_property -dict [list \
+  CONFIG.PROTOCOL {AXI4} \
+  CONFIG.DATA_WIDTH {32} \
+  CONFIG.ADDR_WIDTH {32} \
+  CONFIG.ENABLE_TIMEOUT_CHECKS {1} \
+  CONFIG.ENABLE_PROTOCOL_CHECKS {1} \
+] $axilite_firewall_0
+connect_bd_net [get_bd_pins axilite_firewall_0/aclk]    [get_bd_pins service_clk]
+connect_bd_net [get_bd_pins axilite_firewall_0/aresetn] [get_bd_pins ilreduced_logic_0/Res]
+connect_bd_intf_net [get_bd_intf_pins axi_noc_0/M00_AXI] [get_bd_intf_pins axilite_firewall_0/S_AXI]
+
 # === AXI-Lite SmartConnect for service_layer control ===
 {% if sl_have_xbar %}
   current_bd_design service_layer_user

--- a/linker/slashkit/resources/templates/slash.tcl
+++ b/linker/slashkit/resources/templates/slash.tcl
@@ -1061,6 +1061,19 @@ connect_bd_net [get_bd_pins {{ c.src_pin }}] [get_bd_pins user_clk]
 connect_bd_net [get_bd_pins {{ r.src_pin }}] [get_bd_pins ilreduced_logic_0/Res]
 {% endfor %}
 
+# === AXI Firewall on AXI-Lite ingress (post-INI NoC, pre-SmartConnect) ===
+set axilite_firewall_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.2 axilite_firewall_0 ]
+set_property -dict [list \
+  CONFIG.PROTOCOL {AXI4} \
+  CONFIG.DATA_WIDTH {32} \
+  CONFIG.ADDR_WIDTH {32} \
+  CONFIG.ENABLE_TIMEOUT_CHECKS {1} \
+  CONFIG.ENABLE_PROTOCOL_CHECKS {1} \
+] $axilite_firewall_0
+connect_bd_net [get_bd_pins axilite_firewall_0/aclk]    [get_bd_pins user_clk]
+connect_bd_net [get_bd_pins axilite_firewall_0/aresetn] [get_bd_pins ilreduced_logic_0/Res]
+connect_bd_intf_net [get_bd_intf_pins axi_noc_0/M00_AXI] [get_bd_intf_pins axilite_firewall_0/S_AXI]
+
 # === SmartConnects for AXI-Lite control ===
 {% for sc in smartconnects %}
 # Create {{ sc.name }}


### PR DESCRIPTION
As protection of the PCIe domain from accessing faulty user logic. Does not protect against malicious user logic or missing user logic due to reconfiguration.