### PR TITLE
fix(reset): coordinate V80 SBR with PCIe hotplug

### DIFF
--- a/docs/explanation/pcie-topology.rst
+++ b/docs/explanation/pcie-topology.rst
@@ -130,8 +130,8 @@ with four ioctl operations:
    * - ``REMOVE``
      - Remove a device by BDF from the PCI bus.
    * - ``TOGGLE_SBR``
-     - Assert the Secondary Bus Reset on the root port (2 ms hold), deassert,
-       then wait 5 s for the link to retrain.
+     - Assert Secondary Bus Reset on the immediate upstream bridge, suppress
+       expected pciehp events, and wait for V80 reload and stable link training.
    * - ``RESCAN``
      - Rescan the entire PCI bus to re-enumerate devices.
    * - ``HOTPLUG``
@@ -142,9 +142,8 @@ A typical FPGA programming sequence follows this order:
 .. code-block:: text
 
    1. REMOVE  PF0, PF1, PF2       ← tear down all three functions
-   2. TOGGLE_SBR on root port      ← reset the FPGA, reload bitstream
+   2. TOGGLE_SBR upstream          ← reset the FPGA, reload bitstream, wait for link
    3. RESCAN                       ← re-enumerate the bus
-   4. HOTPLUG each function        ← bind drivers to the new device
 
 The ``vrtd`` daemon orchestrates this sequence through its
 ``ResetSequence`` hotplug operation, which is triggered by

--- a/docs/reference/kernel-abi/index.rst
+++ b/docs/reference/kernel-abi/index.rst
@@ -87,8 +87,8 @@ the same qpair, is safe but offers no throughput benefit over a single-threaded 
 parallel I/O, allocate multiple qpairs via ``QPAIR_ADD`` and distribute transfers across them.
 
 Hotplug ioctls from multiple processes serialize on ``pci_lock_rescan_remove()``.
-``TOGGLE_SBR`` drops this lock before calling ``pci_bridge_secondary_bus_reset()`` to avoid
-deadlock with the PCI slot lock.
+``TOGGLE_SBR`` retains this lock until the V80 has reloaded and the PCIe link is stable. On a
+hotplug-capable bridge it also suppresses expected pciehp link events during that interval.
 
 Card information and BARs: ``/dev/slash_ctl<N>``
 ================================================
@@ -921,25 +921,24 @@ Usage
 Full FPGA Reconfiguration (with secondary bus reset)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For a complete reconfiguration where the FPGA is fully reset, remove both PFs, assert a secondary bus
-reset, wait for FPGA re-initialization, then rescan:
+For a complete reconfiguration where the FPGA is fully reset, remove all three PFs, assert a
+secondary bus reset, wait for the ioctl to report a stable link, then rescan:
 
 .. code-block:: c
 
     struct slash_hotplug_device_request req = { .size = sizeof(req) };
 
-    /* Remove both PFs */
+    /* Remove PF0, PF1, and PF2 */
+    snprintf(req.bdf, sizeof(req.bdf), "0000:61:00.0");
+    ioctl(hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE, &req);
     snprintf(req.bdf, sizeof(req.bdf), "0000:61:00.1");
     ioctl(hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE, &req);
     snprintf(req.bdf, sizeof(req.bdf), "0000:61:00.2");
     ioctl(hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE, &req);
 
-    /* Assert SBR (blocks ~1 s internally for link retraining) */
+    /* Assert SBR; blocks until PDI reload and link training complete */
     snprintf(req.bdf, sizeof(req.bdf), "0000:61:00.0");  /* bus matters, not function digit */
     ioctl(hp_fd, SLASH_HOTPLUG_IOCTL_TOGGLE_SBR, &req);
-
-    /* Wait for FPGA re-initialization — caller responsibility */
-    sleep(7);  /* 5–10 s recommended */
 
     /* Rescan all root buses */
     ioctl(hp_fd, SLASH_HOTPLUG_IOCTL_RESCAN, NULL);
@@ -1048,9 +1047,10 @@ callback. The corresponding ``/dev/slash_ctl<N>`` or ``/dev/slash_qdma_ctl<N>`` 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Asserts a secondary bus reset (SBR) on the upstream PCIe bridge for the bus specified by BDF,
-performing a full hardware reset of all endpoints on that bus. The ioctl blocks for approximately
-1000 ms internally for PCIe link retraining; userspace should wait an **additional 5–10 seconds**
-after the call returns before rescanning.
+performing a full hardware reset of all endpoints on that bus. The ioctl suppresses pciehp link
+events while the V80 reloads, waits five seconds for PDI initialization, and then waits up to
+another 25 seconds for DLL Link Active to remain asserted across two 100 ms polls. Userspace can
+rescan immediately after the ioctl succeeds.
 
 **Interface:**
 
@@ -1065,22 +1065,25 @@ after the call returns before rescanning.
 - ``size`` must cover the ``bdf`` field — otherwise ``-EINVAL``
 - ``bdf`` must be a valid ``DDDD:BB:SS.F`` string; only the domain and bus number are used to
   locate the upstream bridge
-- The endpoint device may have been removed before calling; the kernel resolves the bridge via the
-  bus number, which persists after endpoint removal
+- Every endpoint function on the secondary bus must already be removed; otherwise the ioctl
+  returns ``-EBUSY``
+- The kernel resolves the bridge via the bus number, which persists after endpoint removal
 
 **Postconditions:**
 
-- Bridge config space is saved, ``PCI_BRIDGE_CTL_BUS_RESET`` is asserted for at least 2 ms,
-  deasserted, and config space is restored.
-- The ioctl sleeps 1000 ms for PCIe link retraining before returning.
-- The PCIe link is retrained; the FPGA may still be initializing after return.
+- ``PCI_BRIDGE_CTL_BUS_RESET`` is asserted and deasserted by the PCI core.
+- Expected pciehp link-change events are ignored until V80 PDI reload and link recovery complete.
+- When DLL Link Active reporting is available, the link has remained active for at least 100 ms.
 
 **Return values:**
 
-- ``0`` — success (after 1000 ms delay)
+- ``0`` — PDI reload delay completed and, when reportable, the link is stable
 - ``-EFAULT`` — copy failure
 - ``-EINVAL`` — malformed BDF or request ``size`` too small
 - ``-ENODEV`` — no upstream bridge found for the specified bus
+- ``-EBUSY`` — one or more endpoint functions remain on the secondary bus
+- ``-EIO`` — upstream bridge link status could not be read
+- ``-ETIMEDOUT`` — DLL Link Active did not stabilize within 25 seconds after PDI settling
 
 ``SLASH_HOTPLUG_IOCTL_HOTPLUG``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/driver/libslash/README.md
+++ b/driver/libslash/README.md
@@ -135,7 +135,7 @@ slash_qdma_close(qdma);
 ### Hotplug — PCIe device lifecycle
 
 Typical FPGA reconfiguration flow:
-**remove &rarr; SBR &rarr; sleep &rarr; rescan &rarr; hotplug**.
+**remove &rarr; SBR and link recovery &rarr; rescan**.
 
 ```c
 #include <slash/hotplug.h>
@@ -146,15 +146,10 @@ slash_hotplug_remove(hp, "0000:03:00.0");
 slash_hotplug_remove(hp, "0000:03:00.1");
 slash_hotplug_remove(hp, "0000:03:00.2");
 
-slash_hotplug_toggle_sbr(hp, "0000:03:00.0");  /* assert 2 ms, settle 5 s */
-
-usleep(5000000);  /* wait for device re-init */
+/* Blocks until V80 PDI reload and stable link training complete. */
+slash_hotplug_toggle_sbr(hp, "0000:03:00.0");
 
 slash_hotplug_rescan(hp);
-
-slash_hotplug_hotplug(hp, "0000:03:00.0");  /* remove + rescan in one step */
-slash_hotplug_hotplug(hp, "0000:03:00.1");
-slash_hotplug_hotplug(hp, "0000:03:00.2");
 
 slash_hotplug_close(hp);
 ```

--- a/driver/libslash/include/slash/uapi/slash_hotplug.h
+++ b/driver/libslash/include/slash/uapi/slash_hotplug.h
@@ -26,10 +26,9 @@
  * A typical FPGA reconfiguration flow uses these operations in order:
  *
  *   1. REMOVE all PCI functions (PF0, PF1, PF2 …) from the bus.
- *   2. TOGGLE_SBR on the root-port to reset the device.
- *   3. Sleep (~5 s) to let the device re-initialise.
- *   4. RESCAN the PCI bus to discover the new configuration.
- *   5. HOTPLUG each function to complete re-enumeration.
+ *   2. TOGGLE_SBR on the upstream bridge to reset the device and wait
+ *      for PDI reload and stable link training.
+ *   3. RESCAN the PCI bus to discover the new configuration.
  *
  * For a simple device teardown/re-add (no reset or bitstream change),
  * REMOVE → RESCAN is sufficient.
@@ -88,12 +87,13 @@ struct slash_hotplug_device_request {
  * Toggle a Secondary Bus Reset (SBR) on the device's upstream port.
  *
  * A single ioctl call performs the full SBR sequence on the upstream
- * bridge.  The kernel first attempts pci_bridge_secondary_bus_reset()
- * (which saves/restores bridge config space), falling back to a manual
- * PCI_BRIDGE_CONTROL register toggle if the kernel API is unavailable.
- * A 1000 ms post-SBR link training delay is included before the ioctl
- * returns.  The caller should wait an additional ~10 s for full FPGA
- * re-initialisation before rescanning.
+ * bridge through pci_bridge_secondary_bus_reset().  On hotplug-capable
+ * ports, expected link-change events are suppressed so pciehp does not
+ * remove or re-enumerate the slot during the V80's full PDI reload.  The
+ * secondary bus must be empty before the call; otherwise it returns -EBUSY.
+ * The ioctl blocks for at least five seconds and, when supported by the port,
+ * until DLL Link Active remains asserted for 100 ms.  It can return
+ * -ETIMEDOUT after an additional 25 seconds if the link does not recover.
  */
 #define SLASH_HOTPLUG_IOCTL_TOGGLE_SBR _IOW(SLASH_HOTPLUG_IOCTL_MAGIC, 0x32, struct slash_hotplug_device_request)
 

--- a/driver/slash_hotplug.c
+++ b/driver/slash_hotplug.c
@@ -34,9 +34,8 @@
  *
  * A typical reconfiguration flow:
  *   1. REMOVE each PCI function (PF0, PF1, PF2 ...)
- *   2. TOGGLE_SBR to reset the device
- *   3. Wait in userspace for the FPGA to re-initialize
- *   4. RESCAN to discover the new configuration
+ *   2. TOGGLE_SBR to reset the device and wait for link recovery
+ *   3. RESCAN to discover the new configuration
  *
  * All ioctls that operate on a specific device require an explicit
  * BDF string in the request.
@@ -59,6 +58,9 @@
 #include <linux/uaccess.h>
 
 #define SLASH_HOTPLUG_MODE 0600
+#define SLASH_SBR_PDI_SETTLE_MS 5000
+#define SLASH_SBR_LINK_POLL_MS 100
+#define SLASH_SBR_LINK_TIMEOUT_MS 25000
 
 /**
  * slash_hotplug_copy_request() - Copy and sanitize a hotplug request from userspace.
@@ -210,6 +212,63 @@ static int slash_hotplug_handle_remove(const char *bdf)
 }
 
 /**
+ * slash_hotplug_wait_for_link() - Wait for V80 reload and a stable PCIe link.
+ * @bridge: Immediate upstream bridge whose secondary link was reset.
+ *
+ * The V80 turns SBR into a full PDI reload, so the link can remain down well
+ * after the PCI core's conventional-reset delay.  Wait for the AVED-specified
+ * five-second reload interval, then require DLL Link Active to remain asserted
+ * across two polls.  PCIe requires 100 ms after Gen3+ link activation before
+ * configuration access, which the second poll also supplies.
+ *
+ * Return: 0 when the link is ready (or DLLLA reporting is unavailable),
+ * -EIO on config-space access failure, or -ETIMEDOUT on link timeout.
+ */
+static int slash_hotplug_wait_for_link(struct pci_dev *bridge)
+{
+    unsigned int elapsed_ms = 0;
+    bool active_once = false;
+    u16 status;
+    int ret;
+
+    pr_info("slash_hotplug: toggle_sbr: waiting %u ms for V80 PDI reload\n",
+            SLASH_SBR_PDI_SETTLE_MS);
+    msleep(SLASH_SBR_PDI_SETTLE_MS);
+
+    if (!pci_is_pcie(bridge) || !bridge->link_active_reporting) {
+        pr_info("slash_hotplug: toggle_sbr: DLL Link Active reporting unavailable; reload delay complete\n");
+        return 0;
+    }
+
+    while (elapsed_ms < SLASH_SBR_LINK_TIMEOUT_MS) {
+        ret = pcie_capability_read_word(bridge, PCI_EXP_LNKSTA, &status);
+        if (ret != PCIBIOS_SUCCESSFUL) {
+            pr_err("slash_hotplug: toggle_sbr: failed to read link status (%d)\n",
+                   ret);
+            return -EIO;
+        }
+
+        if (status & PCI_EXP_LNKSTA_DLLLA) {
+            if (active_once) {
+                pr_info("slash_hotplug: toggle_sbr: link stable after %u ms of polling\n",
+                        elapsed_ms);
+                return 0;
+            }
+            active_once = true;
+        } else {
+            active_once = false;
+        }
+
+        msleep(SLASH_SBR_LINK_POLL_MS);
+        elapsed_ms += SLASH_SBR_LINK_POLL_MS;
+    }
+
+    pr_err("slash_hotplug: toggle_sbr: link did not become stable within %u ms\n",
+           SLASH_SBR_LINK_TIMEOUT_MS);
+    return -ETIMEDOUT;
+}
+
+/**
  * slash_hotplug_handle_toggle_sbr() - Perform a Secondary Bus Reset.
  * @bdf: BDF string identifying the device (or its former location).
  *
@@ -222,14 +281,15 @@ static int slash_hotplug_handle_remove(const char *bdf)
  *   3. Wait 2 ms — the PCIe spec minimum reset hold time.
  *   4. Deassert SBR (clear the BUS_RESET bit).
  *
- * The caller is responsible for waiting an appropriate settle time
- * after this ioctl returns before rescanning the bus.
+ * The ioctl waits for V80 PDI reload and stable link training before
+ * returning, so the caller may rescan immediately on success.
  *
  * Bridge resolution:
  *   The endpoint is typically removed before SBR is toggled, so we
  *   resolve the bridge via pci_find_bus() using the bus number from
  *   the BDF.  Bus structures survive endpoint removal.  The bridge
- *   is always the immediate parent (bus->self), never the root port.
+ *   is always the immediate parent (bus->self): a root port for direct
+ *   attachment, or a switch downstream port behind a PCIe switch.
  *
  * Return: 0 on success, negative errno on failure.
  */
@@ -237,6 +297,8 @@ static int slash_hotplug_handle_toggle_sbr(const char *bdf)
 {
     struct pci_bus *ep_bus;
     struct pci_dev *bridge;
+    bool coordinate_hotplug;
+    bool was_ignoring_hotplug;
     int domain, bus_nr, slot, func;
     int ret;
 
@@ -248,12 +310,14 @@ static int slash_hotplug_handle_toggle_sbr(const char *bdf)
     }
 
     /*
-     * Hold pci_lock_rescan_remove() across the pci_find_bus() + pci_dev_get()
-     * pair.  pci_find_bus() does not pin the returned pci_bus; without the
-     * lock, a concurrent bus removal could free ep_bus between the lookup and
-     * the dev_get, turning ep_bus->self into a use-after-free.  The lock is
-     * dropped before pci_bridge_secondary_bus_reset() to avoid deadlocking
-     * with the PCI slot lock that the reset function acquires internally.
+     * Hold pci_lock_rescan_remove() through bridge lookup, reset, and link
+     * recovery. pci_bridge_secondary_bus_reset() is a low-level primitive and
+     * does not serialize against pciehp or concurrent topology changes.
+     *
+     * ponytail: target kernels do not export the temporary pciehp link-change
+     * coordination added upstream.  The global lock plus ignore_hotplug is
+     * the compatible ceiling for RHEL 9 / Ubuntu 22.04; replace it with the
+     * per-port PCI core API if that API becomes exported to modules.
      */
     pr_info("slash_hotplug: toggle_sbr: looking up bus (domain=%04x bus=%02x)\n",
             domain, bus_nr);
@@ -264,46 +328,50 @@ static int slash_hotplug_handle_toggle_sbr(const char *bdf)
         pr_err("slash_hotplug: toggle_sbr: no upstream bridge for %s\n", bdf);
         return -ENODEV;
     }
+    if (!list_empty(&ep_bus->devices)) {
+        pci_unlock_rescan_remove();
+        pr_err("slash_hotplug: toggle_sbr: bus %04x:%02x still has live devices; remove every function before SBR\n",
+               domain, bus_nr);
+        return -EBUSY;
+    }
     bridge = pci_dev_get(ep_bus->self);
-    pci_unlock_rescan_remove();
 
     pr_info("slash_hotplug: toggle_sbr: bridge=%s bus=%02x\n",
             pci_name(bridge), bus_nr);
 
     /*
-     * pci_bridge_secondary_bus_reset() saves and restores bridge config
-     * space (memory windows, bus numbers, ACS, ARI) and holds the proper
-     * PCI slot lock.  This is essential for root ports whose memory-window
-     * configuration would otherwise be lost after an SBR.
-     *
-     * Available since kernel 5.9; guaranteed present on our minimum targets
-     * (RHEL 9 / Ubuntu 22.04, both ship kernel >= 5.14).
+     * SBR generates DLLSC/PDC events.  RHEL 9 backports the PCIe bandwidth
+     * controller, whose shared interrupt can make pciehp consume those events
+     * and power off or re-enumerate the slot while the V80 reloads.  The
+     * legacy ignore_hotplug flag is honored by pciehp's IRQ handler on all
+     * supported kernels.  Keep it asserted for the entire PDI/link outage,
+     * not merely the two-millisecond SBR assertion.
      */
+    coordinate_hotplug = bridge->is_hotplug_bridge;
+    was_ignoring_hotplug = bridge->ignore_hotplug;
+    if (coordinate_hotplug) {
+        bridge->ignore_hotplug = 1;
+        smp_mb();
+        pr_info("slash_hotplug: toggle_sbr: suppressing pciehp link events during V80 reload\n");
+    }
+
     ret = pci_bridge_secondary_bus_reset(bridge);
     if (ret) {
         pr_err("slash_hotplug: toggle_sbr: pci_bridge_secondary_bus_reset failed (%d)\n", ret);
-        goto out_put;
+        goto out_restore_hotplug;
     }
     pr_info("slash_hotplug: toggle_sbr: pci_bridge_secondary_bus_reset OK\n");
 
-    /*
-     * Post-SBR link training delay.  The PCIe spec requires at minimum
-     * 100 ms for link training after SBR deassertion; real FPGA hardware
-     * can take longer.  1000 ms provides margin for link instability seen
-     * on repeated resets where 300 ms was insufficient.
-     * Without this delay, config-space reads on root ports return 0xFFFF
-     * because the link is not yet trained.
-     *
-     * Userspace adds its own ~5 s wait for full FPGA re-initialisation;
-     * this 1000 ms covers the kernel-internal window between SBR
-     * deassertion and ioctl return.
-     */
-    pr_info("slash_hotplug: toggle_sbr: waiting 1000 ms for PCIe link training\n");
-    msleep(1000);
-    pr_info("slash_hotplug: toggle_sbr: post-SBR settle complete (1000 ms)\n");
+    ret = slash_hotplug_wait_for_link(bridge);
 
-out_put:
+out_restore_hotplug:
+    if (coordinate_hotplug) {
+        bridge->ignore_hotplug = was_ignoring_hotplug;
+        smp_mb();
+        pr_info("slash_hotplug: toggle_sbr: restored pciehp link-event handling\n");
+    }
     pci_dev_put(bridge);
+    pci_unlock_rescan_remove();
     if (!ret)
         pr_info("slash_hotplug: toggle_sbr: %s complete\n", bdf);
     return ret;

--- a/driver/tests/test_slash_hotplug.c
+++ b/driver/tests/test_slash_hotplug.c
@@ -18,7 +18,7 @@
  * cross-card damage (touching the wrong accelerator) and stale /dev
  * state (sysfs back but udev missed the node, or wrong minor).
  *
- * Two tests perform a full board reset (TOGGLE_SBR) or accept ~10 s of
+ * Two tests perform a full board reset (TOGGLE_SBR) or accept extended
  * PCIe downtime; these are gated by SLASH_TEST_DESTRUCTIVE=1.  All other
  * tests run on every invocation.
  *
@@ -40,7 +40,6 @@
 #include <sys/sysmacros.h>
 
 #define NODE_RECOVERY_TIMEOUT_S 10
-#define SBR_SETTLE_SECONDS 7
 
 #define SLASH_TEST_MAX_ACCELERATORS 16
 #define SYSFS_MISC_DIR "/sys/class/misc"
@@ -565,6 +564,13 @@ TEST_F(hotplug, toggle_sbr_no_upstream_bridge)
 						   "ffff:ff:00.0"));
 }
 
+TEST_F(hotplug, toggle_sbr_rejects_live_bus)
+{
+	EXPECT_EQ(-EBUSY,
+			  hp_ioctl_bdf(self->hp_fd, SLASH_HOTPLUG_IOCTL_TOGGLE_SBR,
+						   self->accels[0].pf0_bdf));
+}
+
 /* ====================================================================
  * Destructive (env-gated)
  * ==================================================================== */
@@ -616,9 +622,11 @@ TEST_F(hotplug, hotplug_size_below_struct_returns_einval)
 TEST_F(hotplug, full_sbr_cycle)
 {
 	if (getenv("SLASH_TEST_DESTRUCTIVE") == NULL)
-		SKIP(return, "full board reset (~10 s); "
+		SKIP(return, "full board reset (may take up to 30 s); "
 					 "set SLASH_TEST_DESTRUCTIVE=1 to run");
 
+	ASSERT_EQ(0, hp_ioctl_bdf(self->hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE,
+							  self->accels[0].pf0_bdf));
 	ASSERT_EQ(0, hp_ioctl_bdf(self->hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE,
 							  self->accels[0].pf1_bdf));
 	ASSERT_EQ(0, hp_ioctl_bdf(self->hp_fd, SLASH_HOTPLUG_IOCTL_REMOVE,
@@ -626,8 +634,6 @@ TEST_F(hotplug, full_sbr_cycle)
 
 	ASSERT_EQ(0, hp_ioctl_bdf(self->hp_fd, SLASH_HOTPLUG_IOCTL_TOGGLE_SBR,
 							  self->accels[0].pf0_bdf));
-
-	sleep(SBR_SETTLE_SECONDS);
 
 	ASSERT_EQ(0, ioctl(self->hp_fd, SLASH_HOTPLUG_IOCTL_RESCAN));
 

--- a/vrt/vrtd/src/device.c
+++ b/vrt/vrtd/src/device.c
@@ -79,7 +79,7 @@ static int device_read_pci_info(struct device *d, struct vrtd_pci_info *out);
  *                  (which is not an error). Caller must free.
  * @return 0 on success (match found or no match), -1 on I/O or allocation error.
  */
-static int find_qdma_dev_path_by_bdf(const char *ctl_bdf, char **out_path)
+int find_qdma_dev_path_by_bdf(const char *ctl_bdf, char **out_path)
 {
     *out_path = NULL;
 

--- a/vrt/vrtd/src/device.h
+++ b/vrt/vrtd/src/device.h
@@ -112,6 +112,18 @@ DECLARE_OWNING_PTR_ARRAY(device_ptr_array, struct device *, cleanup_device);
 int devices_discover_and_open(struct device_ptr_array *devices);
 
 /**
+ * @brief Find the current /dev/slash_qdma_ctlN path for a PF1 device by BDF.
+ *
+ * Resolves the QDMA misc-device node on the same PCI bus and slot as @p bdf.
+ *
+ * @param bdf       Full PCI BDF including function number.
+ * @param out_path  On success, receives a heap-allocated /dev/ path string, or
+ *                  NULL if the device is not yet registered. Caller must free.
+ * @return 0 on success (device found or absent), -1 on I/O or allocation error.
+ */
+int find_qdma_dev_path_by_bdf(const char *bdf, char **out_path);
+
+/**
  * @brief Find the current /dev/slash_ctlN path for a PF2 device by its full BDF.
  *
  * The /dev node suffix is assigned by an incrementing kernel counter and changes

--- a/vrt/vrtd/src/reset.c
+++ b/vrt/vrtd/src/reset.c
@@ -69,12 +69,11 @@
  *   7. Remove PF0, PF1, PF2 from the PCI bus via slash_hotplug_remove().
  *      ENODEV is tolerated (device may already have been removed by firmware).
  *   8. Toggle Secondary Bus Reset on the upstream PCIe bridge via
- *      slash_hotplug_toggle_sbr().
- *   9. Wait 5 seconds for the device to complete reconfiguration and
- *      re-train the PCIe link.
- *  10. Rescan the PCI bus via slash_hotplug_rescan() to re-enumerate all PFs.
- *  11. Verify the device is back by calling ami_dev_find() on PF0.
- *  12. Run device discovery to re-add the reset device to vrtd's tracked
+ *      slash_hotplug_toggle_sbr().  The ioctl waits for the V80 PDI reload
+ *      and a stable PCIe link before returning.
+ *   9. Rescan the PCI bus via slash_hotplug_rescan() to re-enumerate all PFs.
+ *  10. Poll until PF0 AMI and the PF1/PF2 device nodes are ready.
+ *  11. Run device discovery to re-add the reset device to vrtd's tracked
  *      device list.
  */
 
@@ -83,6 +82,7 @@
 #include "reset.h"
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <unistd.h>
 
@@ -99,6 +99,60 @@
 #include "utils.h"
 
 #define GPIO_ALLOW_SBR 0x1040000
+#define RESET_NODE_POLL_INTERVAL_US 100000
+#define RESET_NODE_READY_TIMEOUT_US 10000000
+#define RESCAN_MAX_RETRIES 5
+#define RESCAN_RETRY_DELAY_US 3000000
+
+/**
+ * Check whether all three V80 functions are ready for vrtd to reopen.
+ *
+ * PF0 readiness is verified through AMI, while PF1/PF2 readiness requires
+ * their BDF-specific device nodes to exist with the permissions vrtd needs.
+ * Keeping the successful AMI handle avoids repeatedly registering PF0 while
+ * udev finishes the other nodes.
+ *
+ * @param pf0_bdf     PF0 AMI BDF.
+ * @param pf1_bdf     PF1 QDMA BDF.
+ * @param pf2_bdf     PF2 control BDF.
+ * @param ami_device  Owning AMI handle, populated once PF0 is ready.
+ * @return true when every function is ready, false while probing or udev is
+ *         still incomplete.
+ */
+static bool reset_functions_ready(
+    const char *pf0_bdf,
+    const char *pf1_bdf,
+    const char *pf2_bdf,
+    struct ami_device **ami_device
+)
+{
+    _cleanup_(cleanup_free)
+    char *ctl_path = NULL;
+    _cleanup_(cleanup_free)
+    char *qdma_path = NULL;
+
+    if (*ami_device == NULL) {
+        int ret = ami_dev_find(pf0_bdf, ami_device);
+        if (ret != AMI_STATUS_OK) {
+            ami_dev_delete(ami_device);
+            return false;
+        }
+    }
+
+    if (find_slash_ctl_dev_path_by_bdf(pf2_bdf, &ctl_path) != 0
+        || ctl_path == NULL
+        || access(ctl_path, R_OK | W_OK) != 0) {
+        return false;
+    }
+
+    if (find_qdma_dev_path_by_bdf(pf1_bdf, &qdma_path) != 0
+        || qdma_path == NULL
+        || access(qdma_path, R_OK | W_OK) != 0) {
+        return false;
+    }
+
+    return true;
+}
 
 /**
  * Perform a full device reset using AMI firmware commands and PCIe hotplug.
@@ -310,23 +364,18 @@ uint16_t reset_with_ami(struct device *device, struct device_ptr_array  *devices
     LOG(LOG_INFO, "reset_with_ami: SBR toggle complete for %s", pf0_bdf);
 
     /*
-     * Step 9: Wait for the FPGA to complete reconfiguration and re-train
-     * the PCIe link.  5 seconds is a conservative estimate that accounts for
-     * bitstream loading time and link training, mentioned in a AVED sw comment.
+     * Step 9-10: Rescan the PCI bus and verify the device reappears.
+     * slash_hotplug_toggle_sbr() does not return until the V80 has had time
+     * to reload its PDI and the upstream bridge reports a stable link.
+     *
+     * The rescan re-enumerates all functions (PF0, PF1, PF2). Poll their
+     * specific AMI, QDMA, and control nodes until driver probing and udev
+     * permissions are complete. If they are not all ready within 10 seconds,
+     * retry the rescan after 3 seconds, up to 5 attempts total.
      */
-    usleep(5000000);
-
-    /*
-     * Step 10-12: Rescan the PCI bus and verify the device reappears.
-     * The rescan re-enumerates all functions (PF0, PF1, PF2), then we wait
-     * for the kernel, drivers, and udev to fully initialize device nodes.
-     * If the device has not reappeared, retry the rescan after 3 seconds,
-     * up to 5 attempts total.
-     */
-    #define RESCAN_MAX_RETRIES 5
-    #define RESCAN_RETRY_DELAY_US 3000000
-
     for (int attempt = 1; attempt <= RESCAN_MAX_RETRIES; attempt++) {
+        bool ready = false;
+
         ret = slash_hotplug_rescan(g_hotplug);
         if (ret != 0) {
             LOG(LOG_ERR, "reset_with_ami: hotplug rescan failed: %m");
@@ -335,48 +384,39 @@ uint16_t reset_with_ami(struct device *device, struct device_ptr_array  *devices
         LOG(LOG_INFO, "reset_with_ami: rescan complete (attempt %d/%d)",
             attempt, RESCAN_MAX_RETRIES);
 
-        /*
-         * After a rescan the following things need to happen:
-         *
-         * * The kernel needs to detect the device on the PCIe bus.
-         * * The kernel needs to hand that device to the slash and ami drivers.
-         * * The slash and ami drivers need to create device nodes.
-         * * The kernel needs to signal to userspace systemd-udev that the device node was created.
-         * * systemd-udev needs to set permisions on the device node.
-         *
-         * That all takes time, so we wait a generous 10 seconds for all of that to occur.
-         *
-         * TODO: A much more robust method would be to remove all the code bellow this
-         * and rework how devices are discovered. We could bring in libudev.
-         * This would allow us to get netlink notifications on device events, such as new devices
-         * appearing. Then we could attempt to open these devices only after the userspace has configured them.
-         */
-        usleep(10000000);
+        for (int elapsed_us = 0;
+             elapsed_us < RESET_NODE_READY_TIMEOUT_US;
+             elapsed_us += RESET_NODE_POLL_INTERVAL_US) {
+            if (reset_functions_ready(pf0_bdf, pf1_bdf, pf2_bdf, &ami_device)) {
+                ready = true;
+                break;
+            }
+            usleep(RESET_NODE_POLL_INTERVAL_US);
+        }
 
-        ret = ami_dev_find(pf0_bdf, &ami_device);
-        if (ret == AMI_STATUS_OK) {
-            LOG(LOG_INFO, "reset_with_ami: device %s found after reset", pf0_bdf);
+        if (ready) {
+            LOG(LOG_INFO, "reset_with_ami: PF0/PF1/PF2 ready after reset");
             break;
         }
 
+        ami_dev_delete(&ami_device);
         if (attempt < RESCAN_MAX_RETRIES) {
-            LOG(LOG_WARNING, "reset_with_ami: ami_dev_find(%s) failed (attempt %d/%d): %s, retrying in 3s",
-                pf0_bdf, attempt, RESCAN_MAX_RETRIES, ami_get_last_error());
+            LOG(LOG_WARNING,
+                "reset_with_ami: PF0/PF1/PF2 not ready (attempt %d/%d), retrying rescan in 3s",
+                attempt, RESCAN_MAX_RETRIES);
             usleep(RESCAN_RETRY_DELAY_US);
         } else {
-            LOG(LOG_ERR, "reset_with_ami: post-reset ami_dev_find(%s) failed after %d attempts: %s",
-                pf0_bdf, RESCAN_MAX_RETRIES, ami_get_last_error());
+            LOG(LOG_ERR,
+                "reset_with_ami: PF0/PF1/PF2 not ready after %d rescan attempts",
+                RESCAN_MAX_RETRIES);
             return VRTD_RET_INTERNAL_ERROR;
         }
     }
 
-    #undef RESCAN_MAX_RETRIES
-    #undef RESCAN_RETRY_DELAY_US
-
     ami_dev_delete(&ami_device);
 
     /*
-     * Step 13: Run device discovery to re-add the reset device to vrtd's
+     * Step 11: Run device discovery to re-add the reset device to vrtd's
      * tracked device list.  This opens the QDMA function, sets up queues,
      * and makes the device available for user requests again.
      */


### PR DESCRIPTION

## Summary

Make a V80 secondary-bus reset one serialized operation that suppresses reset-induced PCIe hotplug events, waits for PDI reload and stable link training, and returns control only when userspace can safely rescan and reopen all three functions.

## Reset race

A V80 SBR triggers a full PDI reload rather than only retraining an ordinary endpoint link. The existing path releases PCI topology serialization before reset and relies on fixed sleeps. During that interval, pciehp can interpret the expected link transitions as physical removal events, while userspace may rescan before PF0, PF1, PF2, their drivers, and udev permissions are ready.

The reset contract also permits callers to leave functions on the secondary bus, which makes it possible to reset underneath live driver state.

## Changes

The hotplug ioctl now requires an empty secondary bus and holds `pci_lock_rescan_remove()` through reset and link recovery. On a hotplug-capable bridge it temporarily sets the legacy `ignore_hotplug` flag, performs `pci_bridge_secondary_bus_reset()`, allows five seconds for the V80 PDI reload, and then requires DLL Link Active to remain asserted across two 100 ms polls. The ioctl times out after a further 25 seconds and restores the previous hotplug state on every exit path.

Holding the global PCI rescan/remove lock can block unrelated PCI topology changes for up to 30 seconds. This is deliberate: the V80 must remain one atomic topology transition, and supported kernels do not export the newer PCI hotplug coordination helper to this out-of-tree module.

After the ioctl succeeds, vrtd rescans immediately instead of adding another fixed post-SBR sleep. It polls every 100 ms for PF0 AMI readiness and accessible PF1 QDMA and PF2 control nodes, retaining the AMI handle while udev finishes the remaining nodes. A rescan that does not produce all three functions within ten seconds is retried up to five times.

## Draft

Needs rebase and testing