### PR TITLE
Stop installing top_wrapper_routed_bb.dcp

### DIFF
--- a/cmake/CheckSlashInstall.cmake
+++ b/cmake/CheckSlashInstall.cmake
@@ -27,7 +27,6 @@ set(_required_files
   "static_shell_slash.dcp"
   "amd_v80_gen5x8_25.1.pdi"
   "amd_v80_gen5x8_25.1_nofpt.pdi"
-  "top_wrapper_routed_bb.dcp"
 )
 
 set(_missing "")

--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -703,7 +703,6 @@ def _install_static_shell_base(config: InstallerConfiguration, static_shell_dir:
         # (FULL_PROBES.FILE) that must be loaded before a user region's partial
         # probe file in the Vivado Hardware Manager.
         install_sources = (
-            impl_dir / "top_wrapper_routed_bb.dcp",
             impl_dir / "static_shell_slash.dcp",
             impl_dir / "static_shell_service_layer.dcp",
             impl_dir / "debug_nets.ltx",
@@ -724,7 +723,6 @@ def _install_static_shell_base(config: InstallerConfiguration, static_shell_dir:
 
     else:  # ShellType.COMPUTE
         dcp_sources = (
-            impl_dir / "top_wrapper_routed_bb.dcp",
             impl_dir / "static_shell_slash.dcp",
         )
         for src in dcp_sources:


### PR DESCRIPTION
The full static checkpoint the abstract shells are written from is 67 MB of a 214 MB install and is read by nothing: RM builds link against the abstract shell selected in _run_rm_build, and no Tcl, Python, packaging script or doc names the file.

Verified by building examples/00_axilite's rm_slash with the checkpoint moved out of resources/static_shell -- link_design and the rest of implementation completed and produced a valid partial PDI and .vbin.
