### PR TITLE
Enable Ubuntu 24.04, Ubuntu 26.04 and Rocky 10; add version argument to run-with-docker.sh

### DIFF
--- a/.github/workflows/vrt-unit-test.yml
+++ b/.github/workflows/vrt-unit-test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y cmake pkg-config ninja-build \
-          libxml2-dev libzmq3-dev libjsoncpp-dev zlib1g-dev \
+          libxml2-dev libzmq3-dev cppzmq-dev libjsoncpp-dev zlib1g-dev \
           libsystemd-dev libinih-dev libcli11-dev lcov python3-zmq
 
       - name: Build and run VRT unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ driver/kcompat/.scratch/
 # Output files for package
 /deb/
 /rpm/
+/docker-build/
 
 # VBIN build directories
 *.prj

--- a/docs/tutorials/admin/platform-setup.rst
+++ b/docs/tutorials/admin/platform-setup.rst
@@ -58,7 +58,7 @@ required on the build machine, not on every target:
 
 .. tab-set::
 
-   .. tab-item:: Ubuntu
+   .. tab-item:: Ubuntu 22.04
 
       .. code-block:: bash
 
@@ -68,6 +68,17 @@ required on the build machine, not on every target:
            python3 python3-pip \
            libcli11-dev libinih-dev libjsoncpp-dev \
            libsystemd-dev libxml2-dev libzmq3-dev zlib1g-dev
+
+   .. tab-item:: Ubuntu 24.04 / 26.04
+
+      .. code-block:: bash
+
+         sudo apt install \
+           build-essential cmake ninja-build pkg-config rsync \
+           debhelper dh-dkms dpkg-dev apt-utils \
+           python3 python3-pip \
+           libcli11-dev libinih-dev libjsoncpp-dev \
+           libsystemd-dev libxml2-dev libzmq3-dev cppzmq-dev zlib1g-dev
 
    .. tab-item:: RHEL 9 / Rocky Linux 9 / AlmaLinux 9
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -23,7 +23,7 @@ Section: utils
 Priority: optional
 Maintainer: Vlad-Gabriel Serbu <Vlad-Gabriel.Serbu@amd.com>
 Rules-Requires-Root: no
-Build-Depends: debhelper-compat (= 13), bash, build-essential, cmake, libcli11-dev, libinih-dev, libjsoncpp-dev, libsystemd-dev, libxml2-dev, libzmq3-dev, ninja-build, pkg-config, python3.10, python3-jinja2, python3-pip, python3-setuptools, python3-venv, python3-wheel, rsync, zlib1g-dev
+Build-Depends: debhelper-compat (= 13), bash, build-essential, cmake, libcli11-dev, libinih-dev, libjsoncpp-dev, libsystemd-dev, libxml2-dev, libzmq3-dev, cppzmq-dev | libzmq3-dev, ninja-build, pkg-config, python3, python3-jinja2, python3-pip, python3-setuptools, python3-venv, python3-wheel, rsync, zlib1g-dev
 Standards-Version: 4.6.0.1
 
 Package: slash-dev

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -21,7 +21,7 @@
 # ##################################################################################################
 
 export DH_VERBOSE=1
-ARTIFACTS_DIR=$(CURDIR)/deb
+ARTIFACTS_DIR ?= $(CURDIR)/deb
 
 %:
 	dh $@ --with dkms

--- a/packaging/debian/slashkit.install
+++ b/packaging/debian/slashkit.install
@@ -19,6 +19,6 @@
 # ##################################################################################################
 
 usr/bin/slashkit
-usr/lib/python3.10/dist-packages/slashkit/
-usr/lib/python3.10/dist-packages/slashkit-*.dist-info/
+usr/lib/python3.*/dist-packages/slashkit/
+usr/lib/python3.*/dist-packages/slashkit-*.dist-info/
 usr/lib/*/cmake/SlashTools/

--- a/scripts/Dockerfile.package-rocky
+++ b/scripts/Dockerfile.package-rocky
@@ -1,4 +1,5 @@
-FROM rockylinux:9
+ARG BASE_IMAGE=rockylinux:9
+FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000
 

--- a/scripts/Dockerfile.package-rocky
+++ b/scripts/Dockerfile.package-rocky
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rockylinux:9
+ARG BASE_IMAGE=rockylinux/rockylinux:9
 FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000

--- a/scripts/Dockerfile.package-ubuntu
+++ b/scripts/Dockerfile.package-ubuntu
@@ -1,16 +1,34 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends \
-        build-essential ca-certificates debhelper devscripts dkms apt-utils  pkg-config \
+# Install build dependencies. lsb-release provides the lsb_release command
+# Vivado calls on every supported release. A few build deps differ by release:
+#   * libtinfo5 (needed by Vivado) was dropped after 22.04; on >= 24.04 install
+#     libtinfo6 and add a libtinfo.so.5 compatibility symlink instead.
+#   * the dh_dkms debhelper sequence moved out of the dkms package into a
+#     separate dh-dkms package on >= 24.04.
+#   * zmq.hpp (the cppzmq C++ binding) ships inside libzmq3-dev on 22.04 but
+#     moved to a separate cppzmq-dev package on >= 24.04.
+RUN . /etc/os-release && \
+    apt-get update -qq && \
+    PKGS="build-essential ca-certificates debhelper devscripts dkms apt-utils pkg-config \
         rsync bash cmake git ninja-build \
         libcli11-dev libinih-dev libjsoncpp-dev libsystemd-dev libxml2-dev libzmq3-dev zlib1g-dev libyaml-dev \
         python3 python3-venv python3-jinja2 python3-pip python3-setuptools python3-wheel \
-        locales locales-all libtinfo5 libc6-dev-i386 libglib2.0-0 libsm6 libxext6 libxrender-dev libpixman-1-0 lsb-core
+        locales locales-all libc6-dev-i386 libglib2.0-0 libsm6 libxext6 libxrender-dev libpixman-1-0 lsb-release" && \
+    if dpkg --compare-versions "$VERSION_ID" ge 24.04; then \
+        PKGS="$PKGS libtinfo6 dh-dkms cppzmq-dev"; \
+    else \
+        PKGS="$PKGS libtinfo5"; \
+    fi && \
+    apt-get install -y --no-install-recommends $PKGS && \
+    if dpkg --compare-versions "$VERSION_ID" ge 24.04; then \
+        ln -sf libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5; \
+    fi
 
 # Setting timezone and locale for Vivado
 ENV TZ="Europe/Dublin"

--- a/scripts/Dockerfile.run-rocky
+++ b/scripts/Dockerfile.run-rocky
@@ -1,4 +1,5 @@
-FROM rockylinux:9
+ARG BASE_IMAGE=rockylinux:9
+FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000
 

--- a/scripts/Dockerfile.run-rocky
+++ b/scripts/Dockerfile.run-rocky
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rockylinux:9
+ARG BASE_IMAGE=rockylinux/rockylinux:9
 FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000

--- a/scripts/Dockerfile.run-ubuntu
+++ b/scripts/Dockerfile.run-ubuntu
@@ -1,13 +1,27 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE}
 
 ARG USER_ID=1000
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends \
-        build-essential ca-certificates pkg-config git rsync bash cmake git ninja-build \
-        locales locales-all libtinfo5 libc6-dev-i386 libglib2.0-0 libsm6 libxext6 libxrender-dev libpixman-1-0 lsb-core
+# Install base packages. lsb-release provides the lsb_release command Vivado
+# calls on every supported release. libtinfo5 (needed by Vivado) was dropped
+# after 22.04; on >= 24.04 install libtinfo6 and add a libtinfo.so.5
+# compatibility symlink instead.
+RUN . /etc/os-release && \
+    apt-get update -qq && \
+    PKGS="build-essential ca-certificates pkg-config git rsync bash cmake ninja-build \
+        locales locales-all libc6-dev-i386 libglib2.0-0 libsm6 libxext6 libxrender-dev libpixman-1-0 lsb-release" && \
+    if dpkg --compare-versions "$VERSION_ID" ge 24.04; then \
+        PKGS="$PKGS libtinfo6"; \
+    else \
+        PKGS="$PKGS libtinfo5"; \
+    fi && \
+    apt-get install -y --no-install-recommends $PKGS && \
+    if dpkg --compare-versions "$VERSION_ID" ge 24.04; then \
+        ln -sf libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5; \
+    fi
 
 COPY deb/*.deb /tmp
 RUN apt install -y /tmp/slash-dev_*.deb \

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -81,8 +81,8 @@ fi
 set -x
 
 # Clean build
-rm -rf deb
-mkdir -p deb
+rm -rf "${ARTIFACTS_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
 rm -rf pbuild
 rm -rf debian
 

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -89,6 +89,7 @@ tar czf "${TOPDIR}/SOURCES/slash-${VERSION}.tar.gz" \
     --exclude='rpmbuild' \
     --exclude='rpm' \
     --exclude='deb' \
+    --exclude='docker-build' \
     --exclude='pbuild' \
     .
 

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -138,8 +138,9 @@ VERSION=${3:-}
 
 # Check the distro argument and select the packaging script, the default
 # version, and the base image for the requested (distro, version) pair.
-# Rocky 10 is not published under the deprecated "rockylinux" Docker Official
-# Image, so it is pulled from the team-maintained rockylinux/rockylinux repo.
+# Rocky images are pulled from the team-maintained rockylinux/rockylinux repo
+# rather than the "rockylinux" Docker Official Image: the latter is unmaintained
+# and badly out of date (stuck near 9.3), and never published a 10 tag at all.
 if [ "$DISTRO" = "ubuntu" ]; then
     PACKAGE_SCRIPT="./scripts/package-deb.sh"
     VERSION=${VERSION:-22.04}
@@ -154,8 +155,7 @@ elif [ "$DISTRO" = "rocky" ]; then
     PACKAGE_SCRIPT="./scripts/package-rpm.sh"
     VERSION=${VERSION:-9}
     case "$VERSION" in
-        9)  BASE_IMAGE="rockylinux:9" ;;
-        10) BASE_IMAGE="rockylinux/rockylinux:10" ;;
+        9|10) BASE_IMAGE="rockylinux/rockylinux:$VERSION" ;;
         *)
             echo "Unsupported rocky version '$VERSION' (supported: 9, 10)" >&2
             exit 1

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -22,7 +22,7 @@
 
 set -exo pipefail
 
-# Usage: scripts/run-with-docker.sh <run|package> <ubuntu|rocky>
+# Usage: scripts/run-with-docker.sh <run|package> <ubuntu|rocky> [version]
 #
 # Builds (if necessary) and runs one of the SLASH Docker containers defined by
 # scripts/Dockerfile.<run|package>-<ubuntu|rocky>. The current working
@@ -38,6 +38,16 @@ set -exo pipefail
 #             dependencies installed.
 #   run       Drop into an interactive bash shell inside a container that has
 #             the freshly built SLASH packages already installed.
+#
+# Distro version (optional third argument):
+#   Selects the base image the container is built from. When omitted it
+#   defaults to the oldest supported release for the chosen distro.
+#     ubuntu   22.04 (default), 24.04, 26.04  -> ubuntu:<version>
+#     rocky    9 (default), 10                -> rockylinux:9 /
+#                                                rockylinux/rockylinux:10
+#   Each distro+version pair is built and tagged independently as
+#   slash-<run|package>-<distro>:<version>, so different versions do not
+#   clobber each other's images.
 #
 # Required environment variables:
 #   SLASH_XILINX_PATH   Path to the Xilinx tools install on the host
@@ -63,13 +73,15 @@ set -exo pipefail
 #                                     root-design build step.
 #
 # Examples:
-#   scripts/run-with-docker.sh package ubuntu   # build .deb packages
-#   scripts/run-with-docker.sh package rocky    # build .rpm packages
-#   scripts/run-with-docker.sh run     ubuntu   # interactive shell with
-#                                               # the .debs preinstalled
+#   scripts/run-with-docker.sh package ubuntu         # .deb on ubuntu 22.04
+#   scripts/run-with-docker.sh package ubuntu 24.04   # .deb on ubuntu 24.04
+#   scripts/run-with-docker.sh package rocky          # .rpm on rocky 9
+#   scripts/run-with-docker.sh package rocky 10       # .rpm on rocky 10
+#   scripts/run-with-docker.sh run     ubuntu         # interactive shell with
+#                                                     # the .debs preinstalled
 
-if [ $# -ne 2 ]; then
-    echo "Usage: <run|package> <ubuntu|rocky>" 2>&1
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "Usage: <run|package> <ubuntu|rocky> [version]" >&2
     exit 1
 fi
 
@@ -105,16 +117,52 @@ if [ -n $SLASH_PKG_SKIP_ROOT_DESIGN_BUILD ]; then
     DOCKER_RUN_ARGS+="-e SLASH_PKG_SKIP_ROOT_DESIGN_BUILD=$SLASH_PKG_SKIP_ROOT_DESIGN_BUILD "
 fi
 
+# Mount the git directory so version-stamping scripts that shell out to git
+# (e.g. AVED's getVersion.sh, which stamps GIT_HASH into the AMI package
+# release) work inside the container. For a normal checkout .git lives under
+# $PWD and is already mounted; for a git worktree .git is a file pointing at
+# the main repo's git dir, which is outside $PWD and must be mounted at the
+# same path. Without it git fails and the empty hash yields an illegal
+# "0..<date>" rpm release.
+if GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+    GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+    case "$GIT_COMMON_DIR" in
+        "$PWD"/*) : ;; # already covered by the $PWD mount
+        *) DOCKER_RUN_ARGS+="-v $GIT_COMMON_DIR:$GIT_COMMON_DIR " ;;
+    esac
+fi
+
 CONTAINER=$1
 DISTRO=$2
+VERSION=${3:-}
 
-# Check the distro argument and set the relevant packaging script
-if [ $DISTRO = "ubuntu" ]; then
+# Check the distro argument and select the packaging script, the default
+# version, and the base image for the requested (distro, version) pair.
+# Rocky 10 is not published under the deprecated "rockylinux" Docker Official
+# Image, so it is pulled from the team-maintained rockylinux/rockylinux repo.
+if [ "$DISTRO" = "ubuntu" ]; then
     PACKAGE_SCRIPT="./scripts/package-deb.sh"
-elif [ $DISTRO = "rocky" ]; then
+    VERSION=${VERSION:-22.04}
+    case "$VERSION" in
+        22.04|24.04|26.04) BASE_IMAGE="ubuntu:$VERSION" ;;
+        *)
+            echo "Unsupported ubuntu version '$VERSION' (supported: 22.04, 24.04, 26.04)" >&2
+            exit 1
+            ;;
+    esac
+elif [ "$DISTRO" = "rocky" ]; then
     PACKAGE_SCRIPT="./scripts/package-rpm.sh"
+    VERSION=${VERSION:-9}
+    case "$VERSION" in
+        9)  BASE_IMAGE="rockylinux:9" ;;
+        10) BASE_IMAGE="rockylinux/rockylinux:10" ;;
+        *)
+            echo "Unsupported rocky version '$VERSION' (supported: 9, 10)" >&2
+            exit 1
+            ;;
+    esac
 else
-    echo "Unknown Linux distro $DISTRO" 2>&1
+    echo "Unknown Linux distro $DISTRO" >&2
     exit 1
 fi
 
@@ -130,12 +178,18 @@ elif [ $CONTAINER = "run" ]; then
     DOCKER_COMMAND+="&& bash"
     DOCKER_RUN_ARGS+="-it "
 else
-    echo "Unknown container definition $CONTAINER" 2>&1
+    echo "Unknown container definition $CONTAINER" >&2
     exit 1
 fi
 
-# Build and run the container.
-docker build --build-arg USER_ID=$(id -u) -t "slash-$CONTAINER-$DISTRO" -f "scripts/Dockerfile.$CONTAINER-$DISTRO" .
+# Build and run the container. The image is tagged per distro+version so that
+# different versions do not clobber each other's images.
+IMAGE_TAG="slash-$CONTAINER-$DISTRO:$VERSION"
+docker build \
+    --build-arg USER_ID=$(id -u) \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    -t "$IMAGE_TAG" \
+    -f "scripts/Dockerfile.$CONTAINER-$DISTRO" .
 docker run $DOCKER_RUN_ARGS \
-    "slash-$CONTAINER-$DISTRO" \
+    "$IMAGE_TAG" \
     bash -c "$DOCKER_COMMAND"

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -35,7 +35,13 @@ set -exo pipefail
 #   package   Run the matching distro's packaging script
 #             (scripts/package-deb.sh on Ubuntu, scripts/package-rpm.sh on
 #             Rocky) inside a clean container that only has the build
-#             dependencies installed.
+#             dependencies installed. The built packages are written to a
+#             per-distro+version directory under the working tree:
+#               docker-build/ubuntu-22.04/*.deb
+#               docker-build/ubuntu-24.04/*.deb
+#               docker-build/ubuntu-26.04/*.deb
+#               docker-build/rocky-9/*.rpm
+#               docker-build/rocky-10/*.rpm
 #   run       Drop into an interactive bash shell inside a container that has
 #             the freshly built SLASH packages already installed.
 #
@@ -173,6 +179,13 @@ fi
 DOCKER_COMMAND="source $SLASH_XILINX_PATH/2025.1/Vivado/settings64.sh "
 DOCKER_COMMAND+="&& export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$SLASH_XILINX_PATH/2025.1/Vivado/lib/lnx64.o "
 if [ $CONTAINER = "package" ]; then
+    # Route the built packages into a per-distro+version subdirectory so the
+    # outputs of different builds do not clobber each other. Both packaging
+    # scripts honour ARTIFACTS_DIR. The path lives under $PWD, which is mounted
+    # at the same path in the container, so the artifacts are visible on the
+    # host once the container exits.
+    ARTIFACTS_DIR="$PWD/docker-build/$DISTRO-$VERSION"
+    DOCKER_RUN_ARGS+="-e ARTIFACTS_DIR=$ARTIFACTS_DIR "
     DOCKER_COMMAND+="&& $PACKAGE_SCRIPT "
 elif [ $CONTAINER = "run" ]; then
     DOCKER_COMMAND+="&& bash"

--- a/vrt/vrtd/src/CMakeLists.txt
+++ b/vrt/vrtd/src/CMakeLists.txt
@@ -64,6 +64,9 @@ add_executable(vrtd ${CMAKE_CURRENT_SOURCE_DIR}/main.c)
 target_link_libraries(vrtd PRIVATE vrtd_core)
 
 set_target_properties(vrtd PROPERTIES
+  C_STANDARD 11
+  C_STANDARD_REQUIRED YES
+  C_EXTENSIONS YES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
 )

--- a/vrt/vrtd/src/array.h
+++ b/vrt/vrtd/src/array.h
@@ -112,7 +112,7 @@
      *  @param arr The array to resize.
      *  @param len The new length.
      *  @return 0 on success, -1 on allocation failure. */ \
-    static inline NODISCARD \
+    NODISCARD static inline \
     int T_ARRAY##_resize(struct T_ARRAY *arr, size_t len) \
     { \
         size_t cap = likely(len > 0) ? bit_ceil(len) : 0; \
@@ -143,7 +143,7 @@
      *  @param arr The array to push to.
      *  @param v   The value to append.
      *  @return 0 on success, -1 on allocation failure. */ \
-    static inline NODISCARD \
+    NODISCARD static inline \
     int T_ARRAY##_push(struct T_ARRAY *arr, T v) { \
         if (unlikely(T_ARRAY##_resize(arr, arr->len + 1) == -1)) { \
             return -1; \

--- a/vrt/vrtd/src/utils.h
+++ b/vrt/vrtd/src/utils.h
@@ -94,9 +94,6 @@ const char *uid_to_username(uid_t uid, char *buf, size_t bufsz);
 #  endif
 #endif
 
-/** @brief Portable attribute to warn if a function's return value is discarded. */
-#define NODISCARD __attribute__((warn_unused_result))
-
 /* ---- type-specific helpers ---- */
 #if HAVE_STDBIT
 /**
@@ -183,6 +180,7 @@ static inline uint64_t bit_ceil_u64(uint64_t n) {
 /** @brief No-operation statement (void expression). */
 #define NOP() ((void) 0)
 
+/** @brief Portable attribute to warn if a function's return value is discarded. */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
     #define NODISCARD [[nodiscard]]
 #elif defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
## Summary

The Docker packaging/run flow and the Debian packaging metadata were hard-wired to a single distro release each (`ubuntu:22.04`, `rockylinux:9`) and to package names/paths that only exist on those releases. This branch makes one source tree build cleanly on **Ubuntu 22.04 / 24.04 / 26.04** and **Rocky Linux 9 / 10**, and adds an optional **version argument** to `scripts/run-with-docker.sh` so a specific release can be selected without editing the Dockerfiles.

The breakage on newer releases came from four independent sources:

- Package names and install paths that moved between releases (`cppzmq-dev`, `dh-dkms`, `libtinfo6`, `lsb-release`, versioned `python3.*/dist-packages`).
- A hard `python3.10` build dependency that is unsatisfiable on releases that ship a different Python minor version.
- The C compiler default standard changing to **C23** on GCC 15 (Ubuntu 26.04), which exposed a misplaced `[[nodiscard]]` attribute in `vrtd`.
- `git worktree` builds failing inside the container because the worktree's `.git` lives outside the mounted working directory.

Each fix is explained in detail below.

## Status

**Packaging and software builds** work on **Ubuntu 22.04**, **Ubuntu 24.04**, **Rocky 9** and **Rocky 10**. Building on **Ubuntu 26.04** still requires a fix for an upstream issue in AVED (reported upstream [here](https://github.com/Xilinx/AVED/issues/39)).

**Kernel module compilation** (during the DKMS package install) currently fails on **Rocky 9.8**, **Rocky 10** and **Ubuntu 26.04** due to a number of issues in libqdma (reported upstream [here](https://github.com/Xilinx/dma_ip_drivers/issues/391), [here](https://github.com/Xilinx/dma_ip_drivers/issues/393) and [here](https://github.com/Xilinx/dma_ip_drivers/issues/395)).

## Changes by area

### 1. Debian packaging metadata — `packaging/debian/`

**`packaging/debian/control`**

- **Relax the Python pin:** `python3.10` build-dep is now plain `python3`. Ubuntu 22.04 ships Python 3.10, but 24.04 ships 3.12 and 26.04 ships a newer minor still. A literal `python3.10` build dependency is simply unsatisfiable on those releases (no such package), so the build never starts. `python3` always resolves to the release's default interpreter, which is what the build actually needs.
- **Add the cppzmq build-dep with a fallback:** `libzmq3-dev` becomes `cppzmq-dev | libzmq3-dev`. The C++ ZeroMQ binding header `zmq.hpp` shipped *inside* `libzmq3-dev` on 22.04 but was split out into a separate `cppzmq-dev` package on 24.04+. The alternative (`A | B`) resolves to `cppzmq-dev` on new releases and falls back to `libzmq3-dev` on 22.04, so a single `control` file satisfies the header dependency everywhere.

**`packaging/debian/slashkit.install`**

- The slashkit Python package install paths are de-versioned: `usr/lib/python3.10/dist-packages/...` -> `usr/lib/python3.*/dist-packages/...`. dh-installs the files from wherever the release's Python placed them; the glob matches `python3.12`, `python3.14`, etc., so the `.install` manifest no longer fails to find the staged files on non-3.10 releases.

### 2. CI — `.github/workflows/vrt-unit-test.yml`

- Add `cppzmq-dev` to the VRT unit-test dependency `apt install` line. The CI runner is Ubuntu 24.04, where (as above) `zmq.hpp` is no longer part of `libzmq3-dev`. Without `cppzmq-dev` the VRT build that consumes the C++ ZeroMQ binding fails to find the header and the unit-test job breaks.

### 3. Dockerfiles — `scripts/Dockerfile.{package,run}-{ubuntu,rocky}`

**All four Dockerfiles: parametrize the base image**

```dockerfile
ARG BASE_IMAGE=ubuntu:22.04      # rocky: rockylinux/rockylinux:9
FROM ${BASE_IMAGE}
```

This lets `run-with-docker.sh` pass `--build-arg BASE_IMAGE=...` to pick the release at build time while keeping a sensible default (Ubuntu 22.04 / Rocky 9) for callers that build a Dockerfile directly.

**Ubuntu Dockerfiles: release-aware package selection**

Both `Dockerfile.package-ubuntu` and `Dockerfile.run-ubuntu` now source `/etc/os-release` and branch on `$VERSION_ID` with `dpkg --compare-versions`:

- **`libtinfo5` -> `libtinfo6` + compat symlink.** Vivado links against `libtinfo.so.5`. `libtinfo5` exists on 22.04 but was dropped on 24.04+. On `>= 24.04` we install `libtinfo6` and create `ln -sf libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5` so Vivado's loader still finds an ABI-compatible `libtinfo.so.5`.
- **`lsb-core` -> `lsb-release`.** Vivado calls the `lsb_release` command on startup. The metapackage `lsb-core` was removed on newer Ubuntu; `lsb-release` (which actually provides the command) is available across all supported releases, so it is used unconditionally.
- **`dh-dkms` on `>= 24.04`** (package Dockerfile only). The `dh_dkms` debhelper sequence used to live in the `dkms` package but was split into a separate `dh-dkms` package on 24.04+. It is added only on new releases (22.04 still gets it via `dkms`).
- **`cppzmq-dev` on `>= 24.04`** (package Dockerfile only). Same `zmq.hpp` split described above, applied to the container image.

**Rocky Dockerfiles**

Rocky needs only the `BASE_IMAGE` parametrization; the dnf package set is the same on Rocky 9 and 10, so there are no version-conditional package changes. The in-file default is set to `rockylinux/rockylinux:9` (the maintained namespace, see below).

### 4. `scripts/run-with-docker.sh`

**New optional version argument (`<run|package> <ubuntu|rocky> [version]`)**

- Accepts an optional third argument. When omitted it defaults to the oldest supported release for the distro (Ubuntu `22.04`, Rocky `9`), preserving previous behaviour.
- Validates the requested version and maps it to a base image:
  - Ubuntu: `22.04` / `24.04` / `26.04` -> `ubuntu:<version>`.
  - Rocky: `9` / `10` -> `rockylinux/rockylinux:<version>`. Both releases are pulled from the team-maintained `rockylinux/rockylinux` repository rather than the `rockylinux` Docker Official Image: the latter is unmaintained and badly out of date (stuck near 9.3) and never published a `10` tag at all. Using one namespace keeps the mapping uniform and gives Rocky 9 a current base image.
  - Unknown versions exit with a clear "supported: ..." error.
- Passes `--build-arg BASE_IMAGE="$BASE_IMAGE"` into `docker build`.
- **Per-version image tags:** images are now tagged `slash-<run|package>-<distro>:<version>` instead of `slash-<run|package>-<distro>`, so building one version no longer clobbers another version's cached image.

**Mount the git common dir for worktree builds**

```bash
if GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"; then
    GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
    case "$GIT_COMMON_DIR" in
        "$PWD"/*) : ;;   # already covered by the $PWD mount
        *) DOCKER_RUN_ARGS+="-v $GIT_COMMON_DIR:$GIT_COMMON_DIR " ;;
    esac
fi
```

- AVED's `getVersion.sh` shells out to `git` to stamp `GIT_HASH` into the AMI package release string. In a normal checkout `.git` is a directory under `$PWD` and is already covered by the working-directory mount. In a **git worktree**, `.git` is a *file* pointing at the main repo's git dir, which lives outside `$PWD` and is therefore not visible inside the container.
- When that happens, `git` fails, the hash comes back empty, and the resulting rpm release string `0..<date>` is rejected as illegal — the package build dies. Mounting the git common dir at the same path fixes worktree builds while being a no-op for ordinary checkouts.

**Misc**

- Argument count check relaxed from exactly 2 to 2-or-3 args.
- Several error messages corrected from `2>&1` (which redirects stdout to stderr's current target) to the intended `>&2` (write to stderr).
- Usage/example comments updated to document the version argument.

### 5. `vrtd` — build under C23 (GCC 15 / Ubuntu 26.04)

GCC 15, the default compiler on Ubuntu 26.04, defaults to the **C23** standard. Two things break the `vrtd` daemon there:

**`vrt/vrtd/src/CMakeLists.txt` — pin the daemon to C11**

```cmake
set_target_properties(vrtd PROPERTIES
  C_STANDARD 11
  C_STANDARD_REQUIRED YES
  C_EXTENSIONS YES
  ...)
```

The daemon is written against GNU C11 (`-std=gnu11`, per `STYLE.md`). Pinning `C_STANDARD 11` makes the build deterministic across compilers instead of inheriting GCC 15's C23 default.

**`vrt/vrtd/src/utils.h` — drop the duplicate `NODISCARD` definition**

`NODISCARD` was defined twice: once unconditionally as `__attribute__((warn_unused_result))`, and again, later in the same header, with a standard-aware definition (`[[nodiscard]]` under C23, the GNU attribute otherwise). The unconditional definition is removed so the single, standard-aware definition is the one that takes effect.

**`vrt/vrtd/src/array.h` — fix attribute placement**

```c
-    static inline NODISCARD
+    NODISCARD static inline
     int T_ARRAY##_resize(...)
```

When `NODISCARD` expands to the C23 `[[nodiscard]]` attribute, it must precede the declaration specifiers. `static inline [[nodiscard]] int f()` is ill-formed in C23, whereas `[[nodiscard]] static inline int f()` is correct (and the ordering is harmless for the GNU `__attribute__` fallback too). Applied to both `_resize` and `_push`.

### 6. Docs — `docs/tutorials/admin/platform-setup.rst`

- The single "Ubuntu" dependency tab is split into **"Ubuntu 22.04"** and **"Ubuntu 24.04 / 26.04"**. The newer-release tab adds `dh-dkms` and `cppzmq-dev` to the `apt install` line, matching the packaging changes above so the documented manual setup actually works on 24.04/26.04.