### PR TITLE
fix: exit on sourcing errors in safe_source

### DIFF
--- a/linker/slashkit/resources/base/scripts/create_project.tcl
+++ b/linker/slashkit/resources/base/scripts/create_project.tcl
@@ -97,7 +97,9 @@ puts "BUILD DIR:      $cwd"
 
 proc safe_source {tcl_path} {
   puts "INFO: Sourcing $tcl_path ..."
-  catch {source $tcl_path} result
+  set result [ source $tcl_path ]
+  puts "INFO: Finished sourcing $tcl_path"
+
   if {[string is integer -strict $result] && $result != 0} {
     puts "EXIT: '$tcl_path' returned $result"
     exit 1


### PR DESCRIPTION
Commit 4226a42 wrapped source $tcl_path in catch, intending to capture its return code, but catch also swallowed actual sourcing errors (e.g. syntax errors, undefined procs) instead of letting them propagate, so safe_source could silently continue past a broken script.

Drop the catch and call source directly so errors are no longer caught and exiting still happens. Also log when sourcing finishes for clearer build output.

### Testing

When sourced script returns a code:

```
****** Vivado v2025.1 (64-bit)
  **** SW Build 6140274 on Wed May 21 22:58:25 MDT 2025
  **** IP Build 6138677 on Thu May 22 03:10:11 MDT 2025
  **** SharedData Build 6139179 on Tue May 20 17:58:58 MDT 2025
  **** Start of session at: Thu Jun 25 19:00:14 2026
    ** Copyright 1986-2022 Xilinx, Inc. All Rights Reserved.
    ** Copyright 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.

source main.tcl
# proc safe_source {tcl_path} {
#   puts "INFO: Sourcing $tcl_path ..."
#   set result [ source $tcl_path ]
#   puts "INFO: Finished sourcing $tcl_path"
# 
#   if {[string is integer -strict $result] && $result != 0} {
#     puts "EXIT: '$tcl_path' returned $result"
#     exit 1
#   }
# }
# safe_source return.tcl
INFO: Sourcing return.tcl ...
## common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
WARNING: [BD::TCL 103-2023] Will not continue with creation of design due to the error(s) above.
## return 3
INFO: Finished sourcing return.tcl
EXIT: 'return.tcl' returned 3
INFO: [Common 17-206] Exiting Vivado at Thu Jun 25 19:00:16 2026...
1
```

When sourced script throws an error:

```
****** Vivado v2025.1 (64-bit)
  **** SW Build 6140274 on Wed May 21 22:58:25 MDT 2025
  **** IP Build 6138677 on Thu May 22 03:10:11 MDT 2025
  **** SharedData Build 6139179 on Tue May 20 17:58:58 MDT 2025
  **** Start of session at: Thu Jun 25 19:00:29 2026
    ** Copyright 1986-2022 Xilinx, Inc. All Rights Reserved.
    ** Copyright 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.

source main.tcl
# proc safe_source {tcl_path} {
#   puts "INFO: Sourcing $tcl_path ..."
#   set result [ source $tcl_path ]
#   puts "INFO: Finished sourcing $tcl_path"
# 
#   if {[string is integer -strict $result] && $result != 0} {
#     puts "EXIT: '$tcl_path' returned $result"
#     exit 1
#   }
# }
# safe_source error.tcl
INFO: Sourcing error.tcl ...
## error "error message"
error message
    while executing
"error "error message""
    (file "error.tcl" line 1)

    while executing
"source $tcl_path "
    (procedure "safe_source" line 3)
    invoked from within
"safe_source error.tcl"
    (file "main.tcl" line 12)
INFO: [Common 17-206] Exiting Vivado at Thu Jun 25 19:00:31 2026...
1
```