### PR TITLE
Manually adding the "import PR" workflow in main

### DIFF
--- a/.github/workflows/import-pr.yml
+++ b/.github/workflows/import-pr.yml
@@ -1,0 +1,21 @@
+name: Import a PR branch into the repository
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: The pull request ID to import
+        required: true
+        type: int
+
+jobs:
+  import_pr:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh pr checkout -b "pr/${{inputs.pr_number}}" ${{inputs.pr_number}}
+          git push "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" "pr/${{inputs.pr_number}}"


### PR DESCRIPTION
PR #127 has introduced configuration files for a hardware CI pipeline to `dev`. However, in order to manually launch the workflow "Import a PR branch into the repository," the workflow file has to be present in the repository's default branch. In our case, this is `main`, not `dev`. This PR therefore introduces this workflow as a separate addition to `main`, so that also external PRs that target `dev` can be imported and tested.