### PR TITLE
Add timing check on static shell build

### DIFF
--- a/linker/slashkit/core/command_config.py
+++ b/linker/slashkit/core/command_config.py
@@ -366,9 +366,13 @@ class InstallerConfiguration(CommandConfiguration):
         ap.add_argument("--out-dir", required=True, type=Path,
                         help="The resource directory to install the artifacts to. "
                         + "If you have checked out the SLASH repository, this would be linker/slashkit/resources")
+        ap.add_argument("--ignore-timing-failure", action="store_true",
+                        help="Install static shell artifacts even when timing failed (WNS < 0 or WHS < 0).")
 
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
+
+        self._ignore_timing_failure: bool = args.ignore_timing_failure
 
         self._build_dir: Path = args.build_dir.expanduser().resolve()
         if self._build_dir.is_dir():
@@ -401,3 +405,12 @@ class InstallerConfiguration(CommandConfiguration):
     @property
     def out_dir(self) -> Path:
         return self._out_dir
+
+    @property
+    def ignore_timing_failure(self) -> bool:
+        return self._ignore_timing_failure
+
+    @property
+    def noninteractive(self) -> bool:
+        value = os.getenv("SLASH_NONINTERACTIVE", "")
+        return value not in ("", "0", "false", "False", "no", "No")

--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -33,6 +33,7 @@ from contextlib import ExitStack
 from slashkit.emit.metadata.report_util import convert_report_utilization_to_xml
 from slashkit.emit.render import export_package
 from slashkit.core.command_config import LinkerConfiguration, InstallerConfiguration, CommandConfiguration
+from slashkit.emit.metadata.timing_freq import require_static_shell_timing_or_confirm
 
 logger = logging.getLogger(__name__)
 
@@ -361,6 +362,13 @@ def install_static_shell(config: InstallerConfiguration) -> None:
     ], check=True)
 
     create_build_project(config)
+
+    require_static_shell_timing_or_confirm(
+        build_dir=config.build_dir,
+        project_name=config.project_name,
+        ignore_failure=config.ignore_timing_failure,
+        noninteractive=config.noninteractive,
+    )
 
     impl_dir = config.build_dir / "slash.runs" / "impl_1"
     dcp_sources = (

--- a/linker/slashkit/emit/metadata/timing_freq.py
+++ b/linker/slashkit/emit/metadata/timing_freq.py
@@ -142,9 +142,11 @@ def require_static_shell_timing_or_confirm(
         )
 
     if sys.stdin.isatty():
-        answer = input("Proceed with install/packaging anyway? [y/N] ").strip().lower()
+        answer = input(
+            "Proceed with install/packaging anyway? [y/N] ").strip().lower()
         if answer in ("y", "yes"):
-            logger.warning("User confirmed install despite static shell timing failure")
+            logger.warning(
+                "User confirmed install despite static shell timing failure")
             return
         raise SystemExit(1)
 

--- a/linker/slashkit/emit/metadata/timing_freq.py
+++ b/linker/slashkit/emit/metadata/timing_freq.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import sys
 from pathlib import Path
 import re
 from typing import Optional
@@ -31,9 +32,10 @@ import xml.etree.ElementTree as ET
 logger = logging.getLogger(__name__)
 
 HW_BUILD_DIR_ENV_KEYS = ("SLASH_HW_BUILD_DIR", "slash_hw_build_dir")
+_FLOAT_RE = re.compile(r"[-+]?\d+(?:\.\d+)?")
 
 
-def extract_design_wns_ns(report_text: str) -> Optional[float]:
+def _find_design_timing_summary_row(report_text: str) -> Optional[list[float]]:
     if not report_text:
         return None
 
@@ -60,14 +62,96 @@ def extract_design_wns_ns(report_text: str) -> Optional[float]:
             continue
         if set(line) <= {"-", " "}:
             continue
-        m = re.match(r"^[-+]?\d+(?:\.\d+)?", line)
-        if m:
-            try:
-                return float(m.group(0))
-            except ValueError:
-                return None
+        values = [float(m.group(0)) for m in _FLOAT_RE.finditer(line)]
+        if values:
+            return values
 
     return None
+
+
+def extract_design_timing_slacks_ns(report_text: str) -> Optional[tuple[float, float]]:
+    values = _find_design_timing_summary_row(report_text)
+    if values is None or len(values) < 3:
+        return None
+    return values[0], values[2]
+
+
+def extract_design_wns_ns(report_text: str) -> Optional[float]:
+    slacks = extract_design_timing_slacks_ns(report_text)
+    if slacks is None:
+        return None
+    return slacks[0]
+
+
+def design_timing_met(wns_ns: float, whs_ns: float) -> bool:
+    return wns_ns >= 0 and whs_ns >= 0
+
+
+def find_static_shell_timing_report(build_dir: Path, project_name: str) -> Optional[Path]:
+    path = build_dir / f"report_timing_{project_name}.txt"
+    if path.is_file():
+        return path
+    return None
+
+
+def require_static_shell_timing_or_confirm(
+    *,
+    build_dir: Path,
+    project_name: str,
+    ignore_failure: bool,
+    noninteractive: bool,
+) -> None:
+    timing_report = find_static_shell_timing_report(build_dir, project_name)
+    if timing_report is None:
+        raise RuntimeError(
+            f"Static shell timing report not found: {build_dir / f'report_timing_{project_name}.txt'}"
+        )
+
+    report_text = timing_report.read_text(encoding="utf-8", errors="replace")
+    slacks = extract_design_timing_slacks_ns(report_text)
+    if slacks is None:
+        raise RuntimeError(
+            f"Could not parse WNS/WHS from static shell timing report: {timing_report}"
+        )
+
+    wns_ns, whs_ns = slacks
+    if design_timing_met(wns_ns, whs_ns):
+        logger.info(
+            "Static shell timing met: WNS(ns)=%.3f, WHS(ns)=%.3f (%s)",
+            wns_ns,
+            whs_ns,
+            timing_report,
+        )
+        return
+
+    print("ERROR: Static shell timing failed.", file=sys.stderr)
+    print(f"  WNS(ns)={wns_ns:.3f}", file=sys.stderr)
+    print(f"  WHS(ns)={whs_ns:.3f}", file=sys.stderr)
+    print(f"  Report: {timing_report}", file=sys.stderr)
+
+    if ignore_failure:
+        logger.warning(
+            "Proceeding despite static shell timing failure (--ignore-timing-failure)"
+        )
+        return
+
+    if noninteractive:
+        raise RuntimeError(
+            "Static shell timing failed and SLASH_NONINTERACTIVE is set; "
+            "use --ignore-timing-failure to override"
+        )
+
+    if sys.stdin.isatty():
+        answer = input("Proceed with install/packaging anyway? [y/N] ").strip().lower()
+        if answer in ("y", "yes"):
+            logger.warning("User confirmed install despite static shell timing failure")
+            return
+        raise SystemExit(1)
+
+    raise RuntimeError(
+        "Static shell timing failed and no interactive terminal is available; "
+        "use --ignore-timing-failure to override"
+    )
 
 
 def compute_max_freq_hz_from_wns(wns_ns: float, base_freq_hz: int = 400_000_000) -> Optional[int]:

--- a/linker/slashkit/resources/base/scripts/build_project.tcl
+++ b/linker/slashkit/resources/base/scripts/build_project.tcl
@@ -42,6 +42,10 @@ proc build_project {{proj_name "user"}} {
   launch_runs impl_1 -to_step write_bitstream -jobs 14
   wait_on_run impl_1
   open_run impl_1
+
+  set timing_report_file [file join [file normalize [pwd]] "report_timing_${proj_name}.txt"]
+  report_timing_summary -delay_type min_max -check_timing_verbose -max_paths 1 -input_pins -routable_nets -file $timing_report_file
+  puts "TIMING REPORT: $timing_report_file"
   
   set impl_output_dir [get_property DIRECTORY [current_run]]
   write_abstract_shell -cell top_i/slash -force [file join $impl_output_dir "static_shell_slash.dcp"]

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -78,6 +78,10 @@ if [[ "${_prereq_ok}" -eq 0 ]]; then
     exit 1
 fi
 
+if [[ "${NONINTERACTIVE}" -eq 1 ]]; then
+    export SLASH_NONINTERACTIVE=1
+fi
+
 set -x
 
 # Clean build

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -76,6 +76,10 @@ if [[ "${_prereq_ok}" -eq 0 ]]; then
     exit 1
 fi
 
+if [[ "${NONINTERACTIVE}" -eq 1 ]]; then
+    export SLASH_NONINTERACTIVE=1
+fi
+
 set -x
 
 rm -rf "${TOPDIR}" "${ARTIFACTS_DIR}" pbuild


### PR DESCRIPTION
Implemented a timing check during static shell build. Prints WNS and prompts user to confirm packaging in case of timing failure or with `--ignore-timing-failure` continues with a warning.