### PR TITLE
Move vrtd binaries to match path with DEB package.

### DIFF
--- a/packaging/rpm/slash.spec
+++ b/packaging/rpm/slash.spec
@@ -184,6 +184,9 @@ bash scripts/pbuild.sh
 %install
 bash scripts/pinstall.sh %{buildroot}
 
+install -d %{buildroot}%{_prefix}/lib/vrt
+mv %{buildroot}%{_bindir}/vrtd* %{buildroot}%{_prefix}/lib/vrt/
+
 # systemd units (mirrors debian/rules rsync lines)
 install -D -m 0644 vrt/vrtd/systemd/vrtd.service \
     %{buildroot}%{_unitdir}/vrtd.service
@@ -276,8 +279,8 @@ udevadm control --reload-rules && udevadm trigger 2>/dev/null || :
 udevadm control --reload-rules && udevadm trigger 2>/dev/null || :
 
 %files -n vrtd
-%{_bindir}/vrtd
-%{_bindir}/vrtd-*
+%{_prefix}/lib/vrt/vrtd
+%{_prefix}/lib/vrt/vrtd-*
 %{_unitdir}/vrtd.service
 %{_unitdir}/vrtd.socket
 %{_udevrulesdir}/99-vrtd.rules


### PR DESCRIPTION
This PR fixes a path mismatch in the RPM package build for vrtd systemd service.

The systemd service expects the vrtd binaries in `/usr/lib/vrt/vrtd`, while the `slash.spec` would install it into `/usr/bin/`.

Result was that the systemd service failed to start. I tested the proposed patch against Rocky 9.8.