### PR TITLE
fix(driver): keep chrdev cleanup available during initialization

### DIFF
--- a/driver/slash_chrdev.c
+++ b/driver/slash_chrdev.c
@@ -97,7 +97,7 @@ int __init slash_chrdev_init(void)
     return 0;
 }
 
-void __exit slash_chrdev_exit(void)
+void slash_chrdev_exit(void)
 {
     struct slash_board_slot *entry;
     struct slash_board_slot *tmp;

--- a/driver/slash_chrdev.h
+++ b/driver/slash_chrdev.h
@@ -32,7 +32,7 @@
 /** Reserve the shared device-number range and create /sys/class/slash. */
 int __init slash_chrdev_init(void);
 /** Destroy the shared class, range, and module-lifetime board map. */
-void __exit slash_chrdev_exit(void);
+void slash_chrdev_exit(void);
 
 /**
  * slash_chrdev_add() - Add one cdev and its BDF-specific class device.


### PR DESCRIPTION
## Summary

Keep character-device cleanup available to the module initialization error path instead of placing it in an exit-only section, eliminating the resulting modpost section-mismatch warning.

## Section lifetime

`slash_chrdev_exit()` serves two lifetimes: `slash_init()` calls it while unwinding a failed initialization, and `slash_exit()` calls it during module teardown. Marking this shared helper `__exit` incorrectly places it in a section that built-in linking may discard even though initialization still references it.

## Changes

Remove `__exit` from the `slash_chrdev_exit()` declaration and definition. The top-level module exit callback retains its `__exit` annotation; the cleanup implementation, ordering, and interfaces remain unchanged.

## Impact to current issues

None, as no one is bundling SLASH into the kernel object directly, as far as I know. This is just a small semantic correctness patch.