### PR TITLE
Set impl_1 strategy before sourcing pre-synth Tcl

### DIFF
--- a/linker/slashkit/resources/base/scripts/slash_project_build.tcl
+++ b/linker/slashkit/resources/base/scripts/slash_project_build.tcl
@@ -147,6 +147,11 @@ foreach p [get_bd_intf_ports] {
     set_property HDL_ATTRIBUTE.LOCKED {TRUE} $p
 }
 source $generated_bd_tcl
+
+# Apply the default implementation strategy before sourcing the user pre-synth Tcl, so a
+# pre-synth script can override per-step directives (STEPS.*.ARGS.DIRECTIVE) on impl_1.
+set_property strategy Congestion_SSI_SpreadLogic_high [get_runs impl_1]
+
 foreach pre_synth_tcl $pre_synth_tcls {
     puts "Sourcing pre-synth Tcl: $pre_synth_tcl"
     source $pre_synth_tcl
@@ -158,7 +163,6 @@ wait_on_run "${slash_rm_name}_synth_1"
 set rm_synth_dcp [file join $rm_work_dir "${slash_proj_name}.runs" "${slash_rm_name}_synth_1" "slash_base.dcp"]
 add_files $rm_synth_dcp
 set_property SCOPED_TO_CELLS {top_i/slash} [get_files $rm_synth_dcp]
-set_property strategy Congestion_SSI_SpreadLogic_high [get_runs impl_1]
 
 launch_runs impl_1 -jobs $jobs
 wait_on_run impl_1


### PR DESCRIPTION
In `slash_project_build.tcl`, the default implementation strategy was applied to impl_1 **after** the user's pre-synth Tcl scripts were sourced. Because `set_property strategy ...` resets every `STEPS.*` option on the run to the strategy's defaults, any per-step directive a pre-synth script set was silently removed before `launch_runs impl_1`.

This moves the strategy assignment ahead of the pre-synth sourcing loop so the strategy is the baseline and pre-synth scripts can override individual step options on top of it.

Testing pending.