### PR TITLE
gitignore: ignore Cursor state and local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,11 @@ Thumbs.db
 # Ignore IDE specific files
 .vscode/
 .idea/
+.cursor/
 *.iml
+
+# Ignore local git worktrees
+.worktrees/
 
 # Ignore test binaries
 /tests/*.exe


### PR DESCRIPTION
## Summary
- Ignore project-local Cursor configuration in `.cursor/`.
- Ignore local development worktrees in `.worktrees/`.