### PR TITLE
Fix Vivado missing IP repository warning on clean builds

### DIFF
--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -218,8 +218,11 @@ def create_build_project(
             str(tcl_path),
             "-tclargs",
             config.project_name,
-            config.ip_repository
         ]
+
+        if config.ip_repository.exists():
+            cmd.append(config.ip_repository)
+
         if action:
             cmd.append(action)
 


### PR DESCRIPTION

`config.ip_repository` defaults to a subdirectory inside `build_dir`. 

https://github.com/Xilinx/SLASH/blob/a11e7287d2a6c57911f4e5f2a23a228447afba6d/linker/slashkit/core/command_config.py#L101-L102

Because `build_dir` is wiped and recreated on every build, `ip_repository` may not exist yet when `create_build_project` is called. 

https://github.com/Xilinx/SLASH/blob/a11e7287d2a6c57911f4e5f2a23a228447afba6d/linker/slashkit/core/command_config.py#L374-L376

Previously it was unconditionally appended to the Vivado command line, which could cause the tool to warn on a clean build.

```
IP REPOS:       <redacted>/SLASH/linker/install.prj/iprepo

INFO: Creating new project 'slash' in '<redacted>/SLASH/linker/install.prj' ...
INFO: [IP_Flow 19-234] Refreshing IP repositories
WARNING: [IP_Flow 19-2248] Failed to load user IP repository '<redacted>/SLASH/linker/install.prj/iprepo'; Can't find the specified path.
If this directory should no longer be in your list of user repositories, go to the IP Settings dialog and remove it.
```

The fix checks `config.ip_repository.exists()` before appending, so the argument is only passed when the directory is actually present.

