### PR TITLE
fix: improve vivado binary handling in argument parser

### DIFF
--- a/linker/slashkit/core/command_config.py
+++ b/linker/slashkit/core/command_config.py
@@ -67,7 +67,7 @@ class CommandConfiguration(object):
     @classmethod
     def populate_argument_parser(cls, ap: argparse.ArgumentParser):
         ap.formatter_class = argparse.RawTextHelpFormatter
-        ap.add_argument("--vivado", required=False, type=Path, default=None,
+        ap.add_argument("--vivado", required=False, type=Path, default=shutil.which("vivado"),
                         help="Vivado binary to use for linking. If not given, it will be derived from PATH.")
         ap.add_argument("--jobs", required=False, type=int, default=8,
                         help="Number of parallel jobs for Vivado runs.")
@@ -76,9 +76,11 @@ class CommandConfiguration(object):
         self._args = args
 
         # Resolve, if necessary find, and verify the Vivado binary
-        self._vivado_bin: Path = args.vivado if args.vivado is not None else Path(
-            shutil.which("vivado"))
-        self._vivado_bin = self._vivado_bin.expanduser().resolve()
+        if not args.vivado:
+            raise ValueError(
+                "Vivado binary not specified and could not be found on PATH.")
+
+        self._vivado_bin = Path(args.vivado).expanduser().resolve()
         if not self._vivado_bin.is_file():
             raise FileNotFoundError(self._vivado_bin)
 


### PR DESCRIPTION

Fixes a `TypeError` crash when Vivado isn't on `PATH` and `--vivado` isn't explicitly passed. The argparse default is now resolved via `shutil.which("vivado")` at parse time, and `CommandConfiguration.__init__` raises a clear `ValueError` if no binary could be determined, instead of passing `None` into `Path(...)`.

### Problem

Previously, `--vivado` defaulted to `None`, and the fallback lookup (`shutil.which("vivado")`) happened in `__init__`. When Vivado wasn't found on `PATH`, `shutil.which` returned `None`, which was then passed directly into `Path(...)`, causing an unhandled `TypeError`:

```
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

### Fix

- `--vivado` now defaults to `shutil.which("vivado")` directly in `populate_argument_parser`, so the PATH lookup happens once, at argument-parsing time.
- In `__init__`, if `args.vivado` is falsy (not provided and not found on PATH), we raise a descriptive `ValueError` instead of constructing a `Path` from `None`.
- The rest of the resolution logic (`expanduser().resolve()` and the `is_file()` check) is preserved.


```
ValueError: Vivado binary not specified and could not be found on PATH.
```
