### PR TITLE
libslash: fix ignored `ftruncate()` result warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ driver/kcompat/.scratch/
 
 # Project-local scratch space
 /tmp/
+tmp/
+**/build-host/

--- a/driver/libslash/src/qdma.c
+++ b/driver/libslash/src/qdma.c
@@ -171,7 +171,9 @@ static ssize_t qdma_fallback_subxfer(int qpair_fd,
         off_t want = (off_t)(x->dev_addr + x->length);
 
         if (fstat(qpair_fd, &st) == 0 && st.st_size < want) {
-            (void)ftruncate(qpair_fd, want);
+            if (ftruncate(qpair_fd, want) != 0) {
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix the compiler warning caused by discarding the `ftruncate()` return value in the QDMA mock C2H fallback.
- Check whether growing the queue-pair memfd succeeds instead of casting away the result.
- Return the original error on failure, preventing the transfer from continuing into a misleading short read.
