### PR TITLE
Make the QEMU submodules opt-in so a recursive clone works

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,17 @@
 [submodule "AVED"]
 	path = submodules/AVED
 	url = https://github.com/Xilinx/AVED.git
+; The two QEMU submodules are needed only by the optional RP1 firmware test
+; (scripts/build-and-test-rp1-qemu.sh), so they are opt-in. `update = none`
+; keeps `git clone --recurse-submodules` from descending into them: QEMU
+; carries its full ROM tree as nested submodules, none of which SLASH builds,
+; and at least one of those URLs is dead upstream. Init them explicitly with
+; `git submodule update --init --checkout <path>`, which overrides this.
 [submodule "submodules/xilinx-qemu"]
 	path = submodules/xilinx-qemu
 	url = https://github.com/Xilinx/qemu.git
+	update = none
 [submodule "submodules/qemu-devicetrees"]
 	path = submodules/qemu-devicetrees
 	url = https://github.com/Xilinx/qemu-devicetrees.git
+	update = none

--- a/README.md
+++ b/README.md
@@ -114,20 +114,30 @@ sudo apt install cmake pkg-config ninja-build \
   linux-headers-$(uname -r)
 ```
 
-**Submodules:**
+**Clone and submodules:**
 
 SLASH depends on [AVED](https://github.com/Xilinx/AVED) and
 [QDMA](https://github.com/Xilinx/dma_ip_drivers):
 
 ```bash
+git clone -b dev https://github.com/Xilinx/SLASH.git
+cd SLASH
 git submodule update --init submodules/AVED submodules/qdma_drv
 ```
 
+Do not clone with `--recurse-submodules`. The optional Xilinx QEMU submodule
+brings in QEMU's entire ROM tree as further nested submodules — none of which
+SLASH builds — and at least one of those third-party URLs no longer exists
+upstream, so a recursive clone fails on a repository you do not need. The two
+QEMU submodules are therefore marked `update = none` in `.gitmodules` and a
+recursive clone skips them.
+
 The optional RP1 firmware test additionally requires Xilinx QEMU and its
-device trees:
+device trees. `--checkout` is what opts back in:
 
 ```bash
-git submodule update --init submodules/xilinx-qemu submodules/qemu-devicetrees
+git submodule update --init --checkout \
+    submodules/xilinx-qemu submodules/qemu-devicetrees
 ```
 
 ## Quick Start

--- a/scripts/build-and-test-rp1-qemu.sh
+++ b/scripts/build-and-test-rp1-qemu.sh
@@ -55,10 +55,12 @@ done
 build_qemu() {
     echo "=== Building Xilinx QEMU (aarch64-softmmu) ==="
 
-    # Ensure submodule is initialised
+    # Ensure submodule is initialised. --checkout overrides the `update = none`
+    # in .gitmodules, which is there to keep a recursive clone out of QEMU's
+    # ROM submodules; not passing it here would silently skip the checkout.
     if [ ! -f "${QEMU_SRC}/configure" ]; then
         echo "Initialising xilinx-qemu submodule..."
-        git -C "${REPO_ROOT}" submodule update --init submodules/xilinx-qemu
+        git -C "${REPO_ROOT}" submodule update --init --checkout submodules/xilinx-qemu
     fi
 
     # Check build dependencies
@@ -124,7 +126,8 @@ if [ ! -f "${DT_FILE}" ]; then
     echo "=== Building ZynqMP device trees ==="
     if [ ! -f "${DT_SRC}/Makefile" ]; then
         echo "ERROR: qemu-devicetrees not found at ${DT_SRC}"
-        echo "Clone it with: git clone https://github.com/Xilinx/qemu-devicetrees.git ${DT_SRC}"
+        echo "Initialise it with:"
+        echo "  git submodule update --init --checkout submodules/qemu-devicetrees"
         exit 1
     fi
     make -C "${DT_SRC}"

--- a/scripts/extra/branch-test.sh
+++ b/scripts/extra/branch-test.sh
@@ -217,7 +217,10 @@ pushd "${SCRATCH}"
 OLD_PYTHONPATH="${PYTHONPATH:-}"
 export PYTHONPATH="${PWD}/linker${PYTHONPATH:+:${PYTHONPATH}}"
 
-protected git submodule update --init submodules/AVED submodules/qdma_drv submodules/xilinx-qemu submodules/qemu-devicetrees
+protected git submodule update --init submodules/AVED submodules/qdma_drv
+# The QEMU pair is `update = none` in .gitmodules so that a recursive clone
+# skips QEMU's ROM submodules; --checkout is what opts back in.
+protected git submodule update --init --checkout submodules/xilinx-qemu submodules/qemu-devicetrees
 
 # Build phase
 


### PR DESCRIPTION
`git clone -b dev --recurse-submodules https://github.com/Xilinx/SLASH` fails. It descends four levels into a ROM tree SLASH never builds:

  SLASH  submodules/xilinx-qemu -> github.com/Xilinx/qemu       @ b05c9752
   qemu  roms/edk2              -> gitlab.com/qemu-project/edk2 @ edc66812
   edk2  .../SubhookLib/subhook -> github.com/Zeex/subhook      [404]

`Zeex/subhook` was deleted upstream; edk2 has since moved to `tianocore/edk2-subhook`, but the pinned edk2 commit predates that, so the dead URL sits two levels outside this repository's control. GitHub answers a deleted repository with a credential prompt, which makes the failure look like a permissions problem rather than a 404.

QEMU is only used by the optional RP1 firmware test, so mark both QEMU submodules `update = none`. `git submodule init` copies that into `.git/config` and the implicit recursive update inside `git clone --recurse-submodules` then skips them, never reaching edk2. This also immunises the clone against the next rotted URL in QEMU's ROM tree. `AVED` and `qdma_drv` are untouched: they are required, they have no nested submodules, and a recursive clone still delivers them.

`update = none` is honoured even when a path is given explicitly, so the three places that opt in now pass `--checkout`, which overrides it.

README.md had no `git clone` command at all, leaving users to guess; the idiomatic guess is the one that breaks. Add it, and say why `--recurse-submodules` is not part of it.

Fixes #185