### PR TITLE
fix: correct path for removing install.prj in root-design-clean.sh

### DIFF
--- a/scripts/root-design-clean.sh
+++ b/scripts/root-design-clean.sh
@@ -27,5 +27,5 @@ cd "$(dirname "$0")/.."
 
 make -C linker/slashkit/resources/base/iprepo clean
 
-rm -rf linker/slashkit/install.prj
+rm -rf linker/install.prj
 rm -rf linker/slashkit/resources/static_shell


### PR DESCRIPTION
The Vivado project is created at `linker/install.prj` instead of `linker/slashkit/install.prj`.