### PR TITLE
docker: delete existing user with clashing UID

### DIFF
--- a/scripts/Dockerfile.package-ubuntu
+++ b/scripts/Dockerfile.package-ubuntu
@@ -36,7 +36,11 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV LC_ALL=en_US.utf-8
 
 # Adding the slash user
-RUN useradd -m -U -u $USER_ID slash
+RUN if id -u $USER_ID >/dev/null 2>&1; then \
+        userdel -r $(id -nu $USER_ID); \
+    fi && \
+    useradd -m -U -u $USER_ID slash
+
 USER slash
 
 # Again, setting timezone and locale for Vivado

--- a/scripts/Dockerfile.run-ubuntu
+++ b/scripts/Dockerfile.run-ubuntu
@@ -41,7 +41,11 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV LC_ALL=en_US.utf-8
 
 # Adding the slash user
-RUN useradd -m -U -u $USER_ID slash
+RUN if id -u $USER_ID >/dev/null 2>&1; then \
+        userdel -r $(id -nu $USER_ID); \
+    fi && \
+    useradd -m -U -u $USER_ID slash
+
 USER slash
 
 # Again, setting timezone and locale for Vivado


### PR DESCRIPTION
Ubuntu 24.04 has a default user `ubuntu` with UID 1000, which makes `useradd` fail.
Fix this by deleting the conflicting user before creating the `slash` user, in both `Dockerfile.package-ubuntu` and `Dockerfile.run-ubuntu`.