### PR TITLE
Only depending on python3 in Ubuntu's build dependencies

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -23,7 +23,7 @@ Section: utils
 Priority: optional
 Maintainer: Vlad-Gabriel Serbu <Vlad-Gabriel.Serbu@amd.com>
 Rules-Requires-Root: no
-Build-Depends: debhelper-compat (= 13), bash, build-essential, cmake, libcli11-dev, libinih-dev, libjsoncpp-dev, libsystemd-dev, libxml2-dev, libzmq3-dev, ninja-build, pkg-config, python3.10, python3-jinja2, python3-pip, python3-setuptools, python3-venv, python3-wheel, rsync, zlib1g-dev
+Build-Depends: debhelper-compat (= 13), bash, build-essential, cmake, libcli11-dev, libinih-dev, libjsoncpp-dev, libsystemd-dev, libxml2-dev, libzmq3-dev, ninja-build, pkg-config, python3, python3-jinja2, python3-pip, python3-setuptools, python3-venv, python3-wheel, rsync, zlib1g-dev
 Standards-Version: 4.6.0.1
 
 Package: slash-dev


### PR DESCRIPTION
When reworking the slashkit packaging, I added the explicit dependency on `python3.10` in Ubuntu's build dependencies. That's not intentional and not consistent with the final slashkit package. This PR fixes that.