### PR TITLE
fix: correct output redirection in error message

### DIFF
--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -100,7 +100,7 @@ DOCKER_RUN_ARGS+="-w $PWD "
 
 # Mounting the Xilinx toolchain in the container
 if [ -z $SLASH_XILINX_PATH ]; then
-    echo "Please set SLASH_XILINX_PATH to the path of your Xilinx tools installation (e.g. /opt/Xilinx)" 2&1
+    echo "Please set SLASH_XILINX_PATH to the path of your Xilinx tools installation (e.g. /opt/Xilinx)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Fix a typo in `scripts/run-with-docker.sh`: the `SLASH_XILINX_PATH` error message used `2&1` instead of `>&2`.