### PR TITLE
docker: remove broken SLASH_XILINX_ROOT mount override

### DIFF
--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -62,9 +62,6 @@ set -exo pipefail
 #                       the container.
 #
 # Optional environment variables:
-#   SLASH_XILINX_ROOT              Mount point for the Xilinx tools inside the
-#                                  container. Defaults to SLASH_XILINX_PATH so
-#                                  paths match host and container.
 #   SLASH_LICENSE_PATH             Path to the Xilinx license file (or
 #                                  directory) on the host. When set, it is
 #                                  mounted into the container and exported as
@@ -104,11 +101,7 @@ if [ -z $SLASH_XILINX_PATH ]; then
     exit 1
 fi
 
-if [ -z $SLASH_XILINX_ROOT ]; then
-    SLASH_XILINX_ROOT=$SLASH_XILINX_PATH
-fi
-
-DOCKER_RUN_ARGS+="-v $SLASH_XILINX_ROOT:$SLASH_XILINX_ROOT "
+DOCKER_RUN_ARGS+="-v $SLASH_XILINX_PATH:$SLASH_XILINX_PATH "
 
 # Mounting the license file for synthesis and implementation, if provided.
 # When unset, the license is assumed to be reachable via SLASH_XILINX_PATH


### PR DESCRIPTION
## Summary

Removes the `SLASH_XILINX_ROOT` environment variable from `scripts/run-with-docker.sh`. It was meant to let users override the in-container mount point for the Xilinx tools (independent of their host path), but this doesn't actually work, so it's misleading to keep around.

## Problem

The Xilinx toolchain's own scripts hardcode absolute paths generated at install time. For example, `settings64.sh` sources files like:

```
source /tools/Xilinx/2025.1/Vivado/.settings64-Vivado.sh
```

If the tools are mounted into the container at a different path than they live at on the host (i.e. `SLASH_XILINX_ROOT != SLASH_XILINX_PATH`), these hardcoded paths no longer resolve inside the container, and sourcing `settings64.sh` fails.

### Repro

```shellscript
export SLASH_XILINX_PATH=/tools/Xilinx
export SLASH_XILINX_ROOT=/opts/Xilinx
scripts/run-with-docker.sh package ubuntu 24.04
```

```
bash: line 1: /tools/Xilinx/2025.1/Vivado/settings64.sh: No such file or directory
```

Even though that file exists on the host at `/tools/Xilinx/2025.1/Vivado/settings64.sh` — it's just not reachable at that path inside the container, because the container only has `/opts/Xilinx` mounted.

## Fix

Always mount `SLASH_XILINX_PATH` to the same path inside the container (`-v $SLASH_XILINX_PATH:$SLASH_XILINX_PATH`), and drop the `SLASH_XILINX_ROOT` variable and its associated doc comment entirely, since there's no valid use case for it given the hardcoded paths in the Xilinx install.

One possible reasonable use case is that `SLASH_XILINX_PATH` on the host side is not at the correct location, and when mounted in docker, use `SLASH_XILINX_ROOT` to mount it at the correct point (i.e. the toolchain is never used on the host). However, in that case the dir shall be mounted as

```diff
-DOCKER_RUN_ARGS+="-v $SLASH_XILINX_ROOT:$SLASH_XILINX_ROOT "
+DOCKER_RUN_ARGS+="-v $SLASH_XILINX_PATH:$SLASH_XILINX_ROOT "
```

Since it was anyways not working, I assume nobody tried using it, so I propose to remove it in this PR.

