### PR TITLE
Allowing the PR import workflow to push to the repository

### DIFF
--- a/.github/workflows/import-pr.yml
+++ b/.github/workflows/import-pr.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: int
 
+permissions:
+  contents: write
+
 jobs:
   import_pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The newly added workflow to import a PR into the repository fails when pushing new commits due to insufficient permissions. This fix should give it these permissions.