### PR TITLE
[Gitlab CI/package_linker] Allocating an exclusive node

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ package_linker:
       description: Build the base design from scratch?
       type: boolean
   variables:
-    SCHEDULER_PARAMETERS: "-A $SLURM_ACCOUNT -q fpgasynthesis -p normal -c 16 --mem 120G -t 12:00:00"
+    SCHEDULER_PARAMETERS: "-A $SLURM_ACCOUNT -q fpgasynthesis -p normal --exclusive -t 12:00:00"
     BASE_DESIGN_REF: dev
   needs:
     - project: $CI_PROJECT_PATH


### PR DESCRIPTION
The Gitlab CI job to package the linker now fails due to insufficient available memory (See https://git.uni-paderborn.de/slash-developers/slash-fixed/-/jobs/565939). @deffel has agreed to let the linker packaging job run on an entire node, which has 754GB of memory; More than enough. This change implements the different allocation.