### PR TITLE
fix: add missing ap_axi_sdata.h and sort includes

### DIFF
--- a/linker/slashkit/resources/templates/sw_emu_tb.cpp
+++ b/linker/slashkit/resources/templates/sw_emu_tb.cpp
@@ -18,25 +18,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <iostream>
-#include <ap_fixed.h>
-#include <hls_stream.h>
-#include <ap_int.h>
-#include <zmq.hpp>
-#include <json/json.h>
+#include <chrono>
 #include <cstdint>
-#include <map>
-#include <vector>
+#include <cstdlib>
 #include <cstring>
-#include <sstream>
-#include <stdexcept>
 #include <fstream>
 #include <functional>
-#include <thread>
 #include <future>
-#include <chrono>
-#include <cstdlib>
+#include <iostream>
+#include <map>
 #include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include <ap_axi_sdata.h>
+#include <ap_fixed.h>
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <json/json.h>
+#include <zmq.hpp>
 
 {% for p in prototypes %}
 {{ p }}


### PR DESCRIPTION

Building the `dcmac_emu` target for `examples/06_dcmac` failed because `hls::axis`, used in the generated testbench, is declared in `<ap_axi_sdata.h>`, which was not included in the template.

The generated  prototypes are:
```cpp
void traffic_producer(hls::stream<hls::axis<ap_uint<512>, 1, 1, 3, '8', false>>& axis_out, ap_uint<32> flits, ap_uint<3> dest);
void traffic_consumer(hls::stream<hls::axis<ap_uint<512>, 1, 1, 3, '8', false>>& axis_in, ap_uint<32>& rx_flits);
```

## Changes

- **Add `<ap_axi_sdata.h>`** to provide the `hls::axis` type definition.
- **Sort includes** into two groups — standard library headers first, then third-party/HLS headers — each group ordered alphabetically.
