### PR TITLE
hotfix: python issues in pinstall.sh

### DIFF
--- a/scripts/pinstall.sh
+++ b/scripts/pinstall.sh
@@ -30,13 +30,21 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    echo "Deactivating virtual environment: ${VIRTUAL_ENV}" 1>&2
+    PATH="${PATH//$VIRTUAL_ENV\/bin:}"
+    PATH="${PATH//:$VIRTUAL_ENV\/bin/}"
+    unset VIRTUAL_ENV VIRTUAL_ENV_PROMPT
+    hash -r
+fi
+
 # Install smi, vrt, vrtd, libvrt*, libslash
 DESTDIR="$1" cmake --build pbuild/smi --target install
 
 # Install CMake toolchain modules (SlashTools)
 DESTDIR="$1" cmake --build pbuild/cmake-tools --target install
 
-python3 -m pip install --no-deps --root $1 linker/dist/slashkit-*.whl
+python3 -m pip install --no-deps --ignore-installed --root "$1" linker/dist/slashkit-*.whl
 if [ -f $1/usr/local/bin/slashkit ]; then
     mv $1/usr/local/bin/slashkit $1/usr/bin/
     mv $1/usr/local/lib/python3* $1/usr/lib/


### PR DESCRIPTION
This commit fixes two issues:

1. If packaging is run on a machine where slashkit is already installed, `pip install` might decide that there is no need to install the slashkit package into the fake root for packaging, unless `--ignore-installed` is provided.
2. If a venv is active as packaging runs, `pip install` will write the wrong path. So we must deactivate the venv if we are in one.