### PR TITLE
build: add setuptools_scm for versioning

### DIFF
--- a/linker/pyproject.toml
+++ b/linker/pyproject.toml
@@ -1,17 +1,21 @@
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=68.0", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "slashkit"
-version = "0.1.0"
 description = "Utility to link VRT binaries (VBINs) from user IP cores"
 license = "MIT"
 requires-python = ">=3.9"
 dependencies = ["jinja2>=2.11.3"]
+dynamic = ["version"]
 
 [project.scripts]
 "slashkit" = "slashkit.__main__:main"
+
+[tool.setuptools_scm]
+root = ".."
+git_describe_command = "git describe --tags --long --match \"v*\""
 
 [tool.setuptools.packages.find]
 include = ["slashkit*"]


### PR DESCRIPTION

This PR migrates the `slashkit` package versioning from a hardcoded string to dynamic versioning managed by `setuptools_scm`. This configuration ensures that package versions are automatically derived from Git tags and commit hashes, allowing developers to easily trace the source of a build back to its exact commit.


This change applies to the Python build artifacts (wheels and source distributions).
It shall not affect the packaging workflow for Debian packages ([`scripts/pinstall.sh`](https://github.com/Xilinx/SLASH/blob/59627cf6fdd875935682ebc6ab05ea229a8e2ba2/scripts/pinstall.sh#L39)):

```text
$ ls linker/dist/slashkit-*.whl
linker/dist/slashkit-0.1.1.dev26+g59627cf-py3-none-any.whl
```