### PR TITLE
fix(ci): synchronize apt index in VRT Unit Test

### DIFF
--- a/.github/workflows/vrt-unit-test.yml
+++ b/.github/workflows/vrt-unit-test.yml
@@ -40,9 +40,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y cmake pkg-config ninja-build \
-          libxml2-dev libzmq3-dev libjsoncpp-dev zlib1g-dev \
-          libsystemd-dev libinih-dev libcli11-dev lcov python3-zmq
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config ninja-build \
+            libxml2-dev libzmq3-dev libjsoncpp-dev zlib1g-dev \
+            libsystemd-dev libinih-dev libcli11-dev lcov python3-zmq
 
       - name: Build and run VRT unit tests
         run: |


### PR DESCRIPTION

This PR fixes the failing `vrt_unit_tests` workflow.

The CI pipeline is currently failing during the "Install dependencies" step. This issue is caused by an out-of-sync package index on the runner.  [Action Run #27342893033](https://github.com/Xilinx/SLASH/actions/runs/27342893033/job/80783943695#logs).

This PR added `apt-get update` prior to the `apt-get install` command to ensure the package repository indexes are synchronized before installation. This aligns with official recommendations outlined in the [GitHub Actions Documentation](https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners#installing-software-on-ubuntu-runners).

