### PR TITLE
feat(docker): use host system timezone instead of hardcoded Europe/Dublin

### DIFF
--- a/scripts/Dockerfile.package-rocky
+++ b/scripts/Dockerfile.package-rocky
@@ -12,14 +12,12 @@ RUN dnf install -y python3 python3-devel python3-jinja2 python3-pip python3-setu
     ncurses-compat-libs glib2 libXext libXrender-devel pixman lsb_release
 
 # Setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ARG TZ
+ENV TZ=${TZ:-Europe/Dublin}
 ENV LC_ALL=en_US.utf-8
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Adding the slash user
 RUN useradd -m -U -u $USER_ID slash
 USER slash
-
-# Again, setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-ENV LC_ALL=en_US.utf-8

--- a/scripts/Dockerfile.package-ubuntu
+++ b/scripts/Dockerfile.package-ubuntu
@@ -31,9 +31,11 @@ RUN . /etc/os-release && \
     fi
 
 # Setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ARG TZ
+ENV TZ=${TZ:-Europe/Dublin}
 ENV LC_ALL=en_US.utf-8
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Adding the slash user
 RUN if id -u $USER_ID >/dev/null 2>&1; then \
@@ -42,7 +44,3 @@ RUN if id -u $USER_ID >/dev/null 2>&1; then \
     useradd -m -U -u $USER_ID slash
 
 USER slash
-
-# Again, setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-ENV LC_ALL=en_US.utf-8

--- a/scripts/Dockerfile.run-rocky
+++ b/scripts/Dockerfile.run-rocky
@@ -13,15 +13,12 @@ COPY rpm/*.rpm /tmp
 RUN dnf install -y /tmp/*.rpm
 
 # Setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ARG TZ
+ENV TZ=${TZ:-Europe/Dublin}
 ENV LC_ALL=en_US.utf-8
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Adding the slash user
 RUN useradd -m -U -u $USER_ID slash
 USER slash
-
-# Again, setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-ENV LC_ALL=en_US.utf-8
-

--- a/scripts/Dockerfile.run-ubuntu
+++ b/scripts/Dockerfile.run-ubuntu
@@ -36,9 +36,11 @@ RUN apt install -y /tmp/slash-dev_*.deb \
   /tmp/libvrt_*.deb
 
 # Setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ARG TZ
+ENV TZ=${TZ:-Europe/Dublin}
 ENV LC_ALL=en_US.utf-8
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Adding the slash user
 RUN if id -u $USER_ID >/dev/null 2>&1; then \
@@ -47,7 +49,3 @@ RUN if id -u $USER_ID >/dev/null 2>&1; then \
     useradd -m -U -u $USER_ID slash
 
 USER slash
-
-# Again, setting timezone and locale for Vivado
-ENV TZ="Europe/Dublin"
-ENV LC_ALL=en_US.utf-8

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -201,6 +201,7 @@ IMAGE_TAG="slash-$CONTAINER-$DISTRO:$VERSION"
 docker build \
     --build-arg USER_ID=$(id -u) \
     --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg TZ=$(timedatectl show -p Timezone --value) \
     -t "$IMAGE_TAG" \
     -f "scripts/Dockerfile.$CONTAINER-$DISTRO" .
 docker run $DOCKER_RUN_ARGS \


### PR DESCRIPTION
All Dockerfiles had TZ hardcoded as `ENV TZ="Europe/Dublin"`, which baked the timezone permanently into the image and made it non-overridable at build time.

This changes TZ to a build ARG (defaulting to Europe/Dublin for backwards compatibility) and passes the host's timezone via `--build-arg TZ=$(cat /etc/timezone)` in `run-with-docker.sh`, so containers reflect the system timezone of whoever is building them.

