### PR TITLE
Running the Gitlab CI pipeline on every push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && ( $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_BRANCH =~ /^pr\// )
+    - if: $CI_PIPELINE_SOURCE == "push"
 
 variables:
   SLURM_ACCOUNT: hpc-prf-cifi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ package_linker:
       type: boolean
   variables:
     SCHEDULER_PARAMETERS: "-A $SLURM_ACCOUNT -q fpgasynthesis -p normal -c 16 --mem 120G -t 12:00:00"
-    BASE_DESIGN_REF: feature/hardware_ci
+    BASE_DESIGN_REF: dev
   needs:
     - project: $CI_PROJECT_PATH
       job: package_linker


### PR DESCRIPTION
While I had found a mechanism to run the Gitlab CI pipeline on external pull requests, I failed to consider _internal_ pull requests. Sadly, the current mirroring mechanism does not transmit pull request information to Gitlab. However, since the first job in the pipeline that all other jobs depend on needs to be launched manually, it is safe to instantiate the pipeline on every push. It will still only run if a maintainer wants it to, but with this change, you now have the option to run the pipeline on every branch.