### PR TITLE
refactor(libvrtdpp): Refactor around Connection

### DIFF
--- a/docs/reference/vrtd/client-flow.rst
+++ b/docs/reference/vrtd/client-flow.rst
@@ -66,8 +66,6 @@ Minimal program that opens a session, grabs device 0, opens BAR 0, and reads a
        auto p = bf.getPtr<std::uint32_t>(vrtd::BarFile::Direction::Read, /*address=*/0);
        std::uint32_t value = *p;  // read via volatile
        (void)value;
-
-       bf.close();
      } catch (const vrtd::Error& e) {
        std::cerr << "vrtd error: " << e.what() << "\n";
        return 1;
@@ -129,7 +127,7 @@ showing the C and C++ entry points side-by-side.
 
 - **C++**: ``vrtd::Session s;`` or ``vrtd::Session s{"/run/vrtd.sock"};``
   Throws ``vrtd::Error(VRTD_RET_BAD_CONN)`` on failure.
-  RAII — destructor calls ``close()``. Thread-safe (internal mutex).
+  The session and its child objects share an RAII connection.
 
 2) Discover Devices
 -------------------
@@ -147,7 +145,8 @@ showing the C and C++ entry points side-by-side.
   - ``vrtd::Device d = s.getDevice(i);`` — throws ``vrtd::Error(VRTD_RET_NOEXIST)``
     if out of range.
   - Accessors: ``d.getNum()``, ``d.getName()``, ``d.getBdf()``.
-  - Any ``Device`` becomes invalid if its originating ``Session`` is closed or moved.
+  - A ``Device`` retains the connection and may outlive or survive a move of
+    its originating ``Session`` facade.
 
 3) BAR Metadata
 ---------------
@@ -221,20 +220,24 @@ Common return codes:
 Thread Safety
 =============
 
-- **Session / Device / Bar (C++)**: public methods are thread-safe (internal
-  mutex). Object validity is tied to the originating session — closing or
-  moving a session invalidates previously obtained ``Device`` / ``Bar`` values.
+- **Session / Device / Bar / QdmaQpair (C++)**: control requests are serialized
+  on their shared connection. Explicitly closing the connection waits for an
+  in-flight request before closing it.
+- **Buffer (C++)**: DMA operations on independent buffers may proceed in
+  parallel; explicit connection close waits for active operations.
 - **BarFile / BarFilePtr (C++)**: not thread-safe. Only one read or write
   operation may be active at a time. Re-entrant ``getPtr()`` calls throw.
 
 Lifetime and Moves (C++)
 =========================
 
-- Moving or closing a ``Session`` invalidates all ``Device`` and ``Bar`` objects
-  obtained from it (subsequent calls throw).
+- ``Device``, ``Bar``, ``Buffer``, and ``QdmaQpair`` retain their shared
+  connection. Moving or destroying a ``Session`` facade does not invalidate
+  them, and the connection closes when its final owner is destroyed.
+- Explicit ``Session::close()`` closes the shared connection and invalidates
+  every object backed by it; subsequent connection-dependent calls throw.
 - ``BarFile`` is move-only. Ensure all ``BarFilePtr`` instances have been
-  destroyed before calling ``bf.close()`` or letting the destructor run,
-  otherwise an exception is thrown.
+  destroyed before calling ``bf.close()`` or letting the destructor run.
 
 Wire Protocol
 =============
@@ -251,7 +254,8 @@ Troubleshooting
 ===============
 
 - **Out-of-range device index** → ``VRTD_RET_NOEXIST`` (C) or ``vrtd::Error`` (C++).
-- **Session closed/moved, then using Device/Bar** → throws (invalid lifetime).
+- **Session explicitly closed, then using Device/Bar** → throws
+  ``VRTD_RET_BAD_LIB_CALL`` without sending another request.
 - **Two concurrent ``getPtr()`` calls on the same BarFile** → throws re-entrancy error.
 - **Transport errors** (socket down, daemon not running) → map to
   ``VRTD_RET_BAD_CONN`` / ``vrtd::Error`` with "connection" message.

--- a/vrt/vrtd/libvrtd/src/requests.c
+++ b/vrt/vrtd/libvrtd/src/requests.c
@@ -1030,17 +1030,31 @@ enum vrtd_ret vrtd_open_bar_file(
         return VRTD_RET_BAD_LIB_CALL;
     }
 
-    int bar_fd = -1;
-    size_t len = 0;
-    enum vrtd_ret ret = vrtd_get_bar_fd(fd, dev,bar,  &bar_file_out->fd, &bar_file_out->len);
+    enum vrtd_ret ret = vrtd_get_bar_fd(
+        fd, dev, bar, &bar_file_out->fd, &bar_file_out->len);
     if (ret != VRTD_RET_OK) {
         return ret;
     }
 
-    bar_file_out->map = mmap(NULL, bar_file_out->len, PROT_READ | PROT_WRITE, MAP_SHARED, bar_file_out->fd, 0);
+    bar_file_out->map = mmap(
+        NULL,
+        bar_file_out->len,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        bar_file_out->fd,
+        0
+    );
     if (bar_file_out->map == MAP_FAILED) {
+        /*
+         * The received BAR descriptor is independent of the vrtd connection.
+         * Closing fd here invalidates the client transport and may later close
+         * an unrelated descriptor if the kernel reuses that number.
+         */
+        close(bar_file_out->fd);
         bar_file_out->map = NULL;
-        close(fd);
+        bar_file_out->len = 0;
+        bar_file_out->fd = -1;
+
         return VRTD_RET_INTERNAL_ERROR;
     }
 

--- a/vrt/vrtd/libvrtdpp/include/vrtd/bar.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/bar.hpp
@@ -21,14 +21,16 @@
 #ifndef VRTD_BAR_HPP
 #define VRTD_BAR_HPP
 
-#include <string>
-#include <string_view>
-#include <functional>
+#include <memory>
 #include <stdint.h>
 
 #include <vrtd/bar_file.hpp>
 
 namespace vrtd {
+
+namespace detail {
+class Connection;
+}
 
 /**
  * @brief Value-type metadata handle for a device BAR (Base Address Register).
@@ -37,23 +39,27 @@ namespace vrtd {
  *
  * @par Semantics
  * - @c isUsable(): this BAR is currently accessible/mappable to the caller.
- * - @c isInUse(): this BAR is leased by another tenant (currently always false).
+ * - @c isInUse(): daemon-reported lease state at discovery time.
  * - @c getStartAddress(), @c getLength(): physical address and size in **bytes**.
  *
  * @par Lifetime
- * A @c Bar becomes invalid if its originating @c Session is closed or moved.
- * Any subsequent member call will throw.
+ * Moving or destroying the originating @c Session does not invalidate a Bar.
+ * Explicitly closing the shared connection does.
  *
  * @par Thread safety
  * Methods are thread-safe and may be called concurrently; they synchronize
- * on the originating @c Session.
+ * on the shared connection.
  */
 class Bar {
 public:
+    /** Release this metadata handle and its shared connection reference. */
     ~Bar() = default;
 
+    /** BAR handles are copyable views of the same connection and metadata. */
     Bar(const Bar&)                = default;
     Bar& operator=(const Bar&)     = default;
+
+    /** Moving transfers the shared connection and cached metadata. */
     Bar(Bar&&) noexcept            = default;
     Bar& operator=(Bar&&) noexcept = default;
 
@@ -73,9 +79,7 @@ public:
     bool isUsable() const noexcept;
 
     /**
-     * @brief Whether this BAR is currently in use by another tenant.
-     *
-     * @note In the current implementation this always returns false.
+     * @brief Return the daemon-reported in-use state from discovery time.
      */
     bool isInUse() const noexcept;
 
@@ -98,18 +102,35 @@ public:
      */
     BarFile openBarFile() const;
 private:
-    // Only allow the Session class to generate this class
-    friend class Session;
-    Bar(uint32_t deviceNum, uint8_t num, bool usable, bool inUse, uint64_t startAddress, uint64_t length, std::function<BarFile(const Bar&)> fOpenBarFile) noexcept;
+    friend class Device;
 
-    uint32_t deviceNum;
-    uint8_t num;
-    bool usable;
-    bool inUse;
-    uint64_t startAddress;
-    uint64_t length;
+    /**
+     * @brief Construct a BAR handle from one daemon metadata snapshot.
+     *
+     * @param connection Shared transport retained for later mapping.
+     * @param deviceNum Zero-based owning device index.
+     * @param num Zero-based BAR index.
+     * @param usable Whether the daemon permits mapping.
+     * @param inUse Whether another tenant currently holds the BAR.
+     * @param startAddress Physical BAR start address.
+     * @param length BAR size in bytes.
+     */
+    Bar(std::shared_ptr<detail::Connection> connection,
+        uint32_t deviceNum,
+        uint8_t num,
+        bool usable,
+        bool inUse,
+        uint64_t startAddress,
+        uint64_t length) noexcept;
 
-    std::function<BarFile(const Bar&)> fOpenBarFile;
+    /** Shared transport used by openBarFile(). */
+    std::shared_ptr<detail::Connection> connection;
+    uint32_t deviceNum; ///< Zero-based owning device index.
+    uint8_t num; ///< Zero-based PCI BAR index.
+    bool usable; ///< Whether this client may map the BAR.
+    bool inUse; ///< Whether another tenant currently holds the BAR.
+    uint64_t startAddress; ///< Physical BAR start address.
+    uint64_t length; ///< BAR size in bytes.
 };
 
 } // namespace vrtd

--- a/vrt/vrtd/libvrtdpp/include/vrtd/bar_file.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/bar_file.hpp
@@ -36,8 +36,9 @@ namespace vrtd {
  * Encapsulates a @c slash_bar_file containing the BAR mapping (@c map) and
  * length (@c len). Provides typed access via @c getPtr<T>() which brackets
  * memory access with the appropriate @c slash_bar_file_start_* /
- * @c slash_bar_file_end_* calls. Direct raw access is available via
- * @c getRawPtr(), but requires manual bracketing.
+ * @c slash_bar_file_end_* calls. Direct raw access through @c getRawPtr() is
+ * intentionally unsynchronized and unsafe; this API exposes no manual
+ * synchronization handle, so prefer typed access for normal MMIO.
  *
  * @warning Not thread-safe. At most one memory operation (read or write)
  *          may be active at a time per @c BarFile instance. Concurrent
@@ -48,34 +49,45 @@ namespace vrtd {
  */
 class BarFile {
 public:
-/**
+    /**
      * @brief Destructor.
      *
      * Releases the mapping and FD if still open.
      *
-     * @warning If a memory operation is still in progress (i.e., a live
-     *          @c BarFilePtr returned by @c getPtr() has not been destroyed),
-     *          the destructor may throw (e.g., to signal improper usage).
-     *          Users must ensure all @c BarFilePtr instances are destroyed
-     *          before destroying or closing the @c BarFile.
+     * @pre Every @c BarFilePtr created by this object has been destroyed.
+     *
+     * The destructor cannot report a violated precondition. If an access
+     * session is still active, it forcibly releases the native resources as a
+     * last resort; any outstanding pointer is then invalid.
      */
-    ~BarFile();
+    ~BarFile() noexcept;
 
+    /** A mapping and its descriptor have exclusive ownership and cannot copy. */
     BarFile(const BarFile&)            = delete;
     BarFile& operator=(const BarFile&) = delete;
 
     /**
      * @brief Move constructor; transfers ownership and closes the source.
+     *
+     * @throws std::runtime_error if @p other has a live @c BarFilePtr. The
+     *         source remains unchanged in that case.
      */
-    BarFile(BarFile&&) noexcept;
+    BarFile(BarFile&&);
 
     /**
      * @brief Move assignment; closes current, then takes ownership.
+     *
+     * Self-assignment has no effect.
+     *
+     * @throws std::runtime_error if either object has a live @c BarFilePtr.
+     *         Both objects remain unchanged in that case.
      */
-    BarFile& operator=(BarFile&&) noexcept;
+    BarFile& operator=(BarFile&&);
 
     /**
      * @brief Size of the mapped BAR in bytes.
+     *
+     * @return Mapping length, or zero after close or move.
      */
     size_t getLen() const noexcept;
 
@@ -83,26 +95,26 @@ public:
      * @brief Get a raw volatile pointer into the mapping.
      *
      * @param address Byte offset from the start of the mapping (default 0).
-     * @return @c volatile void* pointing at @p address inside the mapping.
+     * @return Pointer to the selected byte, or @c nullptr if closed or if the
+     *         starting offset is outside the mapping.
      *
-     * @warning Using the raw pointer requires the caller to manually bracket
-     *          accesses with @c slash_bar_file_start_read() / @c _end_read() or
-     *          @c slash_bar_file_start_write() / @c _end_write() as appropriate.
-     *          Prefer @c getPtr<T>() for RAII-safe access.
+     * Only the starting byte is bounds-checked. The caller owns width and
+     * alignment correctness and must stop using the pointer before close,
+     * move, or destruction. This access path cannot establish a DMA-BUF
+     * synchronization session; use getPtr() when synchronization is required.
      *
-     * @throws std::runtime_error if the file is closed or @p address is out of range.
+     * In other words: you probably don't want to use this. 
      */
     volatile void *getRawPtr(size_t address = 0) const noexcept;
 
     /**
      * @brief Close the mapping and underlying FD.
      *
-     * After a successful close, @c isClosed() returns true and further
-     * operations will throw.
+     * After a successful close, @c isClosed() returns true, @c getLen()
+     * returns zero, and @c getRawPtr() returns null. Typed access throws.
      *
-     * @warning Not idempotent/noexcept by design: if a memory operation is
-     *          still in progress (i.e., a @c BarFilePtr is alive), this
-     *          function may throw to signal misuse.
+     * The operation is idempotent. If a memory operation is still in progress
+     * (i.e., a @c BarFilePtr is alive), it throws to signal misuse.
      */
     void close();
 
@@ -112,23 +124,34 @@ public:
     bool isClosed() const noexcept;
 
 private:
-    friend class Session;
+    friend class Bar;
+
+    /**
+     * @brief Adopt an already mapped BAR returned by libvrtd.
+     *
+     * @param barFile Owning mapping and descriptor consumed by this object.
+     */
     explicit BarFile(slash_bar_file barFile) noexcept;
 
+    /** Exclusively owned native mapping released by vrtd_close_bar_file(). */
     slash_bar_file barFile;
 
-    // Internal single-operation guards (non-thread-safe).
+    /** True while one BarFilePtr owns a read synchronization session. */
     bool reading{};
+
+    /** True while one BarFilePtr owns a write synchronization session. */
     bool writing{};
+
+    /** Permanent closed or moved-from state; mutually excludes typed access. */
     bool closed{};
 
 public:
     /**
-     * @brief Direction of an access session.
+     * @brief DMA-BUF synchronization direction selected by getPtr().
      */
     enum class Direction {
-        Read,
-        Write,
+        Read,  ///< Bracket access with the native read synchronization calls.
+        Write, ///< Bracket access with the native write synchronization calls.
     };
 
     /**
@@ -136,7 +159,8 @@ public:
      *
      * Starts a read or write session (depending on @p direction) and returns
      * a move-only @c BarFilePtr<T> that will automatically end the session on
-     * destruction. Only one operation (read or write) may be active at a time.
+     * destruction. Only one operation (read or write) may be active at a time,
+     * and this BarFile must outlive the returned pointer.
      *
      * @tparam T Element type. Must be an object type; recommended to be
      *           trivially copyable/standard-layout. Accesses are through
@@ -152,10 +176,16 @@ public:
      *         - another read/write operation is already in progress,
      *         - @p direction is invalid.
      *
-     * @warning The caller is responsible for alignment correctness.
+     * @warning Only @p address is bounds-checked. The caller must ensure
+     *          @c sizeof(T) fits in the remaining mapping and that alignment is
+     *          valid. Native synchronization failures are currently ignored.
      */
     template<class T>
     BarFilePtr<T> getPtr(Direction direction, size_t address = 0) {
+        /*
+         * Validate the local state before starting a synchronization session.
+         * A returned pointer owns the only active session for this mapping.
+         */
         if (closed) {
             throw std::runtime_error("Memory operation on closed bar file");
         }
@@ -173,6 +203,11 @@ public:
 
         std::function<void()> callback{};
 
+        /*
+         * Pair the native START operation with a callback-owned END operation.
+         * The callback also clears the local exclusion flag so another access
+         * can begin after the returned BarFilePtr is destroyed.
+         */
         if (direction == Direction::Read) {
             slash_bar_file_start_read(&barFile);
             reading = true;

--- a/vrt/vrtd/libvrtdpp/include/vrtd/bar_file_ptr.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/bar_file_ptr.hpp
@@ -28,6 +28,8 @@
 
 namespace vrtd {
 
+class BarFile;
+
 /**
  * @brief Move-only RAII pointer for BAR memory access sessions.
  *
@@ -39,41 +41,52 @@ namespace vrtd {
  *
  * @warning Not thread-safe. Intended to be short-lived and used on a
  *          single thread that owns the corresponding @c BarFile operation.
+ * @warning The originating BarFile must outlive this pointer.
  */
 template<class T>
 class BarFilePtr {
+    /** Typed BAR access requires an object type. */
     static_assert(std::is_object_v<T>, "T must be an object type");
 public:
+    /** Unqualified element type exposed by this pointer wrapper. */
     using element_type = T;
+
+    /** Volatile pointer type used for MMIO loads and stores. */
     using pointer      = volatile T*;
+
+    /** Non-throwing cleanup action run once when ownership ends. */
     using callback_t   = std::function<void()>;
 
     /**
-     * @brief Construct from a raw volatile pointer and optional destructor callback.
+     * @brief Transfer pointer and cleanup ownership from @p other.
      *
-     * @param p  Raw volatile pointer within the BAR mapping.
-     * @param cb Callback to run on destruction (e.g., to end a read/write session).
+     * The moved-from pointer becomes null and will not run the callback.
      */
-    explicit BarFilePtr(pointer p = nullptr, callback_t cb = {}) noexcept
-        : p_(p), cb_(std::move(cb)) {}
-
-    // move-only (ensures callback runs at most once)
     BarFilePtr(BarFilePtr&& other) noexcept
         : p_(other.p_), cb_(std::move(other.cb_)) {
         other.p_ = nullptr;
         other.cb_ = nullptr;
     }
+
+    /**
+     * @brief End the current access session, then adopt @p other.
+     *
+     * The moved-from pointer becomes null and will not run the callback.
+     */
     BarFilePtr& operator=(BarFilePtr&& other) noexcept {
         if (this != &other) {
             run_callback();
+
             p_  = other.p_;
             cb_ = std::move(other.cb_);
             other.p_ = nullptr;
             other.cb_ = nullptr;
         }
+
         return *this;
     }
 
+    /** Copying would run one cleanup action from multiple owners. */
     BarFilePtr(const BarFilePtr&)            = delete;
     BarFilePtr& operator=(const BarFilePtr&) = delete;
 
@@ -82,56 +95,88 @@ public:
      */
     ~BarFilePtr() { run_callback(); }
 
-    // ---- implicit conversions (only these two) ----
     /**
-     * @brief Implicit conversion to volatile T*.
+     * @brief Return the wrapped volatile element pointer.
      */
     operator pointer() const noexcept { return p_; }
+
     /**
-     * @brief Implicit conversion to volatile void*.
+     * @brief Return the wrapped address without its element type.
      */
     operator volatile void*() const noexcept { return p_; }
 
-    // ---- pointer-like interface ----
+    /** Return the wrapped pointer without transferring cleanup ownership. */
     pointer get()        const noexcept { return p_; }
+
+    /** Dereference the wrapped volatile element. */
     volatile T& operator*() const noexcept { return *p_; }
+
+    /** Access a member through the wrapped volatile element pointer. */
     pointer     operator->() const noexcept { return p_; }
 
-    // index (useful for arrays / pointer arithmetic)
+    /**
+     * @brief Index from the wrapped address.
+     *
+     * Bounds and alignment remain the caller's responsibility.
+     */
     volatile T& operator[](std::size_t i) const noexcept { return p_[i]; }
 
     /**
-     * @brief returns true if non-null.
+     * @brief Return whether the wrapped pointer is non-null.
      */
     explicit operator bool() const noexcept { return p_ != nullptr; }
 
-    // comparisons
+    /** Compare two wrappers by their raw pointer values. */
     friend bool operator==(const BarFilePtr& a, const BarFilePtr& b) noexcept { return a.p_ == b.p_; }
     friend bool operator!=(const BarFilePtr& a, const BarFilePtr& b) noexcept { return !(a == b); }
+
+    /** Compare the wrapped pointer with null. */
     friend bool operator==(const BarFilePtr& a, std::nullptr_t) noexcept { return a.p_ == nullptr; }
     friend bool operator==(std::nullptr_t, const BarFilePtr& a) noexcept { return a.p_ == nullptr; }
     friend bool operator!=(const BarFilePtr& a, std::nullptr_t) noexcept { return a.p_ != nullptr; }
     friend bool operator!=(std::nullptr_t, const BarFilePtr& a) noexcept { return a.p_ != nullptr; }
 
-    // optional: compare directly with a raw volatile T*
+    /** Compare the wrapper with a raw volatile pointer value. */
     friend bool operator==(const BarFilePtr& a, pointer p) noexcept { return a.p_ == p; }
     friend bool operator==(pointer p, const BarFilePtr& a) noexcept { return a.p_ == p; }
     friend bool operator!=(const BarFilePtr& a, pointer p) noexcept { return a.p_ != p; }
     friend bool operator!=(pointer p, const BarFilePtr& a) noexcept { return a.p_ != p; }
 
 private:
+    friend class BarFile;
+
+    /**
+     * @brief Construct a BAR access session for BarFile.
+     *
+     * @param p  Raw volatile pointer within the BAR mapping.
+     * @param cb Callback to run on destruction (e.g., to end a read/write session).
+     *
+     * @warning @p cb must not throw because cleanup runs from noexcept paths.
+     */
+    explicit BarFilePtr(pointer p, callback_t cb) noexcept
+        : p_(p), cb_(std::move(cb)) {}
+
+    /**
+     * @brief Consume and invoke the cleanup action at most once.
+     *
+     * Move the callback out before invocation so re-entrant destruction cannot
+     * invoke the same cleanup twice.
+     */
     void run_callback() noexcept {
         if (cb_) {
             auto cb = std::move(cb_);
-            cb_ = nullptr;      // ensure single fire
+            cb_ = nullptr;
             cb();
         }
     }
 
+    /** Borrowed volatile mapping address, or null after move. */
     pointer     p_  = nullptr;
+
+    /** Sole owner of the access-session cleanup action. */
     callback_t  cb_ = nullptr;
 };
 
-} // namsepace vrtd
+} // namespace vrtd
 
 #endif // VRTD_BAR_FILE_PTR_HPP

--- a/vrt/vrtd/libvrtdpp/include/vrtd/buffer.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/buffer.hpp
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <memory>
 
 #include <vrtd/wire.h>
 
@@ -30,22 +31,31 @@ struct vrtd_buffer;
 
 namespace vrtd {
 
+namespace detail {
+class Connection;
+}
+
 /**
- * @brief Allocation type for buffers.
+ * @brief Device memory class requested from the vrtd allocator.
+ *
+ * Values mirror @c vrtd_alloc_type. The interpretation of Buffer::getAllocArg()
+ * depends on the selected class.
  */
 enum class BufferAllocType : uint32_t {
-    Ddr     = VRTD_ALLOC_TYPE_DDR,
-    Hbm     = VRTD_ALLOC_TYPE_HBM,
-    HbmVnoc = VRTD_ALLOC_TYPE_HBM_VNOC,
+    Ddr     = VRTD_ALLOC_TYPE_DDR, ///< Allocate from DDR memory.
+    Hbm     = VRTD_ALLOC_TYPE_HBM, ///< Allocate from one requested HBM region.
+    HbmVnoc = VRTD_ALLOC_TYPE_HBM_VNOC, ///< Let vrtd place the HBM allocation.
 };
 
 /**
- * @brief Direction for QDMA transfers for a buffer.
+ * @brief QDMA transfer directions enabled for a buffer.
+ *
+ * Values mirror @c vrtd_alloc_dir and constrain which sync method may be used.
  */
 enum class BufferAllocDir : uint32_t {
-    Bidirectional  = VRTD_ALLOC_DIR_BIDIRECTIONAL,
-    HostToDevice   = VRTD_ALLOC_DIR_HOST_TO_DEVICE,
-    DeviceToHost   = VRTD_ALLOC_DIR_DEVICE_TO_HOST,
+    Bidirectional  = VRTD_ALLOC_DIR_BIDIRECTIONAL, ///< Permit both sync directions.
+    HostToDevice   = VRTD_ALLOC_DIR_HOST_TO_DEVICE, ///< Reject syncFromDevice().
+    DeviceToHost   = VRTD_ALLOC_DIR_DEVICE_TO_HOST, ///< Reject syncToDevice().
 };
 
 /**
@@ -65,63 +75,95 @@ enum class MmChannel : uint32_t {
  *
  * A @c Buffer owns the underlying @c vrtd_buffer, including its qpair FD and
  * host-side staging buffer. Destruction closes the FD and releases the mapping.
+ * The buffer retains the connection needed for daemon-side cleanup.
  *
  * @note Move-only; copying is disabled. The moved-from object is closed.
+ * @warning A single Buffer is not safe for concurrent close, move, or sync
+ * operations. Operations on independent buffers may run concurrently.
  */
 class Buffer {
 public:
+    /**
+     * @brief Release daemon and local buffer resources.
+     *
+     * Cleanup is best-effort and does not throw. All pointers and borrowed
+     * descriptors obtained from this object become invalid.
+     */
     ~Buffer();
 
+    /** Native allocation and descriptor ownership cannot be copied. */
     Buffer(const Buffer&)            = delete;
     Buffer& operator=(const Buffer&) = delete;
 
+    /** Transfer ownership and leave @p other closed. */
     Buffer(Buffer&& other) noexcept;
+
+    /**
+     * @brief Close the current allocation, then adopt @p other.
+     *
+     * The moved-from object becomes closed.
+     */
     Buffer& operator=(Buffer&& other) noexcept;
 
     /**
-     * @brief Device index owning this buffer.
+     * @brief Return the owning device index, or zero when closed.
+     *
+     * Zero is also a valid device index; use isClosed() to disambiguate.
      */
     uint32_t getDeviceNum() const noexcept;
 
     /**
-     * @brief Allocation type requested for this buffer.
+     * @brief Return the requested allocation type.
+     *
+     * A closed object reports BufferAllocType::Ddr as a sentinel.
      */
     BufferAllocType getAllocType() const noexcept;
 
     /**
-     * @brief QDMA transfer direction for this buffer.
+     * @brief Return the enabled QDMA transfer direction.
+     *
+     * A closed object reports BufferAllocDir::Bidirectional as a sentinel.
      */
     BufferAllocDir getAllocDir() const noexcept;
 
     /**
-     * @brief Allocation argument (HBM region index for HBM allocations).
+     * @brief Return the type-specific allocation argument, or zero if closed.
+     *
+     * For BufferAllocType::Hbm this is the requested HBM region.
      */
     uint64_t getAllocArg() const noexcept;
 
     /**
-     * @brief Allocated size in bytes (rounded to subregions).
+     * @brief Return the allocated byte count after allocator rounding.
+     *
+     * A closed object returns zero.
      */
     uint64_t getSize() const noexcept;
 
     /**
-     * @brief Physical device address for this allocation.
+     * @brief Return the physical device address, or zero if closed.
      */
     uint64_t getPhysAddr() const noexcept;
 
     /**
-     * @brief Pointer to the host staging buffer.
+     * @brief Return the mutable host mapping, or null if closed.
+     *
+     * The pointer remains mutable for compatibility even on a const Buffer and
+     * becomes invalid on close, move, or destruction.
      */
     void *data() const noexcept;
 
-
     /**
-     * @brief Pointer to the host staging buffer.
+     * @brief Return the writable host mapping, or null if closed.
+     *
+     * The pointer becomes invalid on close, move, or destruction.
      */
     void *data() noexcept;
 
     /**
      * @brief Borrow the owned file descriptor without transferring ownership.
      *
+     * @return QDMA descriptor, or -1 after close or releaseFd().
      * @warning Do not close the returned FD directly unless you have called
      *          @c releaseFd(). Prefer @c close().
      */
@@ -130,46 +172,60 @@ public:
     /**
      * @brief Release qpair FD ownership to the caller.
      *
-     * The buffer remains valid, but will no longer close the FD on destruction.
+     * The buffer remains valid, but later cleanup will not close that
+     * descriptor.
+     *
+     * @return Released descriptor, or -1 if no native buffer is owned.
+     * @warning The caller must close a successfully released descriptor.
      */
     int releaseFd() noexcept;
 
     /**
      * @brief Close and destroy the buffer via vrtd (idempotent).
      *
-     * Releases the server-side allocation and local staging buffer. Errors
-     * are ignored to preserve noexcept semantics.
+     * While connected, cleanup asks vrtd to release the server allocation and
+     * then destroys local mappings and descriptors. After connection closure,
+     * only local state is destroyed because vrtd already reclaims all resources
+     * associated with the disconnected client. Errors are ignored.
      */
     void close() noexcept;
 
     /**
-     * @brief Whether the buffer has been closed or destroyed.
+     * @brief Return whether this object owns no native buffer.
+     *
+     * Moved-from objects are closed.
      */
     bool isClosed() const noexcept;
 
     /**
      * @brief Sync host buffer contents to the device.
      *
-     * @throws vrtd::Error on error.
+     * @param offset First byte in the host mapping.
+     * @param size Number of bytes to transfer.
+     * @throws vrtd::Error if closed, if the range is invalid, if the buffer is
+     *         device-to-host-only, or if DMA fails.
      */
     void syncToDevice(uint64_t offset, uint64_t size);
 
     /**
      * @brief Sync device contents into the host buffer.
      *
-     * @throws vrtd::Error on error.
+     * @param offset First byte in the host mapping.
+     * @param size Number of bytes to transfer.
+     * @throws vrtd::Error if closed, if the range is invalid, if the buffer is
+     *         host-to-device-only, or if DMA fails.
      */
     void syncFromDevice(uint64_t offset, uint64_t size);
 
     /**
-     * @brief Obtain a std::fstream bound to this buffer FD.
+     * @brief Reject stream access to the ioctl-only buffer descriptor.
      *
-     * @param mode Standard iostream open mode (defaults to in|out|binary).
-     * @return A @c std::fstream owning its own FD.
+     * QDMA buffer descriptors support registered-buffer ioctls rather than
+     * read/write stream operations, so this compatibility entry point never
+     * returns.
      *
-     * @throws std::runtime_error if the buffer is closed or the stream cannot be opened.
-     *
-     * @note Implementation is Linux-specific and relies on @c /proc/self/fd.
+     * @param mode Ignored compatibility argument.
+     * @throws std::runtime_error for both open and closed buffers.
      */
     std::fstream fstream(
         std::ios_base::openmode mode =
@@ -177,10 +233,21 @@ public:
     ) const;
 
 private:
-    friend class Session;
+    friend class Device;
 
-    explicit Buffer(struct vrtd_buffer *buffer) noexcept;
+    /**
+     * @brief Adopt a native buffer and retain its cleanup connection.
+     *
+     * @param connection Open shared connection that created @p buffer.
+     * @param buffer Exclusively owned native handle.
+     */
+    Buffer(std::shared_ptr<detail::Connection> connection,
+           struct vrtd_buffer *buffer) noexcept;
 
+    /** Shared connection used to coordinate sync and daemon-side cleanup. */
+    std::shared_ptr<detail::Connection> connection;
+
+    /** Exclusively owned native handle, or null when closed or moved-from. */
     struct vrtd_buffer *buffer{nullptr};
 };
 

--- a/vrt/vrtd/libvrtdpp/include/vrtd/device.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/device.hpp
@@ -23,7 +23,7 @@
 
 #include <string>
 #include <string_view>
-#include <functional>
+#include <memory>
 #include <vector>
 #include <stddef.h>
 #include <stdint.h>
@@ -35,19 +35,26 @@
 
 namespace vrtd {
 
+namespace detail {
+class Connection;
+}
+
+/** @brief Device clock domain selected by clock-control operations. */
 enum class ClockRegion : uint32_t {
-    Service = VRTD_CLOCK_REGION_SERVICE,
-    User = VRTD_CLOCK_REGION_USER,
+    Service = VRTD_CLOCK_REGION_SERVICE, ///< Static service-region clock.
+    User = VRTD_CLOCK_REGION_USER,       ///< Reconfigurable user-region clock.
 };
 
+/** @brief PCIe hotplug/reset operation applied by Device::hotplugOp(). */
 enum class HotplugOp : uint8_t {
-    Rescan = VRTD_DEVICE_HOTPLUG_OP_RESCAN,
-    Remove = VRTD_DEVICE_HOTPLUG_OP_REMOVE,
-    ToggleSbr = VRTD_DEVICE_HOTPLUG_OP_TOGGLE_SBR,
-    Hotplug = VRTD_DEVICE_HOTPLUG_OP_HOTPLUG,
-    ResetSequence = VRTD_DEVICE_HOTPLUG_OP_RESET_SEQUENCE,
+    Rescan = VRTD_DEVICE_HOTPLUG_OP_RESCAN, ///< Rescan the PCI bus.
+    Remove = VRTD_DEVICE_HOTPLUG_OP_REMOVE, ///< Remove selected PCI functions.
+    ToggleSbr = VRTD_DEVICE_HOTPLUG_OP_TOGGLE_SBR, ///< Toggle secondary-bus reset.
+    Hotplug = VRTD_DEVICE_HOTPLUG_OP_HOTPLUG, ///< Remove then rescan.
+    ResetSequence = VRTD_DEVICE_HOTPLUG_OP_RESET_SEQUENCE, ///< Run managed reset.
 };
 
+/** Select all V80 physical functions where a hotplug operation permits it. */
 inline constexpr uint8_t HotplugFunctionAll = VRTD_DEVICE_HOTPLUG_FUNCTION_ALL;
 
 /**
@@ -64,23 +71,27 @@ struct SensorEntry {
 /**
  * @brief Value-type handle describing a vrtd device.
  *
- * A @c Device carries its device number, name, and PCI metadata and routes operations back
- * through its originating @c Session.
+ * A @c Device carries its device number, name, and PCI metadata and retains
+ * the shared vrtd connection used for device operations.
  *
  * @par Lifetime
- * A @c Device becomes invalid if its originating @c Session is closed or moved.
- * Any subsequent member call will throw.
+ * Moving or destroying the originating @c Session does not invalidate a
+ * Device. Explicitly closing the shared connection does.
  *
  * @par Thread safety
  * Methods are thread-safe and may be called concurrently; they synchronize
- * on the originating @c Session.
+ * on the shared connection.
  */
 class Device {
 public:
+    /** Release this metadata handle and its shared connection reference. */
     ~Device() = default;
 
+    /** Device handles are copyable views of the same shared connection. */
     Device(const Device&)                = default;
     Device& operator=(const Device&)     = default;
+
+    /** Moving transfers the shared connection and cached metadata. */
     Device(Device&&) noexcept            = default;
     Device& operator=(Device&&) noexcept = default;
 
@@ -129,8 +140,7 @@ public:
      * @throws vrtd::Error on error (e.g., invalid index or unusable session).
      *
      * @par Notes
-     * The returned @c Bar becomes invalid if the originating @c Session is
-     * later closed or moved.
+     * The returned @c Bar retains the same shared connection.
      */
     Bar getBar(uint8_t num) const;
 
@@ -146,8 +156,7 @@ public:
      * @throws vrtd::Error on error.
      *
      * @par Notes
-     * The returned @c QdmaQpair becomes invalid if the originating
-     * @c Session is later closed or moved.
+     * The returned @c QdmaQpair retains the same shared connection.
      */
     QdmaQpair createQdmaQpair(const struct slash_qdma_qpair_add& cfg) const;
 
@@ -171,7 +180,13 @@ public:
                       MmChannel mmChannel = MmChannel::Auto) const;
 
     /**
-     * @brief Convenience helper for DDR allocations.
+     * @brief Allocate a DDR buffer through openBuffer().
+     *
+     * @param size Requested byte count.
+     * @param allocDir Permitted transfer direction.
+     * @param mmChannel AXI-MM/NoC channel selection.
+     * @return Owning DDR buffer.
+     * @throws vrtd::Error if allocation fails.
      */
     Buffer openDdrBuffer(uint64_t size, BufferAllocDir allocDir = BufferAllocDir::Bidirectional,
                          MmChannel mmChannel = MmChannel::Auto) const {
@@ -179,7 +194,14 @@ public:
     }
 
     /**
-     * @brief Convenience helper for HBM allocations (fixed region).
+     * @brief Allocate a buffer from one fixed HBM region.
+     *
+     * @param region HBM region index passed as the allocation argument.
+     * @param size Requested byte count.
+     * @param allocDir Permitted transfer direction.
+     * @param mmChannel AXI-MM/NoC channel selection.
+     * @return Owning HBM buffer.
+     * @throws vrtd::Error if the region or allocation is invalid.
      */
     Buffer openHbmBuffer(uint32_t region,
                          uint64_t size,
@@ -189,7 +211,13 @@ public:
     }
 
     /**
-     * @brief Convenience helper for HBM VNOC allocations.
+     * @brief Allocate an HBM buffer using daemon VNOC placement.
+     *
+     * @param size Requested byte count.
+     * @param allocDir Permitted transfer direction.
+     * @param mmChannel AXI-MM/NoC channel selection.
+     * @return Owning HBM VNOC buffer.
+     * @throws vrtd::Error if allocation fails.
      */
     Buffer openHbmVnocBuffer(uint64_t size,
                              BufferAllocDir allocDir = BufferAllocDir::Bidirectional,
@@ -221,7 +249,8 @@ public:
      * For ResetSequence, @p function is ignored. For Remove and Hotplug,
      * @p function selects the PCI physical function (0-7) or
      * HotplugFunctionAll for all V80 PFs. ToggleSbr requires a single PCI
-     * physical function (0-7). Use Session::hotplugRescan() for bus rescan.
+     * physical function (0-7). Rescan is global and ignores this Device and
+     * @p function; prefer Session::hotplugRescan() for that operation.
      *
      * @param op       One of HotplugOp.
      * @param function PCI function number (0-7), or HotplugFunctionAll where allowed.
@@ -231,7 +260,9 @@ public:
 
     /**
      * @brief Convenience helper for remove.
+     *
      * @param function PCI function number (0-7), or HotplugFunctionAll for all PFs.
+     * @throws vrtd::Error if removal fails.
      */
     void hotplugRemove(uint8_t function = HotplugFunctionAll) const {
         hotplugOp(HotplugOp::Remove, function);
@@ -239,7 +270,9 @@ public:
 
     /**
      * @brief Convenience helper for SBR toggle.
+     *
      * @param function PCI function number (0-7). Required.
+     * @throws vrtd::Error if the selector is invalid or the reset fails.
      */
     void hotplugToggleSbr(uint8_t function) const {
         hotplugOp(HotplugOp::ToggleSbr, function);
@@ -247,7 +280,9 @@ public:
 
     /**
      * @brief Convenience helper for a remove+rescan hotplug cycle.
+     *
      * @param function PCI function number (0-7), or HotplugFunctionAll for all PFs.
+     * @throws vrtd::Error if removal or rescan fails.
      */
     void hotplug(uint8_t function = HotplugFunctionAll) const {
         hotplugOp(HotplugOp::Hotplug, function);
@@ -256,8 +291,10 @@ public:
     /**
      * @brief Perform a design writer transfer using an input file descriptor.
      *
-     * The daemon takes ownership of the FD and blocks until the transfer completes.
+     * The call blocks until the daemon finishes the transfer. SCM_RIGHTS
+     * duplicates the descriptor, so the caller retains ownership of @p input_fd.
      *
+     * @param input_fd Readable design image descriptor.
      * @throws vrtd::Error on error.
      */
     void designWrite(int input_fd) const;
@@ -267,6 +304,7 @@ public:
      *
      * Convenience helper that opens the path and passes the FD to the daemon.
      *
+     * @param path Design image opened and closed internally by libvrtd.
      * @throws vrtd::Error on error.
      */
     void designWriteFile(std::string_view path) const;
@@ -278,6 +316,11 @@ public:
      * through AMI, selects that partition for boot, and performs the vrtd-managed
      * reset sequence.
      *
+     * SCM_RIGHTS preserves caller ownership of @p input_fd.
+     *
+     * @param input_fd Readable PDI descriptor.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
      * @throws vrtd::Error on error.
      */
     void cfgmemProgram(int input_fd, uint8_t bootDevice, uint32_t partition) const;
@@ -285,8 +328,12 @@ public:
     /**
      * @brief Program a PDI file into cfgmem.
      *
-     * Convenience helper that opens @p path and passes the FD to the daemon.
+     * Opens @p path, programs @p partition through AMI, selects it for boot,
+     * and performs the vrtd-managed reset sequence.
      *
+     * @param path PDI file opened and closed internally by libvrtd.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
      * @throws vrtd::Error on error.
      */
     void cfgmemProgramFile(std::string_view path, uint8_t bootDevice, uint32_t partition) const;
@@ -300,8 +347,6 @@ public:
      */
     uint32_t getClockRate(ClockRegion region) const;
 
-    // TODO: getClockRateMHz()
-
     /**
      * @brief Set the clock rate for a region.
      *
@@ -313,32 +358,38 @@ public:
     uint32_t setClockRate(ClockRegion region, uint32_t rate_hz) const;
 
     /**
-     * @brief Convenience helper for service region get.
-     * @see getClockRate
+     * @brief Return the service-region clock rate in hertz.
+     *
+     * @throws vrtd::Error if the query fails.
      */
     uint32_t getServiceClockRate() const {
         return getClockRate(ClockRegion::Service);
     }
 
     /**
-     * @brief Convenience helper for service region set.
-     * @see setClockRate
+     * @brief Set the service-region clock and return the achieved hertz value.
+     *
+     * @param rate_hz Requested rate in hertz.
+     * @throws vrtd::Error if the rate cannot be applied.
      */
     uint32_t setServiceClockRate(uint32_t rate_hz) const {
         return setClockRate(ClockRegion::Service, rate_hz);
     }
 
     /**
-     * @brief Convenience helper for user region get.
-     * @see getClockRate
+     * @brief Return the user-region clock rate in hertz.
+     *
+     * @throws vrtd::Error if the query fails.
      */
     uint32_t getUserClockRate() const {
         return getClockRate(ClockRegion::User);
     }
 
     /**
-     * @brief Convenience helper for user region set.
-     * @see setClockRate
+     * @brief Set the user-region clock and return the achieved hertz value.
+     *
+     * @param rate_hz Requested rate in hertz.
+     * @throws vrtd::Error if the rate cannot be applied.
      */
     uint32_t setUserClockRate(uint32_t rate_hz) const {
         return setClockRate(ClockRegion::User, rate_hz);
@@ -355,56 +406,34 @@ public:
      */
     std::vector<SensorEntry> getSensorInfo() const;
 
-
-    // reconfigureUserRegion()
-    // reconfigureServiceRegion()
-    // setUserRegionFrequency()
-    // setServiceRegionFrequency()
-
-
 private:
-    // Only allow the Session class to generate this class
     friend class Session;
-    Device(uint32_t num,
+
+    /**
+     * @brief Construct an owned device metadata snapshot.
+     *
+     * Session supplies a shared connection plus bounded copies of the daemon's
+     * name and PCI identity fields. Derived handles retain the same connection.
+     */
+    Device(std::shared_ptr<detail::Connection> connection,
+           uint32_t num,
            std::string_view name,
            std::string_view bdf,
            uint16_t vendorId,
            uint16_t deviceId,
            uint16_t subsystemVendorId,
-           uint16_t subsystemDeviceId,
-           std::function<Bar(const Device&, uint8_t)> fGetBar,
-           std::function<QdmaQpair(const Device&, const struct slash_qdma_qpair_add&)> fCreateQdmaQpair,
-           std::function<Buffer(const Device&, BufferAllocType, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBuffer,
-           std::function<Buffer(const Device&, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBufferRaw,
-           std::function<void(const Device&, HotplugOp, uint8_t)> fHotplugOp,
-           std::function<void(const Device&, int)> fDesignWrite,
-           std::function<void(const Device&, std::string_view)> fDesignWriteFile,
-           std::function<void(const Device&, int, uint8_t, uint32_t)> fCfgmemProgram,
-           std::function<void(const Device&, std::string_view, uint8_t, uint32_t)> fCfgmemProgramFile,
-           std::function<uint32_t(const Device&, ClockRegion)> fGetClockRate,
-           std::function<uint32_t(const Device&, ClockRegion, uint32_t)> fSetClockRate,
-           std::function<std::vector<SensorEntry>(const Device&)> fGetSensorInfo);
+           uint16_t subsystemDeviceId);
 
-    uint32_t num;
-    std::string name;
-    std::string bdf;
-    uint16_t vendorId = 0;
-    uint16_t deviceId = 0;
-    uint16_t subsystemVendorId = 0;
-    uint16_t subsystemDeviceId = 0;
+    /** Shared transport used by all connection-dependent operations. */
+    std::shared_ptr<detail::Connection> connection;
+    uint32_t num; ///< Zero-based daemon device index.
+    std::string name; ///< Owned human-readable daemon name.
+    std::string bdf; ///< Owned board-level PCI BDF.
+    uint16_t vendorId = 0; ///< PCI vendor identifier.
+    uint16_t deviceId = 0; ///< PCI device identifier.
+    uint16_t subsystemVendorId = 0; ///< PCI subsystem vendor identifier.
+    uint16_t subsystemDeviceId = 0; ///< PCI subsystem device identifier.
 
-    std::function<Bar(const Device&, uint8_t)> fGetBar;
-    std::function<QdmaQpair(const Device&, const struct slash_qdma_qpair_add&)> fCreateQdmaQpair;
-    std::function<Buffer(const Device&, BufferAllocType, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBuffer;
-    std::function<Buffer(const Device&, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBufferRaw;
-    std::function<void(const Device&, HotplugOp, uint8_t)> fHotplugOp;
-    std::function<void(const Device&, int)> fDesignWrite;
-    std::function<void(const Device&, std::string_view)> fDesignWriteFile;
-    std::function<void(const Device&, int, uint8_t, uint32_t)> fCfgmemProgram;
-    std::function<void(const Device&, std::string_view, uint8_t, uint32_t)> fCfgmemProgramFile;
-    std::function<uint32_t(const Device&, ClockRegion)> fGetClockRate;
-    std::function<uint32_t(const Device&, ClockRegion, uint32_t)> fSetClockRate;
-    std::function<std::vector<SensorEntry>(const Device&)> fGetSensorInfo;
 };
 
 }

--- a/vrt/vrtd/libvrtdpp/include/vrtd/error.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/error.hpp
@@ -40,6 +40,7 @@ namespace vrtd {
  */
 class Error : public std::exception {
 private:
+    /** libvrtd result code exposed by getErrorCode() and what(). */
     vrtd_ret errorCode;
 
 public:
@@ -49,8 +50,10 @@ public:
      */
     explicit Error(vrtd_ret errorCode) noexcept;
 
+    /** Destroy the value without owning external resources. */
     ~Error() = default;
 
+    /** Error values preserve their result code across copy and move. */
     Error(const Error&)                = default;
     Error& operator=(const Error&)     = default;
     Error(Error&&) noexcept            = default;
@@ -58,6 +61,8 @@ public:
 
     /**
      * @brief Retrieve the underlying error code.
+     *
+     * @return Exact libvrtd result supplied to the constructor.
      */
     vrtd_ret getErrorCode() const noexcept;
 

--- a/vrt/vrtd/libvrtdpp/include/vrtd/qdma_qpair.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/qdma_qpair.hpp
@@ -22,69 +22,93 @@
 #define VRTD_QDMA_QPAIR_HPP
 
 #include <cstdint>
-#include <functional>
 #include <fstream>
+#include <memory>
 #include <fcntl.h>
 
 namespace vrtd {
+
+namespace detail {
+class Connection;
+}
 
 /**
  * @brief RAII wrapper for a QDMA queue pair (qpair).
  *
  * A @c QdmaQpair owns a qpair created through a @c Session. It provides
- * convenience methods to start/stop the qpair and to obtain a read/write
- * file descriptor. On destruction, it requests deletion of the qpair.
+ * lifecycle methods and access to the ioctl-only QDMA descriptor used for
+ * buffer creation and transfer commands. On destruction, it requests deletion
+ * of the qpair.
  *
- * @warning A @c QdmaQpair becomes invalid if its originating @c Session
- *          is closed or moved; methods will throw in that case. The
- *          destructor never throws and will silently ignore errors when
- *          attempting to delete the qpair.
+ * Moving or destroying the originating @c Session does not invalidate a
+ * QdmaQpair. Explicitly closing the shared connection does. The destructor
+ * never throws and silently ignores errors during best-effort deletion.
  */
 class QdmaQpair {
 public:
+    /**
+     * @brief Best-effort delete the owned queue pair.
+     *
+     * Errors do not escape; daemon disconnect remains the cleanup backstop.
+     */
     ~QdmaQpair();
 
+    /** A daemon queue-pair identity has one RAII owner and cannot be copied. */
     QdmaQpair(const QdmaQpair&)            = delete;
     QdmaQpair& operator=(const QdmaQpair&) = delete;
 
+    /** Transfer queue ownership and leave @p other unowned. */
     QdmaQpair(QdmaQpair&& other) noexcept;
+
+    /**
+     * @brief Best-effort delete the current queue, then adopt @p other.
+     *
+     * The moved-from object becomes unowned.
+     */
     QdmaQpair& operator=(QdmaQpair&& other) noexcept;
 
     /**
-     * @brief Device index owning this qpair.
+     * @brief Return the daemon device index owning this qpair.
      */
     uint32_t getDeviceNum() const noexcept { return devNum; }
 
     /**
-     * @brief Qpair identifier as assigned by the kernel.
+     * @brief Return the kernel-assigned queue identifier.
+     *
+     * Zero is valid for an owned queue and is also the moved-from sentinel.
      */
     uint32_t getQid() const noexcept { return qid; }
 
     /**
      * @brief Start the qpair.
      *
-     * @throws vrtd::Error on error.
+     * @throws vrtd::Error if this object is unowned, the shared connection is
+     *         closed, or the daemon rejects the lifecycle transition.
      */
     void start();
 
     /**
      * @brief Stop the qpair.
      *
-     * @throws vrtd::Error on error.
+     * @throws vrtd::Error if this object is unowned, the shared connection is
+     *         closed, or the daemon rejects the lifecycle transition.
      */
     void stop();
 
     /**
-     * @brief Obtain a read/write file descriptor for this qpair.
+     * @brief Obtain an ioctl-only QDMA descriptor for this qpair.
      *
      * @param flags OR of O_CLOEXEC and 0 (other flags may be rejected).
      * @return New file descriptor owned by the caller.
-     * @throws vrtd::Error on error.
+     * @throws vrtd::Error if unowned, closed, or the request fails.
      */
     int fd(uint32_t flags = O_CLOEXEC);
 
     /**
-     * @brief Obtain a std::fstream bound to this qpair.
+     * @brief Obtain a compatibility stream object bound to this qpair.
+     *
+     * The underlying QDMA endpoint remains ioctl-only; ordinary stream
+     * read/write operations are unsupported even if opening the stream succeeds.
      *
      * @param flags OR of O_CLOEXEC and 0 (other flags may be rejected).
      * @param mode  Standard iostream open mode (defaults to in|out|binary).
@@ -92,7 +116,8 @@ public:
      *
      * @throws vrtd::Error or std::runtime_error on error.
      *
-     * @note Implementation is Linux-specific and relies on @c /proc/self/fd.
+     * @note Linux-specific: opens @c /proc/self/fd/<fd> so the stream receives
+     *       its own descriptor before the temporary daemon-provided FD closes.
      */
     std::fstream fstream(
         uint32_t flags = O_CLOEXEC,
@@ -101,23 +126,24 @@ public:
     );
 
 private:
-    friend class Session;
+    friend class Device;
 
-    QdmaQpair(uint32_t devNum,
-              uint32_t qid,
-              std::function<void(const QdmaQpair&)> fStart,
-              std::function<void(const QdmaQpair&)> fStop,
-              std::function<void(const QdmaQpair&)> fDelete,
-              std::function<int(const QdmaQpair&, uint32_t)> fOpenFd) noexcept;
+    /**
+     * @brief Adopt ownership of a newly created daemon queue pair.
+     *
+     * @param connection Shared connection used for all lifecycle operations.
+     * @param devNum Zero-based owning device index.
+     * @param qid Kernel-assigned queue identifier; zero is valid.
+     */
+    QdmaQpair(std::shared_ptr<detail::Connection> connection,
+              uint32_t devNum,
+              uint32_t qid) noexcept;
 
-    uint32_t devNum{};
-    uint32_t qid{};
-    bool owned{true};
-
-    std::function<void(const QdmaQpair&)>        fStart;
-    std::function<void(const QdmaQpair&)>        fStop;
-    std::function<void(const QdmaQpair&)>        fDelete;
-    std::function<int(const QdmaQpair&, uint32_t)> fOpenFd;
+    /** Shared connection retained through best-effort deletion. */
+    std::shared_ptr<detail::Connection> connection;
+    uint32_t devNum{}; ///< Zero-based owning device index.
+    uint32_t qid{}; ///< Kernel-assigned queue identifier.
+    bool owned{true}; ///< Sole indicator that destruction must delete the queue.
 };
 
 } // namespace vrtd

--- a/vrt/vrtd/libvrtdpp/include/vrtd/session.hpp
+++ b/vrt/vrtd/libvrtdpp/include/vrtd/session.hpp
@@ -30,52 +30,76 @@
 #include <vrtd/qdma_qpair.hpp>
 
 #include <functional>
-#include <mutex>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace vrtd {
 
+namespace detail {
+class Connection;
+}
+
+/**
+ * @brief Lifecycle state of an asynchronous cfgmem programming job.
+ *
+ * Values mirror the libvrtd wire protocol and may be compared directly with
+ * the corresponding @c VRTD_CFGMEM_PROGRAM_STATE_* constants.
+ */
 enum class CfgmemProgramState : uint32_t {
-    Queued = VRTD_CFGMEM_PROGRAM_STATE_QUEUED,
-    Running = VRTD_CFGMEM_PROGRAM_STATE_RUNNING,
-    Done = VRTD_CFGMEM_PROGRAM_STATE_DONE,
-    Failed = VRTD_CFGMEM_PROGRAM_STATE_FAILED,
+    Queued = VRTD_CFGMEM_PROGRAM_STATE_QUEUED,   ///< Waiting for a worker.
+    Running = VRTD_CFGMEM_PROGRAM_STATE_RUNNING, ///< Programming is active.
+    Done = VRTD_CFGMEM_PROGRAM_STATE_DONE,       ///< Completed successfully.
+    Failed = VRTD_CFGMEM_PROGRAM_STATE_FAILED,   ///< Completed with an error.
 };
 
+/**
+ * @brief Current phase of an asynchronous cfgmem programming job.
+ *
+ * The phase identifies the operation presently executing; use
+ * CfgmemProgramState to determine whether the job is terminal.
+ */
 enum class CfgmemProgramPhase : uint32_t {
-    Queued = VRTD_CFGMEM_PROGRAM_PHASE_QUEUED,
-    OpeningAmi = VRTD_CFGMEM_PROGRAM_PHASE_OPENING_AMI,
-    DownloadingPdi = VRTD_CFGMEM_PROGRAM_PHASE_DOWNLOADING_PDI,
-    SelectingPartition = VRTD_CFGMEM_PROGRAM_PHASE_SELECTING_PARTITION,
-    ResetPreparing = VRTD_CFGMEM_PROGRAM_PHASE_RESET_PREPARING,
-    RemovingPcie = VRTD_CFGMEM_PROGRAM_PHASE_REMOVING_PCIE,
-    TogglingSbr = VRTD_CFGMEM_PROGRAM_PHASE_TOGGLING_SBR,
-    RescanningPcie = VRTD_CFGMEM_PROGRAM_PHASE_RESCANNING_PCIE,
-    RediscoveringDevice = VRTD_CFGMEM_PROGRAM_PHASE_REDISCOVERING_DEVICE,
-    Done = VRTD_CFGMEM_PROGRAM_PHASE_DONE,
-    Failed = VRTD_CFGMEM_PROGRAM_PHASE_FAILED,
+    Queued = VRTD_CFGMEM_PROGRAM_PHASE_QUEUED, ///< Waiting for execution.
+    OpeningAmi = VRTD_CFGMEM_PROGRAM_PHASE_OPENING_AMI, ///< Opening AMI.
+    DownloadingPdi = VRTD_CFGMEM_PROGRAM_PHASE_DOWNLOADING_PDI, ///< Writing the PDI.
+    SelectingPartition = VRTD_CFGMEM_PROGRAM_PHASE_SELECTING_PARTITION, ///< Selecting boot.
+    ResetPreparing = VRTD_CFGMEM_PROGRAM_PHASE_RESET_PREPARING, ///< Preparing reset.
+    RemovingPcie = VRTD_CFGMEM_PROGRAM_PHASE_REMOVING_PCIE, ///< Removing PCI functions.
+    TogglingSbr = VRTD_CFGMEM_PROGRAM_PHASE_TOGGLING_SBR, ///< Toggling secondary-bus reset.
+    RescanningPcie = VRTD_CFGMEM_PROGRAM_PHASE_RESCANNING_PCIE, ///< Rescanning PCI.
+    RediscoveringDevice = VRTD_CFGMEM_PROGRAM_PHASE_REDISCOVERING_DEVICE, ///< Reopening the board.
+    Done = VRTD_CFGMEM_PROGRAM_PHASE_DONE, ///< Successful terminal phase.
+    Failed = VRTD_CFGMEM_PROGRAM_PHASE_FAILED, ///< Failed terminal phase.
 };
 
+/** @brief Copied progress snapshot for one cfgmem programming job. */
 struct CfgmemProgramStatus {
-    uint64_t jobId = 0;
-    CfgmemProgramState state = CfgmemProgramState::Queued;
-    CfgmemProgramPhase phase = CfgmemProgramPhase::Queued;
-    uint64_t bytesWritten = 0;
-    uint64_t bytesTotal = 0;
-    uint64_t elapsedMsec = 0;
-    enum vrtd_ret result = VRTD_RET_OK;
+    uint64_t jobId = 0; ///< Daemon-assigned job identifier.
+    CfgmemProgramState state = CfgmemProgramState::Queued; ///< Job lifecycle state.
+    CfgmemProgramPhase phase = CfgmemProgramPhase::Queued; ///< Current operation.
+    uint64_t bytesWritten = 0; ///< PDI bytes written so far.
+    uint64_t bytesTotal = 0; ///< Total PDI byte count.
+    uint64_t elapsedMsec = 0; ///< Elapsed job time in milliseconds.
+    enum vrtd_ret result = VRTD_RET_OK; ///< Result code; meaningful when terminal.
 };
 
+/**
+ * @brief Callback invoked with each observed cfgmem progress snapshot.
+ *
+ * Any observed terminal snapshot is delivered before
+ * cfgmemProgramFileProgress() handles its result. Throwing from the callback
+ * stops local polling but does not cancel the daemon job.
+ */
 using CfgmemProgressCallback = std::function<void(const CfgmemProgramStatus&)>;
 
 /**
- * @brief Owning session/connection to the V Runtime Daemon (vrtd).
+ * @brief Owning session/connection to the VRT Daemon (vrtd).
  *
- * A @c Session wraps a connected libvrtd socket and provides typed, exception-based
- * access to devices and BARs. All public member functions are thread-safe; calls
- * synchronize on an internal @c std::mutex.
+ * A @c Session provides typed, exception-based access to a shared connection
+ * to vrtd. Objects created from the session retain that connection and may
+ * outlive the Session facade.
  *
  * @par Exceptions
  * Most member functions throw #vrtd::Error on failure. The destructor never throws.
@@ -84,9 +108,10 @@ using CfgmemProgressCallback = std::function<void(const CfgmemProgramStatus&)>;
  * - The session is non-copyable and movable.
  * - Moving a session leaves the moved-from object in the closed state
  *   (i.e., @c isClosed()==true and @c operator bool() == false).
- * - **Important:** Any @c Device or @c Bar previously obtained from a session becomes
- *   invalid once that session is closed or moved; subsequent operations on those
- *   objects will throw.
+ * - Moving or destroying the Session facade does not invalidate objects
+ *   previously obtained from it.
+ * - Explicitly calling @c close() closes the shared connection and invalidates
+ *   all objects backed by it.
  */
 class Session {
 public:
@@ -104,10 +129,13 @@ public:
     explicit Session(const char *socket_path = nullptr);
 
     /**
-     * @brief Destructor; closes the session if still open.
+     * @brief Destructor; releases this facade's connection reference.
+     *
+     * The connection closes when its final owning object is destroyed.
      */
     ~Session() noexcept;
 
+    /** A Session facade has unique ownership semantics and cannot be copied. */
     Session(const Session&)            = delete;
     Session& operator=(const Session&) = delete;
 
@@ -123,9 +151,10 @@ public:
     /**
      * @brief Move-assign a session.
      *
-     * Closes any existing connection, then takes ownership from @p other.
+     * Releases this facade's existing connection, then takes ownership from
+     * @p other. Objects using the old connection remain valid.
      * The moved-from session becomes closed.
-    *
+     *
      * @param other The session to move from.
      */
     Session& operator=(Session&& other) noexcept;
@@ -134,9 +163,6 @@ public:
      * @brief Number of devices visible via vrtd.
      * @return Device count.
      * @throws vrtd::Error on error.
-     *
-     * @par Thread safety
-     * Safe for concurrent calls across threads.
      */
     uint32_t getNumDevices() const;
 
@@ -148,14 +174,19 @@ public:
      * @throws vrtd::Error if @p i is out of range or if the session is not usable.
      *
      * @par Notes
-     * The returned @c Device becomes invalid if this session is later closed or moved.
+     * The returned @c Device retains the shared connection. It becomes invalid
+     * only when that connection is explicitly closed.
      */
     Device getDevice(size_t i) const;
 
     /**
      * @brief Retrieve a device handle by PCI BDF string.
      *
-     * @param bdf PCI BDF string (e.g., "0000:65:00.0").
+     * Accepts a board BDF such as @c 0000:65:00 or domainless @c 65:00.
+     * A physical-function suffix is stripped because vrtd indexes whole boards;
+     * stripping emits a warning to stderr.
+     *
+     * @param bdf PCI board BDF, optionally with a domain or function suffix.
      * @return A lightweight @c Device value referring back to this session.
      * @throws vrtd::Error if the device cannot be found or if the session is not usable.
      */
@@ -171,6 +202,19 @@ public:
      */
     void hotplugRescan() const;
 
+    /**
+     * @brief Submit an asynchronous cfgmem programming job from an open FD.
+     *
+     * @p device must originate from this shared connection. The descriptor is
+     * duplicated for the daemon through SCM_RIGHTS and remains caller-owned.
+     *
+     * @param device Device whose configuration memory will be programmed.
+     * @param input_fd Readable PDI descriptor.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @return Daemon-assigned job identifier for cfgmemProgramStatus().
+     * @throws vrtd::Error if ownership validation or submission fails.
+     */
     uint64_t cfgmemProgramStart(
         const Device& device,
         int input_fd,
@@ -178,8 +222,32 @@ public:
         uint32_t partition
     ) const;
 
+    /**
+     * @brief Return the latest snapshot for a cfgmem programming job.
+     *
+     * @param jobId Identifier returned by cfgmemProgramStart().
+     * @return Copied progress and terminal-result fields.
+     * @throws vrtd::Error if the job is unknown, belongs to another client, or
+     *         the request fails.
+     */
     CfgmemProgramStatus cfgmemProgramStatus(uint64_t jobId) const;
 
+    /**
+     * @brief Program a PDI file while reporting asynchronous progress.
+     *
+     * Starts a daemon job, polls it until a terminal state, and invokes
+     * @p progressCallback for every observed snapshot including the terminal
+     * one. A zero polling interval selects the ten-second default. Callback
+     * exceptions stop local polling without cancelling the daemon job.
+     *
+     * @param device Device from this shared connection.
+     * @param path PDI file opened by libvrtd.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @param progressCallback Optional observer invoked outside connection locks.
+     * @param pollIntervalMsec Delay between nonterminal polls in milliseconds.
+     * @throws vrtd::Error on submission, polling, or terminal job failure.
+     */
     void cfgmemProgramFileProgress(
         const Device& device,
         std::string_view path,
@@ -192,9 +260,10 @@ public:
     /**
      * @brief Query QDMA capabilities for a device.
      *
-     * @param device Device for which to query QDMA info.
+     * @param device Device from this shared connection.
      * @return A copy of the QDMA capability struct as reported by the daemon.
-     * @throws vrtd::Error on error.
+     * @throws vrtd::Error if the device belongs to another connection or the
+     *         query fails.
      */
     struct slash_qdma_info getQdmaInfo(const Device& device) const;
 
@@ -202,12 +271,14 @@ public:
      * @brief Explicitly close the session.
      *
      * Idempotent. After closing, @c isClosed()==true and further operations
-     * on this session or on previously obtained @c Device/@c Bar objects will throw.
+     * on this session or on previously obtained connection-backed objects
+     * throw. The call first rejects new work and then waits for active
+     * operations to finish before closing the socket.
      */
     void close() noexcept;
 
     /**
-     * @brief Whether the session is closed.
+     * @brief Return whether this facade has no connection or close has begun.
      */
     bool isClosed() const noexcept;
 
@@ -218,195 +289,14 @@ public:
      */
     explicit operator bool() const noexcept;
 private:
-    int fd;
-    mutable std::unique_ptr<std::mutex> m;
-
     /**
-     * @internal Obtains a BAR for @p device. Called via @c Device::getBar().
+     * @brief Shared connection retained by this facade and all derived handles.
+     *
+     * A null pointer marks a moved-from Session. A non-null connection may
+     * itself be permanently closed.
      */
-    Bar getBar(const Device& device, uint8_t bar_number) const;
+    std::shared_ptr<detail::Connection> connection;
 
-    /**
-     * @internal Opens and mmaps a BAR file. Called via @c Bar::openBarFile().
-     */
-    BarFile openBarFile(const Bar &bar) const;
-
-    /**
-     * @internal Create a QDMA qpair on a device.
-     *
-     * Returns an owning @c QdmaQpair that will automatically delete
-     * the qpair on destruction.
-     *
-     * @param device Device on which to create the qpair.
-     * @param cfg    Qpair configuration parameters. The returned qpair
-     *               exposes @c getQid().
-     * @return An owning @c QdmaQpair.
-     * @throws vrtd::Error on error.
-     */
-    QdmaQpair createQdmaQpair(
-        const Device& device,
-        const struct slash_qdma_qpair_add& cfg
-    ) const;
-
-    /**
-     * @internal Open a buffer (allocation + QDMA qpair).
-     *
-     * @param device    Device on which to allocate.
-     * @param allocType Allocation type.
-     * @param size      Requested size in bytes.
-     * @param allocArg  Allocation argument (HBM region index for HBM).
-     * @param allocDir  QDMA transfer direction.
-     * @param mmChannel AXI-MM/NoC channel selection for the queue pair.
-     * @return An owning @c Buffer.
-     * @throws vrtd::Error on error.
-     */
-    Buffer openBuffer(
-        const Device& device,
-        BufferAllocType allocType,
-        uint64_t size,
-        uint64_t allocArg,
-        BufferAllocDir allocDir,
-        MmChannel mmChannel
-    ) const;
-
-    /**
-     * @internal Open a raw buffer (QDMA qpair at caller-specified device address).
-     *
-     * @param device    Device on which to create the qpair.
-     * @param phys_addr Caller-specified device physical address (bypasses allocator).
-     * @param size      Size in bytes.
-     * @param allocDir  QDMA transfer direction.
-     * @param mmChannel AXI-MM/NoC channel selection for the queue pair.
-     * @return An owning @c Buffer.
-     * @throws vrtd::Error on error.
-     */
-    Buffer openBufferRaw(
-        const Device& device,
-        uint64_t phys_addr,
-        uint64_t size,
-        BufferAllocDir allocDir,
-        MmChannel mmChannel
-    ) const;
-
-    /**
-     * @internal Perform a PCIe hotplug operation.
-     *
-     * For ResetSequence, @p function is ignored. For Remove and Hotplug,
-     * @p function selects the PCI physical function (0-7) or
-     * HotplugFunctionAll for all V80 PFs. ToggleSbr requires a single PCI
-     * physical function (0-7). Use hotplugRescan() for device-independent
-     * bus rescan.
-     *
-     * @param device   Device target.
-     * @param op       One of vrtd::HotplugOp.
-     * @param function PCI function number (0-7), or HotplugFunctionAll where allowed.
-     * @throws vrtd::Error on error.
-     */
-    void hotplugOp(const Device& device, HotplugOp op,
-                   uint8_t function = 0) const;
-
-    /**
-     * @internal Perform a design writer transfer using an input FD.
-     *
-     * @param device   Device owning the design writer.
-     * @param input_fd Input file descriptor to transfer from.
-     * @throws vrtd::Error on error.
-     */
-    void designWrite(const Device& device, int input_fd) const;
-
-    /**
-     * @internal Perform a design writer transfer using a file path.
-     *
-     * @param device Device owning the design writer.
-     * @param path   Input file path to transfer from.
-     * @throws vrtd::Error on error.
-     */
-    void designWriteFile(const Device& device, std::string_view path) const;
-
-    /**
-     * @internal Program a PDI into cfgmem using an input FD.
-     *
-     * @param device     Device to program.
-     * @param input_fd   Input PDI file descriptor.
-     * @param bootDevice AMI boot device selector.
-     * @param partition  Flash partition to program and boot.
-     * @throws vrtd::Error on error.
-     */
-    void cfgmemProgram(
-        const Device& device,
-        int input_fd,
-        uint8_t bootDevice,
-        uint32_t partition
-    ) const;
-
-    /**
-     * @internal Program a PDI into cfgmem using a file path.
-     *
-     * @param device     Device to program.
-     * @param path       Input PDI file path.
-     * @param bootDevice AMI boot device selector.
-     * @param partition  Flash partition to program and boot.
-     * @throws vrtd::Error on error.
-     */
-    void cfgmemProgramFile(
-        const Device& device,
-        std::string_view path,
-        uint8_t bootDevice,
-        uint32_t partition
-    ) const;
-
-    /**
-     * @internal Get clock rate for a region.
-     *
-     * @param device Device owning the clock.
-     * @param region One of vrtd_clock_region.
-     * @return Current rate in Hz.
-     * @throws vrtd::Error on error.
-     */
-    uint32_t getClockRate(const Device& device, ClockRegion region) const;
-
-    /**
-     * @internal Set clock rate for a region.
-     *
-     * @param device Device owning the clock.
-     * @param region One of vrtd_clock_region.
-     * @param rate_hz Requested rate in Hz.
-     * @return Achieved rate in Hz.
-     * @throws vrtd::Error on error.
-     */
-    uint32_t setClockRate(const Device& device, ClockRegion region, uint32_t rate_hz) const;
-
-    /**
-     * @internal Start, stop or delete an existing QDMA qpair.
-     *
-     * Convenience wrappers around the vrtd QDMA queue-op requests, used by
-     * @c QdmaQpair via the callbacks injected by @c createQdmaQpair().
-     *
-     * @throws vrtd::Error on error.
-     */
-    void startQdmaQpair(const Device& device, uint32_t qid) const;
-    void stopQdmaQpair (const Device& device, uint32_t qid) const;
-    void deleteQdmaQpair(const Device& device, uint32_t qid) const;
-
-    /**
-     * @internal Obtain a read/write file descriptor for a QDMA qpair.
-     *
-     * @param device Device owning the qpair.
-     * @param qid    Qpair identifier as returned by @c createQdmaQpair().
-     * @param flags  OR of O_CLOEXEC and 0 (other flags may be rejected).
-     * @return A new file descriptor referring to the qpair, owned by the caller.
-     * @throws vrtd::Error on error.
-     */
-    int openQdmaQpairFd(const Device& device, uint32_t qid, uint32_t flags = 0) const;
-
-    /**
-     * @internal Query sensor information for a device.
-     *
-     * @param device Device to query sensors for.
-     * @return Vector of sensor entries.
-     * @throws vrtd::Error on error.
-     */
-    std::vector<SensorEntry> getSensorInfo(const Device& device) const;
 };
 
 }

--- a/vrt/vrtd/libvrtdpp/src/CMakeLists.txt
+++ b/vrt/vrtd/libvrtdpp/src/CMakeLists.txt
@@ -21,6 +21,7 @@
 add_library(
     libvrtdpp
 
+    ${CMAKE_CURRENT_SOURCE_DIR}/connection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bar_file.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bar.cpp
@@ -48,10 +49,11 @@ set_target_properties(libvrtdpp PROPERTIES
 )
 
 set_target_properties(libvrtdpp PROPERTIES
-  CXX_STANDARD 20
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS YES
 )
+target_compile_features(libvrtdpp PUBLIC cxx_std_17)
 
 target_link_libraries(libvrtdpp PUBLIC libvrtd)
 

--- a/vrt/vrtd/libvrtdpp/src/bar.cpp
+++ b/vrt/vrtd/libvrtdpp/src/bar.cpp
@@ -1,75 +1,95 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
-/**
- * @file bar.cpp
- *
- * Implementation of the vrtd::Bar C++ wrapper.
- *
- * Bar is a lightweight value-type that holds PCI BAR metadata (number,
- * physical start address, length, usable/in-use flags) plus a callback
- * for opening a memory-mapped BarFile.  It is constructed by Session
- * when the user queries device BARs and does not own any kernel
- * resources itself.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include <vrtd/bar.hpp>
 
+#include "connection.hpp"
+
+#include <vrtd/error.hpp>
+
+#include <utility>
+
 namespace vrtd {
 
-Bar::Bar(uint32_t deviceNum, uint8_t num, bool usable, bool inUse, uint64_t startAddress, uint64_t length, std::function<BarFile(const Bar&)> fOpenBarFile) noexcept {
-    this->deviceNum = deviceNum;
-    this->num = num;
-    this->usable = usable;
-    this->inUse = inUse;
-    this->startAddress = startAddress;
-    this->length = length;
-    this->fOpenBarFile = fOpenBarFile;
+/*
+ * Snapshot the daemon's BAR metadata while retaining the shared connection.
+ * The handle can therefore open a mapping after its parent Device or Session
+ * facade has been destroyed.
+ */
+Bar::Bar(std::shared_ptr<detail::Connection> connection,
+         uint32_t deviceNum,
+         uint8_t num,
+         bool usable,
+         bool inUse,
+         uint64_t startAddress,
+         uint64_t length) noexcept
+    : connection(std::move(connection))
+    , deviceNum(deviceNum)
+    , num(num)
+    , usable(usable)
+    , inUse(inUse)
+    , startAddress(startAddress)
+    , length(length)
+{
 }
 
-uint32_t Bar::getDeviceNum() const noexcept {
+uint32_t Bar::getDeviceNum() const noexcept
+{
     return deviceNum;
 }
 
-uint8_t Bar::getNum() const noexcept {
+uint8_t Bar::getNum() const noexcept
+{
     return num;
 }
 
-bool Bar::isUsable() const noexcept {
+bool Bar::isUsable() const noexcept
+{
     return usable;
 }
 
-bool Bar::isInUse() const noexcept {
+bool Bar::isInUse() const noexcept
+{
     return inUse;
 }
 
-uint64_t Bar::getStartAddress() const noexcept {
+uint64_t Bar::getStartAddress() const noexcept
+{
     return startAddress;
 }
 
-uint64_t Bar::getLength() const noexcept {
+uint64_t Bar::getLength() const noexcept
+{
     return length;
 }
 
-BarFile Bar::openBarFile() const {
-    return fOpenBarFile(*this);
+BarFile Bar::openBarFile() const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    return BarFile(connection->openBarFile(deviceNum, num));
 }
 
-}
+} // namespace vrtd

--- a/vrt/vrtd/libvrtdpp/src/bar_file.cpp
+++ b/vrt/vrtd/libvrtdpp/src/bar_file.cpp
@@ -27,37 +27,68 @@
  * It wraps a slash_bar_file (fd + mmap pointer + length) obtained from
  * the daemon, and unmaps/closes on destruction.
  *
- * Move semantics are fully supported; copying is disabled.
+ * Move semantics transfer an idle mapping; copying is disabled.
  */
 
 #include <vrtd/bar_file.hpp>
-
-#include <sys/mman.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <vrtd/vrtd.h>
 
 #include <utility>
 
 namespace vrtd {
 
 BarFile::BarFile(slash_bar_file barFile) noexcept {
+    /* Adopt the mapping and FD exactly as returned by libvrtd. */
     this->barFile = barFile;
 }
 
-BarFile::~BarFile() {
-    close();
+BarFile::~BarFile() noexcept {
+    try {
+        close();
+    } catch (...) {
+        /*
+         * A live access violates the destructor precondition. Destruction cannot
+         * preserve the object or report close()'s error, so release the native
+         * resources as a final backstop despite invalidating the live pointer.
+         */
+        vrtd_close_bar_file(&barFile);
+        closed = true;
+    }
 }
 
-BarFile::BarFile(BarFile&& other) noexcept {
+BarFile::BarFile(BarFile&& other) {
+    /*
+     * A live pointer's callback remains bound to the source object. Refuse to
+     * separate that callback from the mapping it must synchronize.
+     */
+    if (other.reading || other.writing) {
+        throw std::runtime_error("Bar file moved while in memory operation");
+    }
+
+    /* Transfer the idle mapping, then permanently close the source. */
     barFile = std::exchange(other.barFile, {});
     reading = std::exchange(other.reading, false);
     writing = std::exchange(other.writing, false);
     closed  = std::exchange(other.closed, true);
 }
 
-BarFile& BarFile::operator=(BarFile&& other) noexcept {
+BarFile& BarFile::operator=(BarFile&& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    /*
+     * Validate the source before closing the destination so either failure
+     * leaves both objects unchanged.
+     */
+    if (other.reading || other.writing) {
+        throw std::runtime_error("Bar file moved while in memory operation");
+    }
+
+    /* close() rejects a live destination before releasing its resources. */
     close();
 
+    /* Transfer the idle mapping, then permanently close the source. */
     barFile = std::exchange(other.barFile, {});
     reading = std::exchange(other.reading, false);
     writing = std::exchange(other.writing, false);
@@ -72,11 +103,15 @@ void BarFile::close() {
     }
 
     if (reading || writing) {
+        /*
+         * Unmapping here would invalidate a live volatile pointer and prevent
+         * its cleanup callback from ending the native synchronization session.
+         */
         throw std::runtime_error("Bar file closed while in memory operation");
     }
 
-    munmap(barFile.map, barFile.len);
-    ::close(barFile.fd);
+    vrtd_close_bar_file(&barFile);
+    closed = true;
 }
 
 bool BarFile::isClosed() const noexcept {
@@ -96,6 +131,10 @@ volatile void *BarFile::getRawPtr(size_t address) const noexcept {
         return nullptr;
     }
 
+    /*
+     * Raw access can validate only the starting byte. The caller owns access
+     * width and alignment because this API has no element type.
+     */
     if (address >= barFile.len) {
         return nullptr;
     }

--- a/vrt/vrtd/libvrtdpp/src/buffer.cpp
+++ b/vrt/vrtd/libvrtdpp/src/buffer.cpp
@@ -1,52 +1,46 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
-/**
- * @file buffer.cpp
- *
- * Implementation of the vrtd::Buffer C++ wrapper.
- *
- * Buffer provides RAII ownership of a @c vrtd_buffer obtained from the
- * daemon via libvrtd.  It wraps the host-side mmap, the QDMA queue pair
- * fd, and the device-side physical address into a single movable object.
- *
- * Key features:
- *  - Move-only semantics (no copies); destruction calls vrtd_buffer_close().
- *  - @c syncToDevice() / @c syncFromDevice() for DMA transfers.
- *  - @c fstream() opens a std::fstream on the qpair fd via
- *    @c /proc/self/fd/<n>, allowing stream-style I/O on the DMA channel.
- *  - @c releaseFd() transfers qpair fd ownership to the caller.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include <vrtd/buffer.hpp>
+
+#include "connection.hpp"
+
 #include <vrtd/error.hpp>
 #include <vrtd/vrtd.h>
 
 #include <stdexcept>
-#include <string>
 #include <utility>
 
 namespace vrtd {
 
-Buffer::Buffer(struct vrtd_buffer *buffer) noexcept
-    : buffer(buffer)
+/*
+ * The native handle stores the connection's socket FD for daemon cleanup.
+ * Retain the Connection beside it so that descriptor cannot outlive its owner.
+ */
+Buffer::Buffer(std::shared_ptr<detail::Connection> connection,
+               struct vrtd_buffer *buffer) noexcept
+    : connection(std::move(connection))
+    , buffer(buffer)
 {
 }
 
@@ -56,9 +50,9 @@ Buffer::~Buffer()
 }
 
 Buffer::Buffer(Buffer&& other) noexcept
-    : buffer(other.buffer)
+    : connection(std::move(other.connection))
+    , buffer(std::exchange(other.buffer, nullptr))
 {
-    other.buffer = nullptr;
 }
 
 Buffer& Buffer::operator=(Buffer&& other) noexcept
@@ -67,10 +61,13 @@ Buffer& Buffer::operator=(Buffer&& other) noexcept
         return *this;
     }
 
+    /*
+     * Release through the destination's original connection before replacing
+     * it. Moving the connection first would route cleanup to the wrong daemon.
+     */
     close();
-
-    buffer = other.buffer;
-    other.buffer = nullptr;
+    connection = std::move(other.connection);
+    buffer = std::exchange(other.buffer, nullptr);
 
     return *this;
 }
@@ -82,18 +79,16 @@ uint32_t Buffer::getDeviceNum() const noexcept
 
 BufferAllocType Buffer::getAllocType() const noexcept
 {
-    if (buffer == nullptr) {
-        return BufferAllocType::Ddr;
-    }
-    return static_cast<BufferAllocType>(buffer->alloc_type);
+    return buffer
+        ? static_cast<BufferAllocType>(buffer->alloc_type)
+        : BufferAllocType::Ddr;
 }
 
 BufferAllocDir Buffer::getAllocDir() const noexcept
 {
-    if (buffer == nullptr) {
-        return BufferAllocDir::Bidirectional;
-    }
-    return static_cast<BufferAllocDir>(buffer->alloc_dir);
+    return buffer
+        ? static_cast<BufferAllocDir>(buffer->alloc_dir)
+        : BufferAllocDir::Bidirectional;
 }
 
 uint64_t Buffer::getAllocArg() const noexcept
@@ -131,16 +126,28 @@ int Buffer::releaseFd() noexcept
     if (buffer == nullptr) {
         return -1;
     }
-    int ret = buffer->qpair_fd;
-    buffer->qpair_fd = -1;
-    return ret;
+
+    /* The -1 sentinel prevents later RAII cleanup from closing caller-owned FD. */
+    return std::exchange(buffer->qpair_fd, -1);
 }
 
 void Buffer::close() noexcept
 {
-    if (buffer != nullptr) {
-        (void) vrtd_buffer_close(buffer);
-        buffer = nullptr;
+    if (buffer == nullptr) {
+        return;
+    }
+
+    /*
+     * Detach ownership before cleanup so repeated or re-entrant close calls
+     * cannot destroy the same native handle twice.
+     */
+    auto raw = std::exchange(buffer, nullptr);
+
+    if (connection) {
+        connection->closeBuffer(raw);
+    } else {
+        /* A malformed/moved owner can still release its local native state. */
+        (void) vrtd_buffer_destroy(raw);
     }
 }
 
@@ -151,36 +158,37 @@ bool Buffer::isClosed() const noexcept
 
 std::fstream Buffer::fstream(std::ios_base::openmode mode) const
 {
-    (void)mode;
+    /*
+     * Buffer QDMA descriptors are ioctl endpoints, not byte streams. Keep the
+     * compatibility API explicit rather than manufacturing a misleading stream.
+     */
+    (void) mode;
+
     if (isClosed()) {
         throw std::runtime_error("Buffer is closed");
     }
 
-    throw std::runtime_error("Buffer qpair fds are ioctl-only; use syncToDevice/syncFromDevice");
+    throw std::runtime_error(
+        "Buffer qpair fds are ioctl-only; use syncToDevice/syncFromDevice"
+    );
 }
 
 void Buffer::syncToDevice(uint64_t offset, uint64_t size)
 {
-    if (buffer == nullptr) {
+    if (buffer == nullptr || !connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    enum vrtd_ret ret = vrtd_buffer_sync_to_device(buffer, offset, size);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+    connection->syncBufferToDevice(buffer, offset, size);
 }
 
 void Buffer::syncFromDevice(uint64_t offset, uint64_t size)
 {
-    if (buffer == nullptr) {
+    if (buffer == nullptr || !connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    enum vrtd_ret ret = vrtd_buffer_sync_from_device(buffer, offset, size);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+    connection->syncBufferFromDevice(buffer, offset, size);
 }
 
 } // namespace vrtd

--- a/vrt/vrtd/libvrtdpp/src/connection.cpp
+++ b/vrt/vrtd/libvrtdpp/src/connection.cpp
@@ -1,0 +1,565 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "connection.hpp"
+
+#include <vrtd/error.hpp>
+
+#include <string>
+#include <utility>
+
+#include <unistd.h>
+
+namespace vrtd::detail {
+
+namespace {
+
+/**
+ * Translate the C API's return convention into the C++ exception contract.
+ *
+ * @param ret Result returned by a libvrtd operation.
+ * @throws vrtd::Error when @p ret is not VRTD_RET_OK.
+ */
+void throwIfError(enum vrtd_ret ret)
+{
+    if (ret != VRTD_RET_OK) {
+        throw Error(ret);
+    }
+}
+
+} // namespace
+
+Connection::Connection(const char *socketPath)
+    : socketFd(vrtd_connect(socketPath))
+{
+    if (socketFd == -1) {
+        throw Error(VRTD_RET_BAD_CONN);
+    }
+}
+
+Connection::~Connection() noexcept
+{
+    close();
+}
+
+Connection::RequestGuard::RequestGuard(const Connection& connection)
+    : lifecycleLock()
+    , requestLock()
+{
+    /*
+     * Reject known-closed connections before touching either mutex. close()
+     * publishes this state before waiting for active lifecycle readers.
+     */
+    if (connection.closed.load(std::memory_order_acquire)) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    /*
+     * Pin the socket before joining the serialized request stream. Recheck
+     * after each potentially blocking acquisition so a racing close cannot
+     * admit new work while it waits for older operations to drain.
+     */
+    lifecycleLock =
+        std::shared_lock<std::shared_mutex>(connection.lifecycleMutex);
+    if (connection.closed.load(std::memory_order_acquire)) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    requestLock = std::unique_lock<std::mutex>(connection.requestMutex);
+    if (connection.closed.load(std::memory_order_acquire)) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+}
+
+Connection::TransferGuard::TransferGuard(const Connection& connection)
+    : lifecycleLock()
+{
+    /*
+     * Avoid joining the lifecycle gate after close starts, then recheck under
+     * the shared lock to cover a close racing the first observation.
+     */
+    if (connection.closed.load(std::memory_order_acquire)) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    lifecycleLock =
+        std::shared_lock<std::shared_mutex>(connection.lifecycleMutex);
+    if (connection.closed.load(std::memory_order_acquire)) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+}
+
+Connection::RequestGuard Connection::request() const
+{
+    return RequestGuard(*this);
+}
+
+Connection::TransferGuard Connection::transfer() const
+{
+    return TransferGuard(*this);
+}
+
+uint32_t Connection::getNumDevices() const
+{
+    auto guard = request();
+    uint32_t count = 0;
+
+    throwIfError(vrtd_get_num_devices(this->socketFd, &count));
+
+    return count;
+}
+
+vrtd_device_info Connection::getDeviceInfo(uint32_t dev) const
+{
+    auto guard = request();
+    struct vrtd_device_info info = {};
+
+    throwIfError(vrtd_get_device_info(this->socketFd, dev, &info));
+
+    return info;
+}
+
+uint32_t Connection::getDeviceByBdf(std::string_view bdf) const
+{
+    auto guard = request();
+
+    /* The C API requires owned NUL-terminated storage, unlike string_view. */
+    std::string value(bdf);
+    uint32_t dev = 0;
+
+    throwIfError(vrtd_get_device_by_bdf(this->socketFd, value.c_str(), &dev));
+
+    return dev;
+}
+
+slash_ioctl_bar_info Connection::getBarInfo(uint32_t dev, uint8_t bar) const
+{
+    auto guard = request();
+    struct slash_ioctl_bar_info info = {};
+
+    throwIfError(vrtd_get_bar_info(this->socketFd, dev, bar, &info));
+
+    return info;
+}
+
+slash_bar_file Connection::openBarFile(uint32_t dev, uint8_t bar) const
+{
+    auto guard = request();
+    struct slash_bar_file file = {};
+
+    throwIfError(vrtd_open_bar_file(this->socketFd, dev, bar, &file));
+
+    return file;
+}
+
+slash_qdma_info Connection::getQdmaInfo(uint32_t dev) const
+{
+    auto guard = request();
+    struct slash_qdma_info info = {};
+
+    throwIfError(vrtd_qdma_get_info(this->socketFd, dev, &info));
+
+    return info;
+}
+
+uint32_t Connection::createQdmaQpair(
+    uint32_t dev,
+    const struct slash_qdma_qpair_add& cfg
+) const
+{
+    auto guard = request();
+
+    /*
+     * libvrtd writes the allocated QID into its input structure. Preserve the
+     * const C++ contract by giving the C API a private copy.
+     */
+    struct slash_qdma_qpair_add value = cfg;
+
+    throwIfError(vrtd_qdma_qpair_add(this->socketFd, dev, &value));
+
+    return value.qid;
+}
+
+void Connection::startQdmaQpair(uint32_t dev, uint32_t qid) const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_qdma_qpair_start(this->socketFd, dev, qid));
+}
+
+void Connection::stopQdmaQpair(uint32_t dev, uint32_t qid) const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_qdma_qpair_stop(this->socketFd, dev, qid));
+}
+
+void Connection::deleteQdmaQpair(uint32_t dev, uint32_t qid) const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_qdma_qpair_del(this->socketFd, dev, qid));
+}
+
+int Connection::openQdmaQpairFd(
+    uint32_t dev,
+    uint32_t qid,
+    uint32_t flags
+) const
+{
+    auto guard = request();
+    int qpairFd = -1;
+
+    throwIfError(
+        vrtd_qdma_qpair_get_fd(this->socketFd, dev, qid, flags, &qpairFd)
+    );
+
+    return qpairFd;
+}
+
+vrtd_buffer *Connection::openBuffer(
+    uint32_t dev,
+    uint32_t allocType,
+    uint64_t size,
+    uint64_t allocArg,
+    uint32_t allocDir,
+    enum vrtd_mm_channel mmChannel
+) const
+{
+    auto guard = request();
+    struct vrtd_buffer *buffer = nullptr;
+
+    throwIfError(
+        vrtd_buffer_open(
+            this->socketFd,
+            dev,
+            allocType,
+            allocDir,
+            allocArg,
+            size,
+            mmChannel,
+            &buffer
+        )
+    );
+
+    /*
+     * A successful C call must return an adoptable handle. Do not construct a
+     * C++ owner that could neither operate on nor release a null handle.
+     */
+    if (buffer == nullptr) {
+        throw Error(VRTD_RET_INTERNAL_ERROR);
+    }
+
+    return buffer;
+}
+
+vrtd_buffer *Connection::openRawBuffer(
+    uint32_t dev,
+    uint64_t physAddr,
+    uint64_t size,
+    uint32_t allocDir,
+    enum vrtd_mm_channel mmChannel
+) const
+{
+    auto guard = request();
+    struct vrtd_buffer *buffer = nullptr;
+
+    throwIfError(
+        vrtd_buffer_open_raw(
+            this->socketFd,
+            dev,
+            physAddr,
+            size,
+            allocDir,
+            mmChannel,
+            &buffer
+        )
+    );
+
+    /* Treat success without a native handle as a C client invariant failure. */
+    if (buffer == nullptr) {
+        throw Error(VRTD_RET_INTERNAL_ERROR);
+    }
+
+    return buffer;
+}
+
+void Connection::closeBuffer(struct vrtd_buffer *buffer) const noexcept
+{
+    if (buffer == nullptr) {
+        return;
+    }
+
+    /*
+     * Buffer cleanup is a noexcept RAII path. While connected, serialize the
+     * close RPC with other control traffic. After disconnect, destroy only
+     * local state; vrtd already reclaims the client's server-side resources.
+     */
+    try {
+        std::shared_lock<std::shared_mutex> lifecycleLock(lifecycleMutex);
+        if (closed.load(std::memory_order_acquire)) {
+            (void) vrtd_buffer_destroy(buffer);
+            return;
+        }
+
+        std::lock_guard<std::mutex> requestLock(requestMutex);
+        (void) vrtd_buffer_close(buffer);
+    } catch (...) {
+        /* Locking or transport failure must not leak local mappings or FDs. */
+        (void) vrtd_buffer_destroy(buffer);
+    }
+}
+
+void Connection::syncBufferToDevice(
+    struct vrtd_buffer *buffer,
+    uint64_t offset,
+    uint64_t size
+) const
+{
+    auto guard = transfer();
+
+    throwIfError(vrtd_buffer_sync_to_device(buffer, offset, size));
+}
+
+void Connection::syncBufferFromDevice(
+    struct vrtd_buffer *buffer,
+    uint64_t offset,
+    uint64_t size
+) const
+{
+    auto guard = transfer();
+
+    throwIfError(vrtd_buffer_sync_from_device(buffer, offset, size));
+}
+
+void Connection::hotplugOp(
+    uint32_t dev,
+    uint8_t op,
+    uint8_t function
+) const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_device_hotplug_op(this->socketFd, dev, op, function));
+}
+
+void Connection::hotplugRescan() const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_device_hotplug_rescan(this->socketFd));
+}
+
+void Connection::designWrite(uint32_t dev, int inputFd) const
+{
+    auto guard = request();
+
+    throwIfError(vrtd_design_write(this->socketFd, dev, inputFd));
+}
+
+void Connection::designWriteFile(uint32_t dev, std::string_view path) const
+{
+    auto guard = request();
+
+    /* Materialize NUL-terminated storage for the path-based C API. */
+    std::string value(path);
+
+    throwIfError(vrtd_design_write_file(this->socketFd, dev, value.c_str()));
+}
+
+void Connection::cfgmemProgram(
+    uint32_t dev,
+    int inputFd,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    auto guard = request();
+
+    throwIfError(
+        vrtd_cfgmem_program(
+            this->socketFd,
+            dev,
+            inputFd,
+            bootDevice,
+            partition
+        )
+    );
+}
+
+void Connection::cfgmemProgramFile(
+    uint32_t dev,
+    std::string_view path,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    auto guard = request();
+
+    /* Materialize NUL-terminated storage for the path-based C API. */
+    std::string value(path);
+
+    throwIfError(
+        vrtd_cfgmem_program_file(
+            this->socketFd,
+            dev,
+            value.c_str(),
+            bootDevice,
+            partition
+        )
+    );
+}
+
+uint64_t Connection::cfgmemProgramStart(
+    uint32_t dev,
+    int inputFd,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    auto guard = request();
+    uint64_t jobId = 0;
+
+    throwIfError(
+        vrtd_cfgmem_program_start(
+            this->socketFd,
+            dev,
+            inputFd,
+            bootDevice,
+            partition,
+            &jobId
+        )
+    );
+
+    return jobId;
+}
+
+uint64_t Connection::cfgmemProgramFileStart(
+    uint32_t dev,
+    std::string_view path,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    auto guard = request();
+    /* Materialize NUL-terminated storage for the path-based C API. */
+    std::string value(path);
+    uint64_t jobId = 0;
+
+    throwIfError(
+        vrtd_cfgmem_program_file_start(
+            this->socketFd,
+            dev,
+            value.c_str(),
+            bootDevice,
+            partition,
+            &jobId
+        )
+    );
+
+    return jobId;
+}
+
+struct vrtd_cfgmem_program_status Connection::cfgmemProgramStatus(
+    uint64_t jobId
+) const
+{
+    auto guard = request();
+    struct vrtd_cfgmem_program_status status = {};
+
+    throwIfError(vrtd_cfgmem_program_status(this->socketFd, jobId, &status));
+
+    return status;
+}
+
+uint32_t Connection::getClockRate(uint32_t dev, uint32_t region) const
+{
+    auto guard = request();
+    uint32_t rate = 0;
+
+    throwIfError(vrtd_clock_get_rate(this->socketFd, dev, region, &rate));
+
+    return rate;
+}
+
+uint32_t Connection::setClockRate(
+    uint32_t dev,
+    uint32_t region,
+    uint32_t rateHz
+) const
+{
+    auto guard = request();
+    uint32_t achieved = 0;
+
+    throwIfError(
+        vrtd_clock_set_rate(this->socketFd, dev, region, rateHz, &achieved)
+    );
+
+    return achieved;
+}
+
+std::vector<vrtd_sensor_entry> Connection::getSensorInfo(uint32_t dev) const
+{
+    auto guard = request();
+    struct vrtd_sensor_entry entries[VRTD_SENSOR_MAX_ENTRIES] = {};
+    uint32_t count = 0;
+
+    throwIfError(
+        vrtd_get_sensor_info(
+            this->socketFd,
+            dev,
+            entries,
+            VRTD_SENSOR_MAX_ENTRIES,
+            &count
+        )
+    );
+
+    /* The C API bounds count by the supplied fixed-capacity output array. */
+    return {entries, entries + count};
+}
+
+void Connection::close() noexcept
+{
+    /*
+     * Publish closure before waiting for lifecycle readers. This prevents
+     * queued callers from extending the drain indefinitely. The exclusive lock
+     * then guarantees no active operation still uses the descriptor.
+     */
+    if (closed.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+
+    std::unique_lock<std::shared_mutex> lifecycleLock(lifecycleMutex);
+    int fd = std::exchange(socketFd, -1);
+
+    if (fd >= 0) {
+        (void) ::close(fd);
+    }
+}
+
+bool Connection::isClosed() const noexcept
+{
+    return closed.load(std::memory_order_acquire);
+}
+
+} // namespace vrtd::detail

--- a/vrt/vrtd/libvrtdpp/src/connection.hpp
+++ b/vrt/vrtd/libvrtdpp/src/connection.hpp
@@ -1,0 +1,478 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef VRTDPP_CONNECTION_HPP
+#define VRTDPP_CONNECTION_HPP
+
+#include <vrtd/vrtd.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <string_view>
+#include <vector>
+
+namespace vrtd::detail {
+
+/**
+ * @brief Shared owner and serializer for one vrtd client connection.
+ *
+ * Public libvrtdpp handles retain this object so that device resources may
+ * outlive the Session facade that discovered them. Control-plane operations
+ * are serialized because libvrtd performs one synchronous request/response
+ * exchange on the shared socket. Buffer DMA operations use only the lifecycle
+ * gate and may therefore run concurrently on independent buffers.
+ *
+ * Calling close() publishes the permanent closed state before waiting for
+ * active operations to drain. New operations then fail locally while existing
+ * operations retain a valid socket until their lifecycle guards are released.
+ */
+class Connection {
+public:
+    /**
+     * @brief Connect to a vrtd UNIX socket.
+     *
+     * @param socketPath Non-null path passed directly to vrtd_connect().
+     * @throws vrtd::Error with VRTD_RET_BAD_CONN if the connection fails.
+     */
+    explicit Connection(const char *socketPath);
+
+    /**
+     * @brief Close the socket when the final shared owner is destroyed.
+     *
+     * Destruction is idempotent and never throws.
+     */
+    ~Connection() noexcept;
+
+    /** Connection state and synchronization primitives cannot be copied. */
+    Connection(const Connection&) = delete;
+    Connection& operator=(const Connection&) = delete;
+
+    /** A live connection has a stable address and cannot be moved. */
+    Connection(Connection&&) = delete;
+    Connection& operator=(Connection&&) = delete;
+
+    /** Return the visible device count; throw vrtd::Error on request failure. */
+    uint32_t getNumDevices() const;
+
+    /** Return copied name and PCI metadata for zero-based device @p dev. */
+    struct vrtd_device_info getDeviceInfo(uint32_t dev) const;
+
+    /**
+     * @brief Resolve a canonical PCI BDF to a daemon device index.
+     *
+     * @param bdf Board-level PCI BDF accepted by vrtd.
+     * @return Zero-based daemon device index.
+     * @throws vrtd::Error if no matching device exists or the request fails.
+     */
+    uint32_t getDeviceByBdf(std::string_view bdf) const;
+
+    /** Return copied metadata for BAR @p bar on zero-based device @p dev. */
+    struct slash_ioctl_bar_info getBarInfo(uint32_t dev, uint8_t bar) const;
+
+    /**
+     * @brief Open and map a device BAR.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param bar Zero-based PCI BAR index.
+     * @return Owning mapping value that must be adopted by BarFile or released
+     *         with vrtd_close_bar_file().
+     * @throws vrtd::Error if the BAR cannot be opened or mapped.
+     */
+    struct slash_bar_file openBarFile(uint32_t dev, uint8_t bar) const;
+
+    /** Return copied QDMA capabilities for zero-based device @p dev. */
+    struct slash_qdma_info getQdmaInfo(uint32_t dev) const;
+
+    /**
+     * @brief Create a QDMA queue pair without modifying caller-owned input.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param cfg Queue configuration copied into the protocol request.
+     * @return Kernel-assigned queue-pair identifier.
+     * @throws vrtd::Error if creation fails.
+     */
+    uint32_t createQdmaQpair(
+        uint32_t dev,
+        const struct slash_qdma_qpair_add& cfg
+    ) const;
+
+    /** Start queue pair @p qid on device @p dev. */
+    void startQdmaQpair(uint32_t dev, uint32_t qid) const;
+
+    /** Stop queue pair @p qid on device @p dev. */
+    void stopQdmaQpair(uint32_t dev, uint32_t qid) const;
+
+    /**
+     * @brief Delete queue pair @p qid on device @p dev.
+     *
+     * The kernel implicitly stops an active queue before releasing it.
+     * @throws vrtd::Error if deletion fails.
+     */
+    void deleteQdmaQpair(uint32_t dev, uint32_t qid) const;
+
+    /**
+     * @brief Obtain a new ioctl-only descriptor for a queue pair.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param qid Existing queue-pair identifier.
+     * @param flags Zero or O_CLOEXEC; other flags may be rejected.
+     * @return New descriptor owned by the caller.
+     * @throws vrtd::Error if the descriptor cannot be obtained.
+     */
+    int openQdmaQpairFd(uint32_t dev, uint32_t qid, uint32_t flags) const;
+
+    /**
+     * @brief Allocate a daemon-managed device buffer and DMA resources.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param allocType One of the vrtd allocation-type wire values.
+     * @param size Requested byte count; the returned handle records any
+     *             allocator rounding.
+     * @param allocArg Allocation-type-specific argument, such as an HBM region.
+     * @param allocDir Permitted DMA transfer direction.
+     * @param mmChannel AXI-MM/NoC channel selection.
+     * @return Exclusively owned native handle that must be passed to
+     *         closeBuffer().
+     * @throws vrtd::Error if allocation or local handle creation fails.
+     */
+    struct vrtd_buffer *openBuffer(
+        uint32_t dev,
+        uint32_t allocType,
+        uint64_t size,
+        uint64_t allocArg,
+        uint32_t allocDir,
+        enum vrtd_mm_channel mmChannel
+    ) const;
+
+    /**
+     * @brief Open DMA resources for a caller-selected device address.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param physAddr Device physical address; the caller must ensure the range
+     *                 is valid and does not conflict with another allocation.
+     * @param size Byte count covered by the raw handle.
+     * @param allocDir Permitted DMA transfer direction.
+     * @param mmChannel AXI-MM/NoC channel selection.
+     * @return Exclusively owned native handle that must be passed to
+     *         closeBuffer().
+     * @throws vrtd::Error on permission, validation, or resource failure.
+     */
+    struct vrtd_buffer *openRawBuffer(
+        uint32_t dev,
+        uint64_t physAddr,
+        uint64_t size,
+        uint32_t allocDir,
+        enum vrtd_mm_channel mmChannel
+    ) const;
+
+    /**
+     * @brief Best-effort release of a native buffer handle.
+     *
+     * Sends daemon-side cleanup while the connection is open. Once the
+     * connection is closed, or if cleanup machinery fails, it releases only
+     * local mappings and descriptors because vrtd reclaims client resources on
+     * disconnect. A null handle is a no-op and no errors escape.
+     *
+     * @param buffer Exclusively owned native handle to consume.
+     */
+    void closeBuffer(struct vrtd_buffer *buffer) const noexcept;
+
+    /**
+     * @brief Transfer a host-buffer range to the device.
+     *
+     * @param buffer Open native buffer permitting host-to-device transfer.
+     * @param offset First byte in the host mapping.
+     * @param size Number of bytes to transfer.
+     * @throws vrtd::Error for a closed connection, invalid range or direction,
+     *         or DMA failure.
+     */
+    void syncBufferToDevice(
+        struct vrtd_buffer *buffer,
+        uint64_t offset,
+        uint64_t size
+    ) const;
+
+    /**
+     * @brief Transfer a device-buffer range into its host mapping.
+     *
+     * @param buffer Open native buffer permitting device-to-host transfer.
+     * @param offset First byte in the host mapping.
+     * @param size Number of bytes to transfer.
+     * @throws vrtd::Error for a closed connection, invalid range or direction,
+     *         or DMA failure.
+     */
+    void syncBufferFromDevice(
+        struct vrtd_buffer *buffer,
+        uint64_t offset,
+        uint64_t size
+    ) const;
+
+    /**
+     * @brief Apply a PCIe hotplug operation to a device or physical function.
+     *
+     * Rescan is global and ignores @p dev and @p function. Reset ignores
+     * @p function. Remove and hotplug accept PF 0-7 or the all-functions
+     * sentinel; SBR requires one PF.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param op One of the vrtd hotplug-operation wire values.
+     * @param function Physical function selector or all-functions sentinel.
+     * @throws vrtd::Error if the operation or selector is invalid or fails.
+     */
+    void hotplugOp(uint32_t dev, uint8_t op, uint8_t function) const;
+
+    /**
+     * @brief Trigger a global PCI bus rescan.
+     *
+     * Device availability and daemon indices may change after this operation.
+     * @throws vrtd::Error if the rescan request fails.
+     */
+    void hotplugRescan() const;
+
+    /**
+     * @brief Synchronously program the device design from an open descriptor.
+     *
+     * SCM_RIGHTS duplicates @p inputFd for the daemon; ownership of the
+     * caller's descriptor is unchanged.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param inputFd Readable design image descriptor.
+     * @throws vrtd::Error if the transfer fails or another transfer is busy.
+     */
+    void designWrite(uint32_t dev, int inputFd) const;
+
+    /**
+     * @brief Synchronously program the device design from a file path.
+     *
+     * libvrtd opens and closes the file internally.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param path Design image path.
+     * @throws vrtd::Error if the file or design transfer fails.
+     */
+    void designWriteFile(uint32_t dev, std::string_view path) const;
+    /**
+     * @brief Synchronously program cfgmem and perform the managed reset.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param inputFd Readable PDI descriptor. SCM_RIGHTS preserves caller
+     *                ownership of the original descriptor.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @throws vrtd::Error if programming or reset fails.
+     */
+    void cfgmemProgram(
+        uint32_t dev,
+        int inputFd,
+        uint8_t bootDevice,
+        uint32_t partition
+    ) const;
+
+    /**
+     * @brief Synchronously program cfgmem from a path and reset the device.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param path PDI path opened and closed internally by libvrtd.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @throws vrtd::Error if the file, programming, or reset operation fails.
+     */
+    void cfgmemProgramFile(
+        uint32_t dev,
+        std::string_view path,
+        uint8_t bootDevice,
+        uint32_t partition
+    ) const;
+
+    /**
+     * @brief Submit an asynchronous cfgmem programming job.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param inputFd Readable PDI descriptor. SCM_RIGHTS preserves caller
+     *                ownership of the original descriptor.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @return Daemon-assigned job identifier for cfgmemProgramStatus().
+     * @throws vrtd::Error if the job cannot be submitted.
+     */
+    uint64_t cfgmemProgramStart(
+        uint32_t dev,
+        int inputFd,
+        uint8_t bootDevice,
+        uint32_t partition
+    ) const;
+
+    /**
+     * @brief Submit an asynchronous cfgmem job from a file path.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param path PDI path opened and closed internally by libvrtd.
+     * @param bootDevice AMI boot-device selector.
+     * @param partition Flash partition to program and select.
+     * @return Daemon-assigned job identifier for cfgmemProgramStatus().
+     * @throws vrtd::Error if the file cannot be opened or submission fails.
+     */
+    uint64_t cfgmemProgramFileStart(
+        uint32_t dev,
+        std::string_view path,
+        uint8_t bootDevice,
+        uint32_t partition
+    ) const;
+
+    /**
+     * @brief Return the latest status snapshot for a cfgmem job.
+     *
+     * @param jobId Identifier returned by a cfgmem start operation.
+     * @return Copied progress, phase, timing, and final-result fields.
+     * @throws vrtd::Error if the job is unknown, belongs to another client, or
+     *         the request fails.
+     */
+    struct vrtd_cfgmem_program_status cfgmemProgramStatus(
+        uint64_t jobId
+    ) const;
+
+    /** Return clock @p region for zero-based device @p dev in hertz. */
+    uint32_t getClockRate(uint32_t dev, uint32_t region) const;
+
+    /**
+     * @brief Request a clock rate and return the achieved value.
+     *
+     * Hardware quantization may make the achieved rate differ from @p rateHz.
+     *
+     * @param dev Zero-based daemon device index.
+     * @param region One of the vrtd clock-region wire values.
+     * @param rateHz Requested rate in hertz.
+     * @return Achieved rate in hertz.
+     * @throws vrtd::Error if the region, rate, or operation is invalid.
+     */
+    uint32_t setClockRate(
+        uint32_t dev,
+        uint32_t region,
+        uint32_t rateHz
+    ) const;
+
+    /**
+     * @brief Return a copied snapshot of all sensors reported for a device.
+     *
+     * Each entry carries a fixed-width name plus raw type, status, unit
+     * exponent, and value fields.
+     *
+     * @param dev Zero-based daemon device index.
+     * @return Variable-length copied sensor snapshot.
+     * @throws vrtd::Error if the sensor query fails.
+     */
+    std::vector<struct vrtd_sensor_entry> getSensorInfo(uint32_t dev) const;
+
+    /**
+     * @brief Permanently close the shared connection.
+     *
+     * The operation first rejects new work, then waits for active operations
+     * before closing the socket. Repeated calls are no-ops and no errors escape.
+     */
+    void close() noexcept;
+
+    /** Return whether close has begun or completed. */
+    bool isClosed() const noexcept;
+
+private:
+    /**
+     * @brief Pins the socket lifetime and serializes one protocol exchange.
+     *
+     * The lifecycle lock is acquired before the request lock. The connection
+     * socket remains open until this guard is destroyed, and no second caller
+     * can interleave a request/response pair on it.
+     */
+    class RequestGuard {
+    public:
+        /**
+         * @brief Acquire a guard or reject a concurrent close.
+         *
+         * Closed-state checks around both lock acquisitions prevent work from
+         * joining after close has published the terminal state.
+         *
+         * @throws vrtd::Error with VRTD_RET_BAD_LIB_CALL when closing or closed.
+         */
+        explicit RequestGuard(const Connection& connection);
+
+    private:
+        /** Shared lifecycle ownership that prevents socket teardown. */
+        std::shared_lock<std::shared_mutex> lifecycleLock;
+
+        /** Exclusive ownership of the synchronous request/response stream. */
+        std::unique_lock<std::mutex> requestLock;
+    };
+
+    /**
+     * @brief Pins the connection lifetime for one buffer DMA transfer.
+     *
+     * Unlike RequestGuard, this guard does not serialize operations. Independent
+     * buffers may therefore transfer concurrently while close() waits for all
+     * active transfers to release their shared lifecycle locks.
+     */
+    class TransferGuard {
+    public:
+        /**
+         * @brief Acquire a transfer guard or reject a concurrent close.
+         *
+         * @throws vrtd::Error with VRTD_RET_BAD_LIB_CALL when closing or closed.
+         */
+        explicit TransferGuard(const Connection& connection);
+
+    private:
+        /** Shared lifecycle ownership that prevents connection teardown. */
+        std::shared_lock<std::shared_mutex> lifecycleLock;
+    };
+
+    /**
+     * @brief Acquire a serialized request guard.
+     *
+     * @throws vrtd::Error with VRTD_RET_BAD_LIB_CALL when closing or closed.
+     */
+    RequestGuard request() const;
+
+    /**
+     * @brief Acquire a concurrent buffer-transfer guard.
+     *
+     * @throws vrtd::Error with VRTD_RET_BAD_LIB_CALL when closing or closed.
+     */
+    TransferGuard transfer() const;
+
+    /** Shared by active operations and held exclusively by close(). */
+    mutable std::shared_mutex lifecycleMutex;
+
+    /** Prevents interleaved request/response pairs on the shared socket. */
+    mutable std::mutex requestMutex;
+
+    /** One-way state flag set before close waits for active operations. */
+    std::atomic<bool> closed{false};
+
+    /** Owned daemon socket, or -1 after exclusive teardown. */
+    int socketFd{-1};
+};
+
+} // namespace vrtd::detail
+
+#endif // VRTDPP_CONNECTION_HPP

--- a/vrt/vrtd/libvrtdpp/src/device.cpp
+++ b/vrt/vrtd/libvrtdpp/src/device.cpp
@@ -1,148 +1,275 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include <vrtd/device.hpp>
 
+#include "connection.hpp"
+
+#include <vrtd/error.hpp>
+
+#include <string.h>
+
+#include <utility>
+
 namespace vrtd {
 
-Device::Device(uint32_t num,
+/*
+ * Keep metadata independent of daemon-owned wire storage while retaining the
+ * transport needed to create child resource handles.
+ */
+Device::Device(std::shared_ptr<detail::Connection> connection,
+               uint32_t num,
                std::string_view name,
                std::string_view bdf,
                uint16_t vendorId,
                uint16_t deviceId,
                uint16_t subsystemVendorId,
-               uint16_t subsystemDeviceId,
-               std::function<Bar(const Device&, uint8_t)> fGetBar,
-               std::function<QdmaQpair(const Device&, const struct slash_qdma_qpair_add&)> fCreateQdmaQpair,
-               std::function<Buffer(const Device&, BufferAllocType, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBuffer,
-               std::function<Buffer(const Device&, uint64_t, uint64_t, BufferAllocDir, MmChannel)> fOpenBufferRaw,
-               std::function<void(const Device&, HotplugOp, uint8_t)> fHotplugOp,
-               std::function<void(const Device&, int)> fDesignWrite,
-               std::function<void(const Device&, std::string_view)> fDesignWriteFile,
-               std::function<void(const Device&, int, uint8_t, uint32_t)> fCfgmemProgram,
-               std::function<void(const Device&, std::string_view, uint8_t, uint32_t)> fCfgmemProgramFile,
-               std::function<uint32_t(const Device&, ClockRegion)> fGetClockRate,
-               std::function<uint32_t(const Device&, ClockRegion, uint32_t)> fSetClockRate,
-               std::function<std::vector<SensorEntry>(const Device&)> fGetSensorInfo) {
-    this->num = num;
-    this->name = name;
-    this->bdf = bdf;
-    this->vendorId = vendorId;
-    this->deviceId = deviceId;
-    this->subsystemVendorId = subsystemVendorId;
-    this->subsystemDeviceId = subsystemDeviceId;
-    this->fGetBar = fGetBar;
-    this->fCreateQdmaQpair = fCreateQdmaQpair;
-    this->fOpenBuffer = fOpenBuffer;
-    this->fOpenBufferRaw = fOpenBufferRaw;
-    this->fHotplugOp = fHotplugOp;
-    this->fDesignWrite = fDesignWrite;
-    this->fDesignWriteFile = fDesignWriteFile;
-    this->fCfgmemProgram = fCfgmemProgram;
-    this->fCfgmemProgramFile = fCfgmemProgramFile;
-    this->fGetClockRate = fGetClockRate;
-    this->fSetClockRate = fSetClockRate;
-    this->fGetSensorInfo = fGetSensorInfo;
+               uint16_t subsystemDeviceId)
+    : connection(std::move(connection))
+    , num(num)
+    , name(name)
+    , bdf(bdf)
+    , vendorId(vendorId)
+    , deviceId(deviceId)
+    , subsystemVendorId(subsystemVendorId)
+    , subsystemDeviceId(subsystemDeviceId)
+{
 }
 
-uint32_t Device::getNum() const noexcept {
+uint32_t Device::getNum() const noexcept
+{
     return num;
 }
 
-const std::string& Device::getName() const noexcept {
+const std::string& Device::getName() const noexcept
+{
     return name;
 }
 
-const std::string& Device::getBdf() const noexcept {
+const std::string& Device::getBdf() const noexcept
+{
     return bdf;
 }
 
-uint16_t Device::getVendorId() const noexcept {
+uint16_t Device::getVendorId() const noexcept
+{
     return vendorId;
 }
 
-uint16_t Device::getDeviceId() const noexcept {
+uint16_t Device::getDeviceId() const noexcept
+{
     return deviceId;
 }
 
-uint16_t Device::getSubsystemVendorId() const noexcept {
+uint16_t Device::getSubsystemVendorId() const noexcept
+{
     return subsystemVendorId;
 }
 
-uint16_t Device::getSubsystemDeviceId() const noexcept {
+uint16_t Device::getSubsystemDeviceId() const noexcept
+{
     return subsystemDeviceId;
 }
 
-Bar Device::getBar(uint8_t num) const {
-    return fGetBar(*this, num);
+Bar Device::getBar(uint8_t bar) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    auto info = connection->getBarInfo(num, bar);
+    return Bar(
+        connection,
+        num,
+        bar,
+        info.usable,
+        info.in_use,
+        info.start_address,
+        info.length
+    );
 }
 
-QdmaQpair Device::createQdmaQpair(const struct slash_qdma_qpair_add& cfg) const {
-    return fCreateQdmaQpair(*this, cfg);
+QdmaQpair Device::createQdmaQpair(
+    const struct slash_qdma_qpair_add& cfg
+) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    return QdmaQpair(connection, num, connection->createQdmaQpair(num, cfg));
 }
 
-Buffer Device::openBuffer(BufferAllocType allocType,
-                          uint64_t size,
-                          uint64_t allocArg,
-                          BufferAllocDir allocDir,
-                          MmChannel mmChannel) const {
-    return fOpenBuffer(*this, allocType, size, allocArg, allocDir, mmChannel);
+Buffer Device::openBuffer(
+    BufferAllocType allocType,
+    uint64_t size,
+    uint64_t allocArg,
+    BufferAllocDir allocDir,
+    MmChannel mmChannel
+) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    auto raw = connection->openBuffer(
+        num,
+        static_cast<uint32_t>(allocType),
+        size,
+        allocArg,
+        static_cast<uint32_t>(allocDir),
+        static_cast<vrtd_mm_channel>(static_cast<uint32_t>(mmChannel))
+    );
+
+    return Buffer(connection, raw);
 }
 
-Buffer Device::openRawBuffer(uint64_t phys_addr,
-                             uint64_t size,
-                             BufferAllocDir allocDir,
-                             MmChannel mmChannel) const {
-    return fOpenBufferRaw(*this, phys_addr, size, allocDir, mmChannel);
+Buffer Device::openRawBuffer(
+    uint64_t physAddr,
+    uint64_t size,
+    BufferAllocDir allocDir,
+    MmChannel mmChannel
+) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    auto raw = connection->openRawBuffer(
+        num,
+        physAddr,
+        size,
+        static_cast<uint32_t>(allocDir),
+        static_cast<vrtd_mm_channel>(static_cast<uint32_t>(mmChannel))
+    );
+
+    return Buffer(connection, raw);
 }
 
-void Device::hotplugOp(HotplugOp op, uint8_t function) const {
-    fHotplugOp(*this, op, function);
+void Device::hotplugOp(HotplugOp op, uint8_t function) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    connection->hotplugOp(num, static_cast<uint8_t>(op), function);
 }
 
-void Device::designWrite(int input_fd) const {
-    fDesignWrite(*this, input_fd);
+void Device::designWrite(int inputFd) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    connection->designWrite(num, inputFd);
 }
 
-void Device::designWriteFile(std::string_view path) const {
-    fDesignWriteFile(*this, path);
+void Device::designWriteFile(std::string_view path) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    connection->designWriteFile(num, path);
 }
 
-void Device::cfgmemProgram(int input_fd, uint8_t bootDevice, uint32_t partition) const {
-    fCfgmemProgram(*this, input_fd, bootDevice, partition);
+void Device::cfgmemProgram(
+    int inputFd,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    connection->cfgmemProgram(num, inputFd, bootDevice, partition);
 }
 
-void Device::cfgmemProgramFile(std::string_view path, uint8_t bootDevice, uint32_t partition) const {
-    fCfgmemProgramFile(*this, path, bootDevice, partition);
+void Device::cfgmemProgramFile(
+    std::string_view path,
+    uint8_t bootDevice,
+    uint32_t partition
+) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    connection->cfgmemProgramFile(num, path, bootDevice, partition);
 }
 
-uint32_t Device::getClockRate(ClockRegion region) const {
-    return fGetClockRate(*this, region);
+uint32_t Device::getClockRate(ClockRegion region) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    return connection->getClockRate(num, static_cast<uint32_t>(region));
 }
 
-uint32_t Device::setClockRate(ClockRegion region, uint32_t rate_hz) const {
-    return fSetClockRate(*this, region, rate_hz);
+uint32_t Device::setClockRate(ClockRegion region, uint32_t rateHz) const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    return connection->setClockRate(
+        num,
+        static_cast<uint32_t>(region),
+        rateHz
+    );
 }
 
-std::vector<SensorEntry> Device::getSensorInfo() const {
-    return fGetSensorInfo(*this);
+std::vector<SensorEntry> Device::getSensorInfo() const
+{
+    if (!connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
+    }
+
+    auto raw = connection->getSensorInfo(num);
+
+    std::vector<SensorEntry> result;
+    result.reserve(raw.size());
+
+    /*
+     * Convert fixed-width C ABI entries into owning C++ values. Sensor names
+     * are bounded because daemon-provided arrays need not be NUL-terminated.
+     */
+    for (const auto& entry : raw) {
+        result.push_back(SensorEntry{
+            std::string(
+                entry.name,
+                strnlen(entry.name, sizeof(entry.name))
+            ),
+            entry.type,
+            entry.status,
+            entry.unit_mod,
+            entry.value
+        });
+    }
+
+    return result;
 }
 
-}
+} // namespace vrtd

--- a/vrt/vrtd/libvrtdpp/src/error.cpp
+++ b/vrt/vrtd/libvrtdpp/src/error.cpp
@@ -41,6 +41,10 @@ vrtd_ret Error::getErrorCode() const noexcept {
 }
 
 const char *Error::what() const noexcept {
+    /*
+     * Return static storage for every protocol error so diagnostics remain
+     * allocation-free and safe from noexcept exception paths.
+     */
     switch (errorCode) {
     case VRTD_RET_BAD_LIB_CALL:
         return "Bad library call";
@@ -55,7 +59,7 @@ const char *Error::what() const noexcept {
         return "Invalid argument";
 
     case VRTD_RET_NOEXIST:
-        return "Requested resouce doesn't exist";
+        return "Requested resource doesn't exist";
 
     case VRTD_RET_INTERNAL_ERROR:
         return "Internal error in vrtd daemon or local libvrtd";
@@ -63,7 +67,11 @@ const char *Error::what() const noexcept {
     case VRTD_RET_AUTH_ERROR:
         return "Missing permission";
 
+    case VRTD_RET_BUSY:
+        return "Resource busy";
+
     default:
+        /* Covers accidental success values and future protocol extensions. */
         return "Unknown error";
     }
 }

--- a/vrt/vrtd/libvrtdpp/src/qdma_qpair.cpp
+++ b/vrt/vrtd/libvrtdpp/src/qdma_qpair.cpp
@@ -1,89 +1,79 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
-/**
- * @file qdma_qpair.cpp
- *
- * Implementation of the vrtd::QdmaQpair C++ wrapper.
- *
- * QdmaQpair manages the lifecycle of a QDMA queue pair obtained from
- * the vrtd daemon.  It uses the **callback injection** pattern: the
- * Session that creates the QdmaQpair provides start/stop/delete/openFd
- * callbacks that issue the appropriate wire protocol requests.  This
- * keeps QdmaQpair decoupled from Session while still enabling RAII
- * cleanup (stop + delete on destruction).
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include <vrtd/qdma_qpair.hpp>
 
-#include <utility>
+#include "connection.hpp"
+
+#include <vrtd/error.hpp>
+
 #include <stdexcept>
 #include <string>
+#include <utility>
+
 #include <unistd.h>
 
 namespace vrtd {
 
-QdmaQpair::QdmaQpair(uint32_t devNum,
-                     uint32_t qid,
-                     std::function<void(const QdmaQpair&)> fStart,
-                     std::function<void(const QdmaQpair&)> fStop,
-                     std::function<void(const QdmaQpair&)> fDelete,
-                     std::function<int(const QdmaQpair&, uint32_t)> fOpenFd) noexcept
-    : devNum(devNum)
+/*
+ * Device creates this wrapper only after the daemon allocates the queue. The
+ * owned flag, not the numeric QID, controls exactly-once deletion because zero
+ * is a valid kernel-assigned identifier.
+ */
+QdmaQpair::QdmaQpair(std::shared_ptr<detail::Connection> connection,
+                     uint32_t devNum,
+                     uint32_t qid) noexcept
+    : connection(std::move(connection))
+    , devNum(devNum)
     , qid(qid)
     , owned(true)
-    , fStart(std::move(fStart))
-    , fStop(std::move(fStop))
-    , fDelete(std::move(fDelete))
-    , fOpenFd(std::move(fOpenFd))
 {
 }
 
 QdmaQpair::~QdmaQpair()
 {
-    if (!owned) {
-        return;
-    }
-
-    if (!fDelete || qid == 0) {
+    if (!owned || !connection) {
         return;
     }
 
     try {
-        fDelete(*this);
+        connection->deleteQdmaQpair(devNum, qid);
     } catch (...) {
-        // Destructors must not throw; ignore errors on best-effort delete.
+        // Destructors must not throw; daemon disconnect also releases qpairs.
     }
 }
 
 QdmaQpair::QdmaQpair(QdmaQpair&& other) noexcept
-    : devNum(other.devNum)
+    : connection(std::move(other.connection))
+    , devNum(other.devNum)
     , qid(other.qid)
-    , owned(other.owned)
-    , fStart(std::move(other.fStart))
-    , fStop(std::move(other.fStop))
-    , fDelete(std::move(other.fDelete))
-    , fOpenFd(std::move(other.fOpenFd))
+    , owned(std::exchange(other.owned, false))
 {
-    other.owned = false;
-    other.qid   = 0;
+    /*
+     * Transfer deletion responsibility through owned rather than inferring it
+     * from qid: queue identifier zero is valid.
+     */
+    other.qid = 0;
 }
 
 QdmaQpair& QdmaQpair::operator=(QdmaQpair&& other) noexcept
@@ -92,75 +82,84 @@ QdmaQpair& QdmaQpair::operator=(QdmaQpair&& other) noexcept
         return *this;
     }
 
-    // Drop current ownership (best-effort delete in destructor semantics)
-    if (owned && fDelete && qid != 0) {
+    if (owned && connection) {
         try {
-            fDelete(*this);
+            connection->deleteQdmaQpair(devNum, qid);
         } catch (...) {
-            // ignore
+            /*
+             * Preserve noexcept move assignment. If deletion failed because
+             * the connection closed, vrtd releases the queue on disconnect.
+             */
         }
     }
 
+    connection = std::move(other.connection);
     devNum = other.devNum;
-    qid    = other.qid;
-    owned  = other.owned;
-    fStart = std::move(other.fStart);
-    fStop  = std::move(other.fStop);
-    fDelete= std::move(other.fDelete);
-    fOpenFd= std::move(other.fOpenFd);
-
-    other.owned = false;
-    other.qid   = 0;
+    qid = other.qid;
+    owned = std::exchange(other.owned, false);
+    other.qid = 0;
 
     return *this;
 }
 
 void QdmaQpair::start()
 {
-    if (!fStart) {
-        throw std::runtime_error("QDMA qpair start not available");
+    if (!owned || !connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    fStart(*this);
+    connection->startQdmaQpair(devNum, qid);
 }
 
 void QdmaQpair::stop()
 {
-    if (!fStop) {
-        throw std::runtime_error("QDMA qpair stop not available");
+    if (!owned || !connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    fStop(*this);
+    connection->stopQdmaQpair(devNum, qid);
 }
 
 int QdmaQpair::fd(uint32_t flags)
 {
-    if (!fOpenFd) {
-        throw std::runtime_error("QDMA qpair fd() not available");
+    if (!owned || !connection) {
+        throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    return fOpenFd(*this, flags);
+    return connection->openQdmaQpairFd(devNum, qid, flags);
 }
 
-std::fstream QdmaQpair::fstream(uint32_t flags, std::ios_base::openmode mode)
+std::fstream QdmaQpair::fstream(
+    uint32_t flags,
+    std::ios_base::openmode mode
+)
 {
-    int qfd = fd(flags);
+    int qpairFd = fd(flags);
 
     try {
-        std::string path = "/proc/self/fd/" + std::to_string(qfd);
-
-        std::fstream stream;
-        stream.open(path, mode);
-
-        ::close(qfd);
+        /*
+         * Open the procfs descriptor path while the received FD is still live.
+         * The stream opens its own file description, after which the temporary
+         * daemon-provided descriptor can close.
+         */
+        std::string path = "/proc/self/fd/" + std::to_string(qpairFd);
+        std::fstream stream(path, mode);
+        (void) ::close(qpairFd);
+        qpairFd = -1;
 
         if (!stream.is_open()) {
-            throw std::runtime_error("Failed to open fstream for QDMA qpair");
+            throw std::runtime_error(
+                "Failed to open fstream for QDMA qpair"
+            );
         }
 
         return stream;
     } catch (...) {
-        ::close(qfd);
+        /* Close the temporary exactly once if ownership was not transferred. */
+        if (qpairFd >= 0) {
+            (void) ::close(qpairFd);
+        }
+
         throw;
     }
 }

--- a/vrt/vrtd/libvrtdpp/src/session.cpp
+++ b/vrt/vrtd/libvrtdpp/src/session.cpp
@@ -1,61 +1,56 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
-
-/**
- * @file session.cpp
- *
- * Implementation of the vrtd::Session C++ wrapper.
- *
- * Session manages a single AF_UNIX connection to the vrtd daemon,
- * providing thread-safe request dispatch (via an internal mutex) and
- * RAII resource management.
- *
- * The key design pattern is **callback injection**: when creating QDMA
- * queue pairs or other resources, Session passes lambdas that capture
- * the session fd.  This allows resource objects (QdmaQpair, etc.) to
- * issue their own cleanup requests to the daemon when destroyed,
- * without holding a direct reference to the Session.
- */
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#include "vrtd/wire.h"
-#endif
 
 #include <vrtd/session.hpp>
+
+#include "connection.hpp"
+
 #include <vrtd/error.hpp>
 
-#include <string.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <cstdlib>
 #include <iostream>
-#include <utility>
 #include <string>
+#include <utility>
+
+#include <string.h>
+#include <unistd.h>
 
 namespace vrtd {
 
 namespace {
 
-CfgmemProgramStatus convertCfgmemStatus(const struct vrtd_cfgmem_program_status& raw) {
+/**
+ * Convert one fixed-width wire snapshot into the owning public C++ value.
+ *
+ * No pointers into the wire structure escape this helper.
+ *
+ * @param raw Status structure returned by libvrtd.
+ * @return Equivalent public status value with copied scalar fields.
+ */
+CfgmemProgramStatus convertCfgmemStatus(
+    const struct vrtd_cfgmem_program_status& raw
+)
+{
     CfgmemProgramStatus status;
     status.jobId = raw.job_id;
     status.state = static_cast<CfgmemProgramState>(raw.state);
@@ -64,394 +59,151 @@ CfgmemProgramStatus convertCfgmemStatus(const struct vrtd_cfgmem_program_status&
     status.bytesTotal = raw.bytes_total;
     status.elapsedMsec = raw.elapsed_msec;
     status.result = static_cast<enum vrtd_ret>(raw.result);
+
     return status;
 }
 
 } // namespace
 
 Session::Session(const char *socketPath)
-: m(std::make_unique<std::mutex>()) {
-    // When no explicit path is given, honor the VRTD_SOCKET environment
-    // variable before falling back to the compiled-in default, so tools like
-    // v80-smi can target a non-standard daemon socket the same way
-    // vrt::Device does.
+{
+    /*
+     * An explicit path wins. Otherwise honor a non-empty environment override
+     * and treat an empty value as unset before falling back to the system path.
+     */
     if (socketPath == nullptr) {
-        const char *envPath = getenv("VRTD_SOCKET");
+        const char *envPath = std::getenv("VRTD_SOCKET");
         socketPath = (envPath != nullptr && envPath[0] != '\0')
             ? envPath
             : VRTD_STANDARD_PATH;
     }
 
-    fd = vrtd_connect(socketPath);
-
-    if (fd == -1) {
-        throw std::runtime_error(std::string("Failed to open socket ") + strerrordesc_np(errno));
-    }
+    connection = std::make_shared<detail::Connection>(socketPath);
 }
 
-Session::~Session() noexcept
+Session::~Session() noexcept = default;
+
+Session::Session(Session&& other) noexcept = default;
+
+Session& Session::operator=(Session&& other) noexcept = default;
+
+uint32_t Session::getNumDevices() const
 {
-    close();
-}
-
-Session::Session(Session&& other) noexcept
-{
-    if (!other.isClosed()) {
-        std::lock_guard<std::mutex> lk(*other.m);
-
-        fd = std::exchange(other.fd, -1);
-        m = std::exchange(other.m, nullptr);
-    } else {
-        fd = -1;
-        m = nullptr;
-    }
-}
-
-Session& Session::operator=(Session&& other) noexcept
-{
-    close();
-
-    if (!other.isClosed()) {
-        std::lock_guard<std::mutex> lk(*other.m);
-
-        fd = std::exchange(other.fd, -1);
-        m = std::exchange(other.m, nullptr);
-    }
-
-    return *this;
-}
-
-uint32_t Session::getNumDevices() const {
-    if (isClosed()) {
+    if (!connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    uint32_t numDevices;
-
-    auto ret = vrtd_get_num_devices(fd, &numDevices);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return numDevices;
+    return connection->getNumDevices();
 }
 
-Device Session::getDevice(size_t i) const {
-    if (isClosed()) {
+Device Session::getDevice(size_t i) const
+{
+    if (!connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    vrtd_device_info info = {};
-
-    auto ret = vrtd_get_device_info(fd, i, &info);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+    /* Device strings are fixed-width wire arrays and need bounded copies. */
+    auto info = connection->getDeviceInfo(i);
 
     return Device(
+        connection,
         i,
         {info.name, strnlen(info.name, sizeof(info.name))},
         {info.pci.bdf, strnlen(info.pci.bdf, sizeof(info.pci.bdf))},
         info.pci.vendor_id,
         info.pci.device_id,
         info.pci.subsystem_vendor_id,
-        info.pci.subsystem_device_id,
-        [&](const Device& device, uint8_t num) { return getBar(device, num); },
-        [&](const Device& device, const slash_qdma_qpair_add& cfg) { return createQdmaQpair(device, cfg); },
-        [&](const Device& device, BufferAllocType type, uint64_t size, uint64_t arg, BufferAllocDir dir, MmChannel mm) {
-            return openBuffer(device, type, size, arg, dir, mm);
-        },
-        [&](const Device& device, uint64_t phys_addr, uint64_t size, BufferAllocDir dir, MmChannel mm) {
-            return openBufferRaw(device, phys_addr, size, dir, mm);
-        },
-        [&](const Device& device, HotplugOp op, uint8_t function) { return hotplugOp(device, op, function); },
-        [&](const Device& device, int input_fd) { return designWrite(device, input_fd); },
-        [&](const Device& device, std::string_view path) { return designWriteFile(device, path); },
-        [&](const Device& device, int input_fd, uint8_t bootDevice, uint32_t partition) {
-            return cfgmemProgram(device, input_fd, bootDevice, partition);
-        },
-        [&](const Device& device, std::string_view path, uint8_t bootDevice, uint32_t partition) {
-            return cfgmemProgramFile(device, path, bootDevice, partition);
-        },
-        [&](const Device& device, ClockRegion region) { return getClockRate(device, region); },
-        [&](const Device& device, ClockRegion region, uint32_t rate_hz) { return setClockRate(device, region, rate_hz); },
-        [&](const Device& device) { return getSensorInfo(device); }
+        info.pci.subsystem_device_id
     );
 }
 
-Device Session::getDeviceByBdf(std::string_view bdf) const {
-    if (isClosed()) {
+Device Session::getDeviceByBdf(std::string_view bdf) const
+{
+    if (!connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    // Normalize to board-level BDF (DDDD:BB:DD) to match how the daemon
-    // stores devices.  Strip function digit if present, and prepend domain
-    // 0000: if only one colon (short BDF like "03:00").
-    std::string bdf_str(bdf);
-
-    // Strip function digit (.F)
-    auto dot = bdf_str.rfind('.');
+    /*
+     * vrtd identifies a board rather than an individual physical function.
+     * Accept function-form input for compatibility, but warn before discarding
+     * the suffix because that changes the requested identifier.
+     */
+    std::string normalized(bdf);
+    auto dot = normalized.rfind('.');
     if (dot != std::string::npos) {
         std::cerr << "Warning: BDF '" << bdf
-                  << "' contains a PF function number; "
-                  << "stripping " << bdf_str.substr(dot)
+                  << "' contains a PF function number; stripping "
+                  << normalized.substr(dot)
                   << " — use board address (e.g. "
-                  << bdf_str.substr(0, dot) << ") instead"
+                  << normalized.substr(0, dot) << ") instead"
                   << std::endl;
-        bdf_str = bdf_str.substr(0, dot);
+        normalized.erase(dot);
     }
 
-    // Prepend default domain if missing
-    if (bdf_str.find(':') == bdf_str.rfind(':')) {
-        bdf_str = "0000:" + bdf_str;
+    /* Domainless BB:DD input is resolved in the default PCI domain. */
+    if (normalized.find(':') == normalized.rfind(':')) {
+        normalized.insert(0, "0000:");
     }
 
-    uint32_t dev_num = 0;
-    auto ret = vrtd_get_device_by_bdf(fd, bdf_str.c_str(), &dev_num);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    vrtd_device_info info = {};
-    ret = vrtd_get_device_info(fd, dev_num, &info);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+    /*
+     * Resolve the normalized board first, then snapshot its metadata into the
+     * returned Device. Bounded copies tolerate non-NUL-terminated wire arrays.
+     */
+    uint32_t dev = connection->getDeviceByBdf(normalized);
+    auto info = connection->getDeviceInfo(dev);
 
     return Device(
-        dev_num,
+        connection,
+        dev,
         {info.name, strnlen(info.name, sizeof(info.name))},
         {info.pci.bdf, strnlen(info.pci.bdf, sizeof(info.pci.bdf))},
         info.pci.vendor_id,
         info.pci.device_id,
         info.pci.subsystem_vendor_id,
-        info.pci.subsystem_device_id,
-        [&](const Device& device, uint8_t num) { return getBar(device, num); },
-        [&](const Device& device, const slash_qdma_qpair_add& cfg) { return createQdmaQpair(device, cfg); },
-        [&](const Device& device, BufferAllocType type, uint64_t size, uint64_t arg, BufferAllocDir dir, MmChannel mm) {
-            return openBuffer(device, type, size, arg, dir, mm);
-        },
-        [&](const Device& device, uint64_t phys_addr, uint64_t size, BufferAllocDir dir, MmChannel mm) {
-            return openBufferRaw(device, phys_addr, size, dir, mm);
-        },
-        [&](const Device& device, HotplugOp op, uint8_t function) { return hotplugOp(device, op, function); },
-        [&](const Device& device, int input_fd) { return designWrite(device, input_fd); },
-        [&](const Device& device, std::string_view path) { return designWriteFile(device, path); },
-        [&](const Device& device, int input_fd, uint8_t bootDevice, uint32_t partition) {
-            return cfgmemProgram(device, input_fd, bootDevice, partition);
-        },
-        [&](const Device& device, std::string_view path, uint8_t bootDevice, uint32_t partition) {
-            return cfgmemProgramFile(device, path, bootDevice, partition);
-        },
-        [&](const Device& device, ClockRegion region) { return getClockRate(device, region); },
-        [&](const Device& device, ClockRegion region, uint32_t rate_hz) { return setClockRate(device, region, rate_hz); },
-        [&](const Device& device) { return getSensorInfo(device); }
+        info.pci.subsystem_device_id
     );
 }
 
-Bar Session::getBar(const Device& device, uint8_t num) const {
-    if (isClosed()) {
+void Session::hotplugRescan() const
+{
+    if (!connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    slash_ioctl_bar_info barInfo;
-
-    auto ret = vrtd_get_bar_info(fd, device.getNum(), num, &barInfo);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return Bar(device.getNum(), num, barInfo.usable, barInfo.in_use, barInfo.start_address, barInfo.length, [&](const Bar&bar) { return openBarFile(bar); } );
-}
-
-BarFile Session::openBarFile(const Bar& bar) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    slash_bar_file barFile;
-
-    auto ret = vrtd_open_bar_file(fd, bar.getDeviceNum(), bar.getNum(), &barFile);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return BarFile(barFile);
-}
-
-slash_qdma_info Session::getQdmaInfo(const Device& device) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    slash_qdma_info info;
-    auto ret = vrtd_qdma_get_info(fd, device.getNum(), &info);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return info;
-}
-
-QdmaQpair Session::createQdmaQpair(
-    const Device& device,
-    const slash_qdma_qpair_add& cfg
-) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    slash_qdma_qpair_add tmp = cfg;
-    auto ret = vrtd_qdma_qpair_add(fd, device.getNum(), &tmp);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return QdmaQpair(
-        device.getNum(),
-        tmp.qid,
-        [this, device](const QdmaQpair& qp) { startQdmaQpair(device, qp.getQid()); },
-        [this, device](const QdmaQpair& qp) { stopQdmaQpair(device, qp.getQid()); },
-        [this, device](const QdmaQpair& qp) { deleteQdmaQpair(device, qp.getQid()); },
-        [this, device](const QdmaQpair& qp, uint32_t flags) { return openQdmaQpairFd(device, qp.getQid(), flags); }
-    );
-}
-
-Buffer Session::openBuffer(
-    const Device& device,
-    BufferAllocType allocType,
-    uint64_t size,
-    uint64_t allocArg,
-    BufferAllocDir allocDir,
-    MmChannel mmChannel
-) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    struct vrtd_buffer *raw = nullptr;
-    auto ret = vrtd_buffer_open(
-        fd,
-        device.getNum(),
-        static_cast<uint32_t>(allocType),
-        static_cast<uint32_t>(allocDir),
-        allocArg,
-        size,
-        static_cast<vrtd_mm_channel>(static_cast<uint32_t>(mmChannel)),
-        &raw
-    );
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    if (raw == nullptr) {
-        throw Error(VRTD_RET_INTERNAL_ERROR);
-    }
-
-    return Buffer(raw);
-}
-
-Buffer Session::openBufferRaw(
-    const Device& device,
-    uint64_t phys_addr,
-    uint64_t size,
-    BufferAllocDir allocDir,
-    MmChannel mmChannel
-) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    struct vrtd_buffer *raw = nullptr;
-    auto ret = vrtd_buffer_open_raw(
-        fd,
-        device.getNum(),
-        phys_addr,
-        size,
-        static_cast<uint32_t>(allocDir),
-        static_cast<vrtd_mm_channel>(static_cast<uint32_t>(mmChannel)),
-        &raw
-    );
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    if (raw == nullptr) {
-        throw Error(VRTD_RET_INTERNAL_ERROR);
-    }
-
-    return Buffer(raw);
-}
-
-void Session::hotplugOp(const Device& device, HotplugOp op,
-                        uint8_t function) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_device_hotplug_op(fd, device.getNum(),
-                                      static_cast<uint8_t>(op), function);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-}
-
-void Session::hotplugRescan() const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_device_hotplug_rescan(fd);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+    connection->hotplugRescan();
 }
 
 uint64_t Session::cfgmemProgramStart(
     const Device& device,
-    int input_fd,
+    int inputFd,
     uint8_t bootDevice,
     uint32_t partition
-) const {
-    if (isClosed()) {
+) const
+{
+    /*
+     * A numeric device index is meaningful only on the connection that issued
+     * it. Pointer identity accepts children retained across a Session move but
+     * rejects handles obtained from a different daemon connection.
+     */
+    if (!connection || device.connection.get() != connection.get()) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    uint64_t jobId = 0;
-    auto ret = vrtd_cfgmem_program_start(fd, device.getNum(), input_fd,
-                                         bootDevice, partition, &jobId);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return jobId;
+    return connection->cfgmemProgramStart(
+        device.getNum(),
+        inputFd,
+        bootDevice,
+        partition
+    );
 }
 
-CfgmemProgramStatus Session::cfgmemProgramStatus(uint64_t jobId) const {
-    if (isClosed()) {
+CfgmemProgramStatus Session::cfgmemProgramStatus(uint64_t jobId) const
+{
+    if (!connection) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    struct vrtd_cfgmem_program_status raw = {};
-    auto ret = vrtd_cfgmem_program_status(fd, jobId, &raw);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return convertCfgmemStatus(raw);
+    return convertCfgmemStatus(connection->cfgmemProgramStatus(jobId));
 }
 
 void Session::cfgmemProgramFileProgress(
@@ -461,44 +213,36 @@ void Session::cfgmemProgramFileProgress(
     uint32_t partition,
     CfgmemProgressCallback progressCallback,
     uint64_t pollIntervalMsec
-) const {
-    if (isClosed()) {
+) const
+{
+    /*
+     * Validate ownership before starting the irreversible daemon job. A
+     * callback exception later stops polling but cannot cancel this job.
+     */
+    if (!connection || device.connection.get() != connection.get()) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
 
-    std::string path_str(path);
-    uint64_t jobId = 0;
-    {
-        std::lock_guard<std::mutex> lk(*m);
-        auto ret = vrtd_cfgmem_program_file_start(
-            fd,
-            device.getNum(),
-            path_str.c_str(),
-            bootDevice,
-            partition,
-            &jobId
-        );
-        if (ret != VRTD_RET_OK) {
-            throw Error(ret);
-        }
-    }
+    /* Start asynchronously, then normalize zero to the documented default. */
+    uint64_t jobId = connection->cfgmemProgramFileStart(
+        device.getNum(),
+        path,
+        bootDevice,
+        partition
+    );
+    uint64_t sleepMsec = pollIntervalMsec == 0
+        ? 10000ULL
+        : pollIntervalMsec;
 
-    const uint64_t sleepMsec = pollIntervalMsec == 0 ? 10000ULL : pollIntervalMsec;
     for (;;) {
-        CfgmemProgramStatus status;
-        {
-            if (isClosed()) {
-                throw Error(VRTD_RET_BAD_LIB_CALL);
-            }
-            std::lock_guard<std::mutex> lk(*m);
-
-            struct vrtd_cfgmem_program_status raw = {};
-            auto ret = vrtd_cfgmem_program_status(fd, jobId, &raw);
-            if (ret != VRTD_RET_OK) {
-                throw Error(ret);
-            }
-            status = convertCfgmemStatus(raw);
-        }
+        /*
+         * Invoke the optional callback outside Connection's request guard. This
+         * permits re-entrant queries and, when supplied, lets it observe the
+         * terminal snapshot before this function handles the final result.
+         */
+        auto status = convertCfgmemStatus(
+            connection->cfgmemProgramStatus(jobId)
+        );
 
         if (progressCallback) {
             progressCallback(status);
@@ -512,199 +256,36 @@ void Session::cfgmemProgramFileProgress(
             return;
         }
 
-        usleep((useconds_t)(sleepMsec * 1000ULL));
+        /* Delay only between nonterminal snapshots. */
+        usleep(static_cast<useconds_t>(sleepMsec * 1000ULL));
     }
 }
 
-void Session::designWrite(const Device& device, int input_fd) const {
-    if (isClosed()) {
+slash_qdma_info Session::getQdmaInfo(const Device& device) const
+{
+    /* Reject foreign device indices before they reach the daemon. */
+    if (!connection || device.connection.get() != connection.get()) {
         throw Error(VRTD_RET_BAD_LIB_CALL);
     }
-    std::lock_guard<std::mutex> lk(*m);
 
-    auto ret = vrtd_design_write(fd, device.getNum(), input_fd);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
+    return connection->getQdmaInfo(device.getNum());
+}
+
+void Session::close() noexcept
+{
+    if (connection) {
+        connection->close();
     }
 }
 
-void Session::designWriteFile(const Device& device, std::string_view path) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    std::string path_str(path);
-    auto ret = vrtd_design_write_file(fd, device.getNum(), path_str.c_str());
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+bool Session::isClosed() const noexcept
+{
+    return !connection || connection->isClosed();
 }
 
-void Session::cfgmemProgram(
-    const Device& device,
-    int input_fd,
-    uint8_t bootDevice,
-    uint32_t partition
-) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_cfgmem_program(fd, device.getNum(), input_fd,
-                                   bootDevice, partition);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
+Session::operator bool() const noexcept
+{
+    return !isClosed();
 }
 
-void Session::cfgmemProgramFile(
-    const Device& device,
-    std::string_view path,
-    uint8_t bootDevice,
-    uint32_t partition
-) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    std::string path_str(path);
-    auto ret = vrtd_cfgmem_program_file(fd, device.getNum(), path_str.c_str(),
-                                        bootDevice, partition);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-}
-
-uint32_t Session::getClockRate(const Device& device, ClockRegion region) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    uint32_t rate = 0;
-    auto ret = vrtd_clock_get_rate(fd, device.getNum(), static_cast<uint32_t>(region), &rate);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return rate;
-}
-
-uint32_t Session::setClockRate(const Device& device, ClockRegion region, uint32_t rate_hz) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    uint32_t achieved = 0;
-    auto ret = vrtd_clock_set_rate(fd, device.getNum(), static_cast<uint32_t>(region), rate_hz, &achieved);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return achieved;
-}
-
-void Session::startQdmaQpair(const Device& device, uint32_t qid) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_qdma_qpair_start(fd, device.getNum(), qid);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-}
-
-void Session::stopQdmaQpair(const Device& device, uint32_t qid) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_qdma_qpair_stop(fd, device.getNum(), qid);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-}
-
-void Session::deleteQdmaQpair(const Device& device, uint32_t qid) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    auto ret = vrtd_qdma_qpair_del(fd, device.getNum(), qid);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-}
-
-int Session::openQdmaQpairFd(const Device& device, uint32_t qid, uint32_t flags) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    int qfd = -1;
-    auto ret = vrtd_qdma_qpair_get_fd(fd, device.getNum(), qid, flags, &qfd);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    return qfd;
-}
-
-std::vector<SensorEntry> Session::getSensorInfo(const Device& device) const {
-    if (isClosed()) {
-        throw Error(VRTD_RET_BAD_LIB_CALL);
-    }
-    std::lock_guard<std::mutex> lk(*m);
-
-    struct vrtd_sensor_entry entries[VRTD_SENSOR_MAX_ENTRIES];
-    uint32_t count = 0;
-
-    auto ret = vrtd_get_sensor_info(fd, device.getNum(), entries,
-                                    VRTD_SENSOR_MAX_ENTRIES, &count);
-    if (ret != VRTD_RET_OK) {
-        throw Error(ret);
-    }
-
-    std::vector<SensorEntry> result;
-    result.reserve(count);
-    for (uint32_t i = 0; i < count; i++) {
-        result.push_back(SensorEntry{
-            std::string(entries[i].name, strnlen(entries[i].name, sizeof(entries[i].name))),
-            entries[i].type,
-            entries[i].status,
-            entries[i].unit_mod,
-            entries[i].value
-        });
-    }
-
-    return result;
-}
-
-void Session::close() noexcept {
-    if (isClosed()) {
-        return;
-    }
-
-    ::close(fd);
-    fd = -1;
-    m = nullptr;
-}
-
-bool Session::isClosed() const noexcept {
-    if (fd == -1 || !m) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-}
+} // namespace vrtd

--- a/vrt/vrtd/tests/CMakeLists.txt
+++ b/vrt/vrtd/tests/CMakeLists.txt
@@ -33,3 +33,18 @@ add_vrtd_test(v80_policy_test v80_policy_test.cpp)
 add_vrtd_test(design_writer_test design_writer_test.cpp)
 add_vrtd_test(device_test device_test.cpp)
 add_vrtd_test(flash_worker_test flash_worker_test.cpp)
+
+add_executable(libvrtdpp_test libvrtdpp_test.cpp)
+target_link_libraries(
+  libvrtdpp_test
+  PRIVATE
+    GTest::gtest_main
+    vrtd::libvrtdpp
+    Threads::Threads
+)
+set_target_properties(libvrtdpp_test PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED YES
+)
+gtest_discover_tests(libvrtdpp_test)
+add_dependencies(unit_tests libvrtdpp_test)

--- a/vrt/vrtd/tests/libvrtdpp_test.cpp
+++ b/vrt/vrtd/tests/libvrtdpp_test.cpp
@@ -1,0 +1,680 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <gtest/gtest.h>
+
+#include <vrtd/error.hpp>
+#include <vrtd/session.hpp>
+#include <vrtd/wire.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <future>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+/** Captured wire request with byte-exact owned body storage. */
+struct ObservedRequest {
+    uint16_t opcode; ///< vrtd request opcode.
+    std::vector<uint8_t> body; ///< Unmodified request body bytes.
+};
+
+/**
+ * Minimal single-client vrtd protocol peer used by public API tests.
+ *
+ * The fake implements only the opcodes needed to exercise libvrtdpp. It records
+ * each validated request before replying and can hold GET_NUM_DEVICES in flight
+ * to test deterministic close/request ordering. All filesystem and socket
+ * resources are released during teardown.
+ */
+class FakeVrtd {
+public:
+    /**
+     * Create a unique pathname listener and start the server thread.
+     *
+     * @param blockNumDevices Hold GET_NUM_DEVICES until explicitly released.
+     */
+    explicit FakeVrtd(bool blockNumDevices = false)
+        : blockNumDevices(blockNumDevices)
+        , path(
+            "vrtdpp-" + std::to_string(getpid()) + "-" +
+            std::to_string(nextId.fetch_add(1)) + ".sock"
+        )
+    {
+        /* Bind a short relative path so sockaddr_un limits are deterministic. */
+        listenFd = socket(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+        if (listenFd < 0) {
+            throw std::runtime_error("socket failed");
+        }
+
+        struct sockaddr_un address = {};
+        address.sun_family = AF_UNIX;
+        if (path.size() >= sizeof(address.sun_path)) {
+            throw std::runtime_error("socket path is too long");
+        }
+        std::memcpy(address.sun_path, path.c_str(), path.size() + 1);
+        unlink(path.c_str());
+        if (bind(
+                listenFd,
+                reinterpret_cast<struct sockaddr *>(&address),
+                sizeof(address)
+            ) != 0 ||
+            listen(listenFd, 1) != 0) {
+            close(listenFd);
+            listenFd = -1;
+            unlink(path.c_str());
+            throw std::runtime_error("bind/listen failed");
+        }
+
+        /* Do not start the peer until clients can connect successfully. */
+        server = std::thread([this] { run(); });
+    }
+
+    /**
+     * Stop the peer without leaving accept, recv, or the test gate blocked.
+     *
+     * Wake the condition variable before shutting sockets down, then join the
+     * only server thread before unlinking its pathname.
+     */
+    ~FakeVrtd()
+    {
+        {
+            std::lock_guard<std::mutex> lock(blockMutex);
+            stop = true;
+            releaseNumDevices = true;
+        }
+        blockCv.notify_all();
+
+        int client = clientFd.load();
+        if (client >= 0) {
+            shutdown(client, SHUT_RDWR);
+        }
+        if (listenFd >= 0) {
+            shutdown(listenFd, SHUT_RDWR);
+            close(listenFd);
+        }
+        if (server.joinable()) {
+            server.join();
+        }
+        unlink(path.c_str());
+    }
+
+    /** Native socket and thread ownership cannot be copied. */
+    FakeVrtd(const FakeVrtd&) = delete;
+    FakeVrtd& operator=(const FakeVrtd&) = delete;
+
+    /** Return the listener path, valid for this fixture's lifetime. */
+    const std::string& socketPath() const noexcept
+    {
+        return path;
+    }
+
+    /** Make subsequent BAR responses carry a deliberately unmappable FD. */
+    void returnUnmappableBarFd() noexcept
+    {
+        unmappableBarFd.store(true);
+    }
+
+    /** Return a synchronized snapshot of the number of captured requests. */
+    size_t requestCount() const
+    {
+        std::lock_guard<std::mutex> lock(requestMutex);
+        return requests.size();
+    }
+
+    /**
+     * Return the most recently captured request for @p opcode.
+     *
+     * @throws std::runtime_error if no matching request was observed.
+     */
+    ObservedRequest lastRequest(uint16_t opcode) const
+    {
+        std::lock_guard<std::mutex> lock(requestMutex);
+        for (auto it = requests.rbegin(); it != requests.rend(); ++it) {
+            if (it->opcode == opcode) {
+                return *it;
+            }
+        }
+        throw std::runtime_error("request not observed");
+    }
+
+    /**
+     * Wait until GET_NUM_DEVICES reaches the deterministic server gate.
+     *
+     * A timeout releases the gate before throwing so future destruction cannot
+     * deadlock on the blocked client request.
+     */
+    void waitForNumDevices()
+    {
+        std::unique_lock<std::mutex> lock(blockMutex);
+        if (!blockCv.wait_for(lock, 2s, [this] { return numDevicesSeen; })) {
+            releaseNumDevices = true;
+            lock.unlock();
+            blockCv.notify_all();
+            throw std::runtime_error("GET_NUM_DEVICES was not observed");
+        }
+    }
+
+    /** Release a GET_NUM_DEVICES request held by the test gate. */
+    void releaseBlockedNumDevices()
+    {
+        {
+            std::lock_guard<std::mutex> lock(blockMutex);
+            releaseNumDevices = true;
+        }
+        blockCv.notify_all();
+    }
+
+    /** Rethrow a server-thread failure in the calling test thread. */
+    void rethrowServerError()
+    {
+        std::exception_ptr error;
+        {
+            std::lock_guard<std::mutex> lock(errorMutex);
+            error = serverError;
+        }
+        if (error) {
+            std::rethrow_exception(error);
+        }
+    }
+
+private:
+    /**
+     * Send a successful response matching one captured request.
+     *
+     * @tparam Body Packed wire response body type.
+     * @param request Request whose sequence number must be echoed.
+     * @param body Response body sent in the same packet as the header.
+     * @param responseFd Optional descriptor transferred through SCM_RIGHTS.
+     */
+    template<typename Body>
+    void sendResponse(
+        const struct vrtd_req_header& request,
+        const Body& body,
+        int responseFd = -1
+    )
+    {
+        struct vrtd_resp_header header = {};
+        header.size = static_cast<uint16_t>(sizeof(body));
+        header.ret = VRTD_RET_OK;
+        header.seqno = request.seqno;
+        struct iovec iov[] = {
+            {&header, sizeof(header)},
+            {const_cast<Body *>(&body), sizeof(body)},
+        };
+        struct msghdr message = {};
+        message.msg_iov = iov;
+        message.msg_iovlen = 2;
+
+        std::array<char, CMSG_SPACE(sizeof(int))> control = {};
+        if (responseFd >= 0) {
+            /* SCM_RIGHTS duplicates the descriptor into the receiving process. */
+            message.msg_control = control.data();
+            message.msg_controllen = control.size();
+            auto *cmsg = CMSG_FIRSTHDR(&message);
+            cmsg->cmsg_level = SOL_SOCKET;
+            cmsg->cmsg_type = SCM_RIGHTS;
+            cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+            std::memcpy(CMSG_DATA(cmsg), &responseFd, sizeof(responseFd));
+            message.msg_controllen = cmsg->cmsg_len;
+        }
+
+        if (sendmsg(clientFd.load(), &message, MSG_NOSIGNAL) < 0 && !stop) {
+            throw std::runtime_error("sendmsg failed");
+        }
+    }
+
+    /**
+     * Decode a captured body after checking its exact wire size.
+     *
+     * Copying avoids alignment and aliasing assumptions about byte storage.
+     */
+    template<typename Request>
+    static Request requestBody(const ObservedRequest& observed)
+    {
+        if (observed.body.size() != sizeof(Request)) {
+            throw std::runtime_error("unexpected request size");
+        }
+        Request request = {};
+        std::memcpy(&request, observed.body.data(), sizeof(request));
+        return request;
+    }
+
+    /**
+     * Dispatch one validated request to the small protocol script.
+     *
+     * Unsupported opcodes indicate that the C++ client issued traffic outside
+     * this test's declared contract and are reported as server failures.
+     */
+    void handle(
+        const struct vrtd_req_header& header,
+        const ObservedRequest& observed
+    )
+    {
+        switch (header.opcode) {
+        case VRTD_REQ_GET_NUM_DEVICES: {
+            if (blockNumDevices) {
+                std::unique_lock<std::mutex> lock(blockMutex);
+                numDevicesSeen = true;
+                blockCv.notify_all();
+                blockCv.wait(lock, [this] {
+                    return releaseNumDevices || stop;
+                });
+            }
+            struct vrtd_resp_get_num_devices response = {};
+            response.num_devices = 1;
+            sendResponse(header, response);
+            break;
+        }
+        case VRTD_REQ_GET_DEVICE_INFO: {
+            auto request =
+                requestBody<struct vrtd_req_get_device_info>(observed);
+            struct vrtd_resp_get_device_info response = {};
+            std::strcpy(response.info.name, "fake-v80");
+            std::strcpy(response.info.pci.bdf, "0000:65:00");
+            response.info.pci.vendor_id = 0x10ee;
+            response.info.pci.device_id = 0x50b4;
+            response.info.pci.subsystem_vendor_id = 0x10ee;
+            response.info.pci.subsystem_device_id =
+                static_cast<uint16_t>(request.dev_number);
+            sendResponse(header, response);
+            break;
+        }
+        case VRTD_REQ_GET_BAR_INFO: {
+            auto request =
+                requestBody<struct vrtd_req_get_bar_info>(observed);
+            struct vrtd_resp_get_bar_info response = {};
+            response.bar_info.size = sizeof(response.bar_info);
+            response.bar_info.bar_number = request.bar_number;
+            response.bar_info.usable = 1;
+            response.bar_info.start_address = 0x1000;
+            response.bar_info.length = 4096;
+            sendResponse(header, response);
+            break;
+        }
+        case VRTD_REQ_GET_BAR_FD: {
+            (void) requestBody<struct vrtd_req_get_bar_fd>(observed);
+
+            int fd = -1;
+            if (unmappableBarFd.load()) {
+                int pipeFds[2] = {-1, -1};
+                if (pipe2(pipeFds, O_CLOEXEC) != 0) {
+                    throw std::runtime_error("pipe creation failed");
+                }
+
+                fd = pipeFds[0];
+                close(pipeFds[1]);
+            } else {
+                fd = memfd_create("vrtdpp-bar", MFD_CLOEXEC);
+                if (fd < 0 || ftruncate(fd, 4096) != 0) {
+                    if (fd >= 0) {
+                        close(fd);
+                    }
+                    throw std::runtime_error("memfd creation failed");
+                }
+            }
+
+            struct vrtd_resp_get_bar_fd response = {};
+            response.len = 4096;
+            try {
+                /*
+                 * The client receives a duplicate through SCM_RIGHTS. Close the
+                 * fake daemon's copy on both success and send failure.
+                 */
+                sendResponse(header, response, fd);
+            } catch (...) {
+                close(fd);
+                throw;
+            }
+            close(fd);
+            break;
+        }
+        case VRTD_REQ_QDMA_QPAIR_ADD: {
+            auto request =
+                requestBody<struct vrtd_req_qdma_qpair_add>(observed);
+            struct vrtd_resp_qdma_qpair_add response = {};
+            response.add = request.add;
+            response.add.qid = 0;
+            sendResponse(header, response);
+            break;
+        }
+        case VRTD_REQ_QDMA_QPAIR_OP: {
+            (void) requestBody<struct vrtd_req_qdma_qpair_op>(observed);
+            struct vrtd_resp_qdma_qpair_op response = {};
+            sendResponse(header, response);
+            break;
+        }
+        default:
+            throw std::runtime_error("unexpected opcode");
+        }
+    }
+
+    /**
+     * Accept one client and serve complete SOCK_SEQPACKET requests.
+     *
+     * Packets are validated before their bodies are sliced, recorded before
+     * dispatch, and processed serially. Exceptions are saved for rethrow on the
+     * test thread because failures cannot escape std::thread entry.
+     */
+    void run() noexcept
+    {
+        int accepted = -1;
+        try {
+            /* This fake intentionally models one libvrtd connection. */
+            accepted = accept4(listenFd, nullptr, nullptr, SOCK_CLOEXEC);
+            if (accepted < 0) {
+                if (!stop) {
+                    throw std::runtime_error("accept failed");
+                }
+                return;
+            }
+            clientFd.store(accepted);
+
+            std::array<uint8_t, VRTD_MSG_MAX_SIZE> packet = {};
+            while (!stop) {
+                ssize_t length = recv(
+                    accepted,
+                    packet.data(),
+                    packet.size(),
+                    0
+                );
+                if (length <= 0) {
+                    break;
+                }
+                if (static_cast<size_t>(length) <
+                    sizeof(struct vrtd_req_header)) {
+                    throw std::runtime_error("short request");
+                }
+
+                struct vrtd_req_header header = {};
+                std::memcpy(&header, packet.data(), sizeof(header));
+                if (static_cast<size_t>(length) !=
+                    sizeof(header) + header.size) {
+                    throw std::runtime_error("invalid request size");
+                }
+
+                ObservedRequest observed = {
+                    header.opcode,
+                    std::vector<uint8_t>(
+                        packet.begin() + sizeof(header),
+                        packet.begin() + length
+                    ),
+                };
+                {
+                    /* Publish the request before a scripted response unblocks the client. */
+                    std::lock_guard<std::mutex> lock(requestMutex);
+                    requests.push_back(observed);
+                }
+                handle(header, observed);
+            }
+        } catch (...) {
+            /* Preserve the first server failure for deterministic test reporting. */
+            std::lock_guard<std::mutex> lock(errorMutex);
+            serverError = std::current_exception();
+        }
+        if (accepted >= 0) {
+            shutdown(accepted, SHUT_RDWR);
+            close(accepted);
+        }
+        clientFd.store(-1);
+    }
+
+    /** Monotonic suffix preventing socket-path collisions within the process. */
+    inline static std::atomic<uint32_t> nextId{0};
+
+    bool blockNumDevices; ///< Whether GET_NUM_DEVICES uses the test gate.
+    std::string path; ///< Relative listener pathname.
+    int listenFd{-1}; ///< Server-owned listening descriptor.
+    std::atomic<int> clientFd{-1}; ///< Accepted descriptor visible to teardown.
+    std::thread server; ///< Sole protocol-serving thread.
+    std::atomic<bool> stop{false}; ///< Cross-thread terminal-state request.
+    std::atomic<bool> unmappableBarFd{false}; ///< Return a pipe for BAR mmap failure.
+
+    /** Protect captured request ordering and snapshots. */
+    mutable std::mutex requestMutex;
+    std::vector<ObservedRequest> requests; ///< Requests in receive order.
+
+    /** Coordinate deterministic blocking of one GET_NUM_DEVICES response. */
+    std::mutex blockMutex;
+    std::condition_variable blockCv;
+    bool numDevicesSeen{false}; ///< True after the blocked request arrives.
+    bool releaseNumDevices{false}; ///< True when the scripted reply may proceed.
+
+    /** Protect deferred exception transfer from the server thread. */
+    std::mutex errorMutex;
+    std::exception_ptr serverError; ///< Captured server failure, if any.
+};
+
+/** Assert that local misuse reports VRTD_RET_BAD_LIB_CALL specifically. */
+void expectBadCall(const std::function<void()>& operation)
+{
+    try {
+        operation();
+        FAIL() << "operation did not throw";
+    } catch (const vrtd::Error& error) {
+        EXPECT_EQ(error.getErrorCode(), VRTD_RET_BAD_LIB_CALL);
+    }
+}
+
+/** Child handles retain the connection and delete valid queue identifier zero. */
+TEST(LibvrtdppTest, ChildrenKeepConnectionAliveAndDeleteQidZero)
+{
+    FakeVrtd daemon;
+    std::optional<vrtd::Bar> bar;
+    std::optional<vrtd::QdmaQpair> qpair;
+
+    {
+        vrtd::Session session(daemon.socketPath().c_str());
+        auto device = session.getDevice(0);
+        bar.emplace(device.getBar(2));
+        struct slash_qdma_qpair_add config = {};
+        config.size = sizeof(config);
+        qpair.emplace(device.createQdmaQpair(config));
+        EXPECT_EQ(qpair->getQid(), 0u);
+    }
+
+    {
+        auto mapping = bar->openBarFile();
+        EXPECT_EQ(mapping.getLen(), 4096u);
+        mapping.close();
+        mapping.close();
+        EXPECT_TRUE(mapping.isClosed());
+    }
+    qpair.reset();
+
+    auto deletion = daemon.lastRequest(VRTD_REQ_QDMA_QPAIR_OP);
+    ASSERT_EQ(deletion.body.size(), sizeof(struct vrtd_req_qdma_qpair_op));
+    struct vrtd_req_qdma_qpair_op request = {};
+    std::memcpy(&request, deletion.body.data(), sizeof(request));
+    EXPECT_EQ(request.dev_number, 0u);
+    EXPECT_EQ(request.qid, 0u);
+    EXPECT_EQ(request.op, static_cast<uint32_t>(SLASH_QDMA_QUEUE_OP_DEL));
+    daemon.rethrowServerError();
+}
+
+/** BarFile moves reject either endpoint while it owns a live access session. */
+TEST(LibvrtdppTest, BarFileMoveRejectsLiveAccess)
+{
+    FakeVrtd daemon;
+    vrtd::Session session(daemon.socketPath().c_str());
+    auto bar = session.getDevice(0).getBar(2);
+    auto source = bar.openBarFile();
+
+    {
+        auto access = source.getPtr<uint32_t>(vrtd::BarFile::Direction::Read);
+
+        EXPECT_THROW(
+            (void) vrtd::BarFile(std::move(source)),
+            std::runtime_error
+        );
+        EXPECT_FALSE(source.isClosed());
+    }
+
+    auto destination = bar.openBarFile();
+    {
+        auto access = source.getPtr<uint32_t>(vrtd::BarFile::Direction::Read);
+
+        EXPECT_THROW(destination = std::move(source), std::runtime_error);
+        EXPECT_FALSE(source.isClosed());
+        EXPECT_FALSE(destination.isClosed());
+    }
+
+    {
+        auto access =
+            destination.getPtr<uint32_t>(vrtd::BarFile::Direction::Write);
+
+        EXPECT_THROW(destination = std::move(source), std::runtime_error);
+        EXPECT_FALSE(source.isClosed());
+        EXPECT_FALSE(destination.isClosed());
+    }
+
+    daemon.rethrowServerError();
+}
+
+/** A BAR mmap failure closes only the received BAR FD, not the session socket. */
+TEST(LibvrtdppTest, BarMapFailureKeepsSessionUsable)
+{
+    FakeVrtd daemon;
+    daemon.returnUnmappableBarFd();
+
+    vrtd::Session session(daemon.socketPath().c_str());
+    auto bar = session.getDevice(0).getBar(2);
+
+    try {
+        (void) bar.openBarFile();
+        FAIL() << "unmappable BAR did not fail";
+    } catch (const vrtd::Error& error) {
+        EXPECT_EQ(error.getErrorCode(), VRTD_RET_INTERNAL_ERROR);
+    }
+
+    EXPECT_EQ(session.getNumDevices(), 1u);
+    daemon.rethrowServerError();
+}
+
+/** Explicit close invalidates every handle without issuing another request. */
+TEST(LibvrtdppTest, ExplicitCloseInvalidatesAllSharedHandles)
+{
+    FakeVrtd daemon;
+    vrtd::Session session(daemon.socketPath().c_str());
+    auto device = session.getDevice(0);
+    auto bar = device.getBar(2);
+    size_t requestCount = daemon.requestCount();
+
+    session.close();
+
+    EXPECT_TRUE(session.isClosed());
+    EXPECT_FALSE(session);
+    expectBadCall([&] { (void) device.getBar(2); });
+    expectBadCall([&] { (void) bar.openBarFile(); });
+    EXPECT_EQ(daemon.requestCount(), requestCount);
+    daemon.rethrowServerError();
+}
+
+/** Moving a Session facade leaves existing connection-owning children usable. */
+TEST(LibvrtdppTest, SessionMovePreservesExistingChildren)
+{
+    FakeVrtd daemon;
+    vrtd::Session source(daemon.socketPath().c_str());
+    auto device = source.getDevice(0);
+
+    vrtd::Session destination(std::move(source));
+
+    EXPECT_TRUE(source.isClosed());
+    EXPECT_TRUE(destination);
+    EXPECT_TRUE(device.getBar(2).isUsable());
+    daemon.rethrowServerError();
+}
+
+/** Session-level methods reject foreign Device indices before wire I/O. */
+TEST(LibvrtdppTest, SessionRejectsDeviceFromAnotherConnection)
+{
+    FakeVrtd firstDaemon;
+    FakeVrtd secondDaemon;
+    vrtd::Session first(firstDaemon.socketPath().c_str());
+    vrtd::Session second(secondDaemon.socketPath().c_str());
+    auto foreignDevice = second.getDevice(0);
+    size_t requestCount = firstDaemon.requestCount();
+
+    expectBadCall([&] { (void) first.getQdmaInfo(foreignDevice); });
+
+    EXPECT_EQ(firstDaemon.requestCount(), requestCount);
+    firstDaemon.rethrowServerError();
+    secondDaemon.rethrowServerError();
+}
+
+/** Close drains an in-flight RPC and rejects all subsequent operations. */
+TEST(LibvrtdppTest, CloseWaitsForInFlightRequest)
+{
+    FakeVrtd daemon(true);
+    vrtd::Session session(daemon.socketPath().c_str());
+
+    auto request = std::async(std::launch::async, [&] {
+        return session.getNumDevices();
+    });
+    daemon.waitForNumDevices();
+    std::promise<void> closeStartedPromise;
+    auto closeStarted = closeStartedPromise.get_future();
+    auto close = std::async(std::launch::async, [&] {
+        closeStartedPromise.set_value();
+        session.close();
+    });
+
+    if (closeStarted.wait_for(2s) != std::future_status::ready) {
+        daemon.releaseBlockedNumDevices();
+        FAIL() << "close task did not start";
+    }
+    EXPECT_EQ(close.wait_for(50ms), std::future_status::timeout);
+    daemon.releaseBlockedNumDevices();
+
+    ASSERT_EQ(request.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(request.get(), 1u);
+    ASSERT_EQ(close.wait_for(2s), std::future_status::ready);
+    close.get();
+    expectBadCall([&] { (void) session.getNumDevices(); });
+    daemon.rethrowServerError();
+}
+
+} // namespace


### PR DESCRIPTION
libvrtdpp is a library that wraps the libvrtd client library in C++ classes.

It is currently quite messy, because the `Session` class that owns the vrtd socket is also the user facing class interface. Other classes represent RAII resources, and call back into `Session` with runtime callbacks to execute their functions

This refactor introduces a `Connection` internal class for socket management and libvrtd function execution. RAII resource classes are created with a reference to `Connection`, eliminating the need for many callbacks to be passed to them.

## Draft

This is currently a draft, as it needs rebasing and testing.