### PR TITLE
Pass `jobs` argument to create_project.tcl

### DIFF
--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -223,6 +223,8 @@ def create_build_project(
         if action:
             cmd.append(action)
 
+        cmd.append(str(config.n_jobs))
+
         subprocess.run(cmd, cwd=str(config.build_dir), check=True,
                        env=_environment_with_udev_ld_preload())
 

--- a/linker/slashkit/resources/base/scripts/build_project.tcl
+++ b/linker/slashkit/resources/base/scripts/build_project.tcl
@@ -18,8 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
-proc build_project {{proj_name "user"}} {
-  puts "INFO: Using proj_name='$proj_name'"
+proc build_project {{proj_name "user"} {jobs 14}} {
+  puts "INFO: Using proj_name='$proj_name' and jobs='$jobs'"
 
   # Ensure top BD is generated
   generate_target all [get_files "top.bd"]
@@ -39,7 +39,7 @@ proc build_project {{proj_name "user"}} {
   set_property STEPS.WRITE_DEVICE_IMAGE.TCL.PRE  [get_files *write_device_image.pre.tcl]  [get_runs impl_1]
 
   # Launch and wait
-  launch_runs impl_1 -to_step write_bitstream -jobs 14
+  launch_runs impl_1 -to_step write_bitstream -jobs $jobs
   wait_on_run impl_1
   open_run impl_1
   

--- a/linker/slashkit/resources/base/scripts/create_project.tcl
+++ b/linker/slashkit/resources/base/scripts/create_project.tcl
@@ -18,38 +18,62 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ##################################################################################################
 
+# Usage:
+#   vivado -mode batch -source $script -tclargs [project_name] [iprepos] [action] [jobs]
+# 
+# Arguments:
+#   project_name   Name of the Vivado project.
+#                  Default: user
+# 
+#   iprepos        Path to the IP repository directory.
+# 
+#   action         What to do. One of:
+#                    create  – create the project only
+#                    build   – run synthesis and implementation only
+#                    all     – create then build  (default)
+# 
+#   jobs           Number of parallel jobs for implementation.
+#                  Default: 14
+
 set src_dir [file dirname [file normalize [info script]]]
 set cwd     [pwd]
-
-if {[llength $argv] < 1} {
-  puts "INFO: No project_name provided via -tclargs; defaulting to 'user'."
-  set project_name "user"
-} else {
-  set project_name [lindex $argv 0]
-}
-
-# Optional IP repository path(s) via -tclargs; defaults to ../iprepo
 set default_iprepos [file normalize [file join $src_dir ".." "iprepo"]]
+
+set project_name "user"
 set iprepos $default_iprepos
-
-# Optional action via -tclargs: create | build | all (default: all)
 set action "all"
+set jobs "14"
 
-if {[llength $argv] >= 2} {
-  set arg1 [lindex $argv 1]
-  if {[llength $argv] == 2} {
-    if {[lsearch -exact {create build all} $arg1] >= 0} {
-      set action $arg1
-    } else {
-      set iprepos $arg1
+if {[llength $argv] > 0} {
+  set project_name [lindex $argv 0]
+  set remaining_args [lrange $argv 1 end]
+
+  if {[llength $remaining_args] > 0} {
+    set arg [lindex $remaining_args end]
+    if {[string is integer -strict $arg]} {
+      set jobs $arg
+      set remaining_args [lrange $remaining_args 0 end-1]
     }
-  } else {
-    set iprepos $arg1
   }
-}
 
-if {[llength $argv] >= 3} {
-  set action [lindex $argv 2]
+  if {[llength $remaining_args] > 0} {
+    set arg [lindex $remaining_args end]
+    if {[lsearch -exact {create build all} $arg] >= 0} {
+      set action $arg
+      set remaining_args [lrange $remaining_args 0 end-1]
+    }
+  }
+
+  if {[llength $remaining_args] > 0} {
+    set iprepos [lindex $remaining_args end]
+    set remaining_args [lrange $remaining_args 0 end-1]
+  }
+
+  if {[llength $remaining_args] > 0} {
+    error "Too many arguments provided via -tclargs: $remaining_args"
+  }
+} else {
+  puts "INFO: No project_name provided via -tclargs; defaulting to '$project_name'."
 }
 
 set do_create 0
@@ -114,7 +138,7 @@ if {![file exists $proj_exists]} {
 
 if {$do_build} {
   safe_source [file normalize [file join $src_dir "build_project.tcl"]]
-  build_project $project_name
+  build_project $project_name $jobs
   puts "INFO: Project build complete."
 } elseif {$do_create} {
   puts "INFO: Project creation complete (build skipped)."

--- a/linker/slashkit/resources/base/scripts/create_project.tcl
+++ b/linker/slashkit/resources/base/scripts/create_project.tcl
@@ -109,7 +109,9 @@ if {![file exists $proj_exists]} {
   if {!$do_create} {
     error "Project not found at $proj_exists. Run with action 'create' first."
   }
-  lappend iprepos $default_iprepos
+  if {[lsearch -exact $iprepos $default_iprepos] == -1} {
+    lappend iprepos $default_iprepos
+  }
   puts "INFO: Creating new project '$design_name' in '$cwd' ..."
   create_project $design_name $cwd -part xcv80-lsva4737-2MHP-e-S -force
   set_property ip_repo_paths $iprepos [current_project]


### PR DESCRIPTION
## Problem

The help message indicates `jobs` argument is accepted:

https://github.com/Xilinx/SLASH/blob/a11e7287d2a6c57911f4e5f2a23a228447afba6d/linker/slashkit/core/command_config.py#L350

However, it is never actually forwarded to the `launch_runs` procedure in `build_project.tcl`:

https://github.com/Xilinx/SLASH/blob/a11e7287d2a6c57911f4e5f2a23a228447afba6d/linker/slashkit/resources/base/scripts/build_project.tcl#L42

As a result, implementation always runs with the hard-coded value of 14 jobs regardless of what the user passes.

## Changes

**Primary fix**
- Add a `jobs` parameter (default: `14`) to the `build_project` procedure in `build_project.tcl`. (a79adfc4962b0d9bde96a3faae94ed63a570ec97) 
- Pass the `n_jobs` argument from the Python side to `create_project.tcl`. (73acd217d9b20ca3e6df27742ab1bdbee2ab0fe1)
- Update `create_project.tcl` to accept and parse a `jobs` positional argument from `-tclargs`, then pass it through to `build_project`. (e77112711b058eee2d56309ba8ca51497cb91527)

**Incidental improvements**
- Refactor argument parsing in `create_project.tcl` for improved readability and maintainability; add a usage/arguments comment block at the top of the script. (e77112711b058eee2d56309ba8ca51497cb91527)
- Fix a bug where the default IP repository (`../iprepo`) could be appended twice if no `iprepos` argument was provided on the command line. (449ba0c95172b9ea720082afbd6e14fbb6756447)

