### PR TITLE
[VRT] Fix null ptr deref when a buddy superblock is full

### DIFF
--- a/vrt/include/vrt/allocator/allocator.hpp
+++ b/vrt/include/vrt/allocator/allocator.hpp
@@ -251,8 +251,9 @@ protected:
             }
             return buffer;
         }
-        
-        return nullptr;
+
+        // no free buddy of sufficient size, caller should fall through to next superblock
+        throw std::bad_alloc();
     }
 
     void deallocate(const UntypedBuffer& whole, UntypedBuffer buffer, const char* tooSmallError, const char* ownershipError) {


### PR DESCRIPTION
`BuddySuperblockBase::allocate` returned nullptr when a superblock had no free buddy large enough for a request. However, its callers in `Allocator::allocate` are written to expect a `std::bad_alloc` instead. This means that, instead of moving on to the next superblock, the null was wrapped in a MediumBlock and returned as a valid allocation, then dereferenced host-side which produces a segfault.

### To reproduce

A host program crashes immediately in the `vrt::Buffer` constructor when allocating three 32 MiB buffers on the MEM/HBM_VNOC path. The fault is host-side, the actual vbin design doesn't matter much.

`LargeBlockSuperblock` is fixed at 64 MiB, so two 32 MiB buffers fill one superblock and the third needs a new one:
- Buffer 1 (32 MiB): no superblocks yet, create superblock 1, split, return the lower 32 MiB.
- Buffer 2 (32 MiB): superblock 1 matches, return the free upper 32 MiB. Superblock 1 is now full.
- Buffer 3 (32 MiB): superblock 1 is full. `BuddySuperblockBase::allocate` falls through its search loop and returns `nullptr`.
The caller catches `bad_alloc` to fall through, but a returned null is not an exception, so the `catch` never fires and the new-superblock fallback below the loop is skipped:
```cpp
try {
    UntypedBuffer buffer = superblock->allocate(size); // returned null on full, no throw
    return std::make_unique<MediumBlock>(superblock.get(), buffer); // wrapped the null and returned
} catch (const std::bad_alloc&) {
    continue; // intended exhaustion path, never reached
}
```

### Fix

Replace `return nullptr` with a `throw std::bad_alloc()`. Matches the exception already used at the top of the same function for the oversize-index case.

### Testing

Reproduced and fixed on V80 with libvrt built from this branch.

- [x]  Pre-fix: three 32 MiB allocations, segfault on third allocation, gdb backtrace shows last call `vrtd::Buffer::getPhysAddr(this=0x0)`, called from `Buffer::initAllocate` via `view->getPhysAddr()`. Buffers 0 and 1 sit at 0x4000000000 and 0x4002000000, 32 MiB apart.
- [x] Post-fix: all three allocations succeed, H2D/D2H returns correct data.
- [x] 200 x 4 KiB (SmallBlock plus a new medium superblock)
- [x] 16 x 32 MiB (many new medium superblocks)
- [x] 1 x 96 MiB (LargeBlock)
- [x] 5 x 64 MiB (one superblock per buffer)