### PR TITLE
feat(rp1): add graph api follow-up fixes and optimizations

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -50,7 +50,13 @@ heterogeneous graph execution.
      - sharpen_loop
      - Loops and conditionals: a fixed-count FPGA loop carrying state, running
        alongside a CPU reduction, followed by a post-loop conditional.
+   * - extra
+     - rp1_latency
+     - Latency microbenchmarks rather than a tutorial: the RP1 command
+       processor dispatch path against the legacy host-driven VRT path, using
+       the same no-op kernel on the same board.
 
 Each example includes a ``CMakeLists.txt`` with targets for hardware (``hw``), emulation (``emu``),
 and simulation (``sim``) flows. See ``examples/README.md`` in the repository for build
-instructions.
+instructions. The ``extra/`` projects are the exception: they build standalone against an
+installed or in-repo VRT and link a hardware vbin only.

--- a/driver/libslash/include/slash/uapi/rp1_protocol.h
+++ b/driver/libslash/include/slash/uapi/rp1_protocol.h
@@ -17,9 +17,9 @@
  * stack (libslash, SMI, VRT FpgaDevice).  It describes:
  *
  *   - Opcodes, flags, status codes, and condition operators
- *   - The 64-byte node packet and its 48-byte payload union
+ *   - The 32-byte node packet and its 20-byte payload union
  *   - The 4 KB control block at the base of the host-visible BAR window
- *   - The 16-byte signal slot and 16-byte completion-queue entry
+ *   - The 16-byte signal slot, 64-byte graph result, and trace entry
  *   - The in-flight kernel tracking table
  *   - Recommended default layout offsets within the BAR window
  *
@@ -61,8 +61,8 @@ extern "C" {
 #define RP1_CTRL_BAR_OFFSET             0x00000000UL  /* host BAR-relative */
 #define RP1_CTRL_WINDOW_SIZE            0x04000000UL  /* 64 MB aperture */
 
-#define RP1_DEFAULT_NODE_ARRAY_OFFSET   0x00001000UL  /* 256 KB */
-#define RP1_DEFAULT_CQ_OFFSET           0x00041000UL  /*  64 KB */
+#define RP1_DEFAULT_NODE_ARRAY_OFFSET   0x00001000UL  /* 256 KB reserved */
+#define RP1_RESERVED_CQ_OFFSET          0x00041000UL  /* legacy v4 CQ gap */
 #define RP1_DEFAULT_ARG_BUF_OFFSET      0x00051000UL  /*   1 MB */
 #define RP1_DEFAULT_SIG_ARRAY_OFFSET    0x00151000UL  /*   4 KB */
 #define RP1_DEFAULT_TRACE_OFFSET        0x00152000UL  /* trace ring */
@@ -72,40 +72,47 @@ extern "C" {
  * ====================================================================== */
 
 typedef enum {
-    RP1_OP_NOP             = 0x0000,
-    RP1_OP_WAIT            = 0x0001,
-    RP1_OP_SIGNAL          = 0x0002,
-    RP1_OP_KERNEL_DISPATCH = 0x0010,
-    RP1_OP_SCALAR_WRITE    = 0x0011,
-    RP1_OP_SCALAR_READ     = 0x0012,
-    RP1_OP_SCALAR_COPY     = 0x0013,
-    RP1_OP_DMA_COPY        = 0x0020,
-    RP1_OP_DMA_FILL        = 0x0021,
-    RP1_OP_PDI_LOAD        = 0x0030,
-    RP1_OP_LOOP            = 0x0040,
-    RP1_OP_COND            = 0x0041,
-    RP1_OP_RERUN           = 0x0042,
-    RP1_OP_HALT            = 0x00FF,
+    RP1_OP_NOP             = 0,
+    RP1_OP_WAIT            = 1,
+    RP1_OP_SIGNAL          = 2,
+    RP1_OP_KERNEL_DISPATCH = 3,
+    RP1_OP_SCALAR_WRITE    = 4,
+    RP1_OP_SCALAR_READ     = 5,
+    RP1_OP_SCALAR_COPY     = 6,
+    RP1_OP_DMA_COPY        = 7,
+    RP1_OP_DMA_FILL        = 8,
+    RP1_OP_PDI_LOAD        = 9,
+    RP1_OP_LOOP            = 10,
+    RP1_OP_COND            = 11,
+    RP1_OP_RERUN           = 12,
+    RP1_OP_HALT            = 13,
 } rp1_opcode_t;
 
 /* =========================================================================
- * Universal node flags (rp1_node_t.flags)
+ * Compact node control word
  * ====================================================================== */
 
-#define RP1_FLAG_HALT_ON_ERROR  (1u << 0)
-#define RP1_FLAG_SILENT         (1u << 1)
-#define RP1_FLAG_INFINITE       (1u << 2)   /* KERNEL_DISPATCH: node DONE immediately */
+#define RP1_NODE_OPCODE_SHIFT    0u
+#define RP1_NODE_OPCODE_MASK     0x000Fu
+#define RP1_NODE_FLAGS_SHIFT     4u
+#define RP1_NODE_FLAGS_MASK      0x00F0u
+#define RP1_NODE_STATUS_SHIFT    8u
+#define RP1_NODE_STATUS_MASK     0x0F00u
+#define RP1_NODE_RESERVED_MASK   0xF000u
+
+/* Bit 0 marks an infinite dispatch; flags bits 1-3 are reserved and zero. */
+#define RP1_FLAG_INFINITE        (1u << 0)
 
 /* =========================================================================
- * Node status (written by RP1 into rp1_node_t.status)
+ * Node status (written by RP1 into the node control word)
  * ====================================================================== */
 
 typedef enum {
-    RP1_NODE_PENDING    = 0x0000,
-    RP1_NODE_DISPATCHED = 0x0001,
-    RP1_NODE_DONE       = 0x0002,
-    RP1_NODE_WAITING    = 0x0003,  /* RP1_OP_WAIT: gated on a signal slot      */
-    RP1_NODE_ERROR      = 0x00FF,
+    RP1_NODE_PENDING    = 0,
+    RP1_NODE_DISPATCHED = 1,
+    RP1_NODE_DONE       = 2,
+    RP1_NODE_WAITING    = 3,  /* RP1_OP_WAIT: gated on a signal slot */
+    RP1_NODE_ERROR      = 4,
 } rp1_node_status_t;
 
 /* =========================================================================
@@ -120,19 +127,10 @@ typedef enum {
 #define RP1_ERR_PDI_FAILED      5u  /* PLM rejected a partial-PDI load command   */
 #define RP1_ERR_INVALID_CONFIG  6u  /* invalid shared control-block configuration */
 #define RP1_ERR_INVALID_NODE    7u  /* malformed node packet                      */
-#define RP1_ERR_CQ_CORRUPT      8u  /* CQ producer/consumer cursors are invalid   */
-
-/* ORed into rp1_error_code when terminal recovery requires an RP1/card reset
- * because one or more launched kernels could not be proven quiescent. */
-#define RP1_ERR_RECOVERY_REQUIRED  (1u << 31)
-#define RP1_ERR_CODE_MASK           (~RP1_ERR_RECOVERY_REQUIRED)
-
 /* terminal_error_detail values for RP1_ERR_INVALID_CONFIG. */
 #define RP1_CONFIG_NODE_COUNT       1u
 #define RP1_CONFIG_NODE_BASE        2u
-#define RP1_CONFIG_CQ_SIZE          3u
-#define RP1_CONFIG_CQ_BASE          4u
-#define RP1_CONFIG_CQ_CURSORS       5u
+#define RP1_CONFIG_RESERVED_CQ      3u
 #define RP1_CONFIG_ARG_BASE         6u
 #define RP1_CONFIG_SIGNAL_BASE      7u
 #define RP1_CONFIG_TRACE            8u
@@ -144,7 +142,6 @@ typedef enum {
 #define RP1_NODE_BAD_TARGET         4u
 #define RP1_NODE_BAD_OPERATION      5u
 #define RP1_NODE_BAD_ARGUMENTS      6u
-#define RP1_NODE_PDI_WITHOUT_CQ     7u
 
 /* =========================================================================
  * Condition operators (used by LOOP and COND)
@@ -189,6 +186,64 @@ typedef enum {
 } rp1_state_t;
 
 /* =========================================================================
+ * Terminal graph result (protocol v6)
+ * ====================================================================== */
+
+#define RP1_GRAPH_RESULT_MAGIC  0x52534C54UL  /* "RSLT" */
+#define RP1_TERMINAL_OPCODE_NONE 0xFFFFFFFFu
+
+typedef enum {
+    RP1_GRAPH_RESULT_NONE    = 0,
+    RP1_GRAPH_RESULT_SUCCESS = 1,
+    RP1_GRAPH_RESULT_FAILED  = 2,
+    RP1_GRAPH_RESULT_HALTED  = 3,
+} rp1_graph_outcome_t;
+
+typedef enum {
+    RP1_IMAGE_STATE_NONE    = 0,
+    RP1_IMAGE_STATE_KNOWN   = 1,
+    RP1_IMAGE_STATE_UNKNOWN = 2,
+} rp1_image_state_t;
+
+#define RP1_RESULT_RECOVERY_REQUIRED    (1u << 0)
+#define RP1_RESULT_EFFECTS_MAY_BE_PARTIAL (1u << 1)
+#define RP1_RESULT_INFINITE_WORK_REMAINS  (1u << 2)
+#define RP1_RESULT_TRACE_ENABLED          (1u << 3)
+#define RP1_RESULT_TRACE_OVERFLOW         (1u << 4)
+#define RP1_RESULT_UNREACHED_NODES        (1u << 5)
+
+#define RP1_QUIESCE_FINITE_DONE_SHIFT      0u
+#define RP1_QUIESCE_FINITE_TIMEOUT_SHIFT   8u
+#define RP1_QUIESCE_INFINITE_SHIFT        16u
+#define RP1_QUIESCE_COUNT_MASK             0xFFu
+#define RP1_QUIESCE_PACK(done, timeout, infinite)                       \
+    ((((uint32_t)(done) & RP1_QUIESCE_COUNT_MASK)                       \
+      << RP1_QUIESCE_FINITE_DONE_SHIFT) |                               \
+     (((uint32_t)(timeout) & RP1_QUIESCE_COUNT_MASK)                    \
+      << RP1_QUIESCE_FINITE_TIMEOUT_SHIFT) |                            \
+     (((uint32_t)(infinite) & RP1_QUIESCE_COUNT_MASK)                   \
+      << RP1_QUIESCE_INFINITE_SHIFT))
+
+typedef struct {
+    volatile uint32_t magic;               /* Written last: RP1_GRAPH_RESULT_MAGIC */
+    volatile uint32_t graph_seq;           /* Accepted graph sequence               */
+    volatile uint32_t outcome;             /* rp1_graph_outcome_t                    */
+    volatile uint32_t flags;               /* RP1_RESULT_*                           */
+    volatile uint32_t error_code;          /* First terminal RP1_ERR_* code          */
+    volatile uint32_t terminal_node;        /* Failing or HALT node                   */
+    volatile uint32_t terminal_opcode;      /* Opcode at terminal_node                */
+    volatile uint32_t error_detail;         /* Error-specific primary detail          */
+    volatile uint32_t error_aux;            /* Error-specific auxiliary detail        */
+    volatile uint32_t active_image_id;      /* Final known image id, or 0             */
+    volatile uint32_t image_state;          /* rp1_image_state_t                      */
+    volatile uint32_t completed_operations; /* Successful node executions             */
+    volatile uint32_t graph_elapsed_ticks;  /* Graph work through GRAPH_DONE          */
+    volatile uint32_t publish_elapsed_ticks;/* Includes final trace/result preparation */
+    volatile uint32_t trace_write_idx;      /* Final monotonic trace producer cursor  */
+    volatile uint32_t quiescence;           /* RP1_QUIESCE_PACK counts                */
+} rp1_graph_result_t;
+
+/* =========================================================================
  * Trace events (optional trace ring)
  * ====================================================================== */
 
@@ -205,10 +260,12 @@ typedef enum {
     RP1_TRACE_PDI_LOAD       = 9,
     RP1_TRACE_IMAGE_MISMATCH = 10,
     RP1_TRACE_GRAPH_DONE     = 11,
+    RP1_TRACE_FLUSH_START    = 12,
+    RP1_TRACE_FLUSH_END      = 13,
 } rp1_trace_event_t;
 
 /* =========================================================================
- * Payload structures (each 48 bytes, embedded in rp1_node_t)
+ * Payload structures (embedded in the 20-byte rp1_node_t payload)
  * ====================================================================== */
 
 /* Single kernel argument register write -- protocol v2.
@@ -224,7 +281,7 @@ typedef struct {
     uint32_t value;        /* 32-bit value to write                           */
 } rp1_kernel_arg_t;
 
-/* KERNEL_DISPATCH (0x0010)
+/* KERNEL_DISPATCH
  *
  * arg_buffer_offset is the byte offset into the shared argument buffer where
  * this kernel's rp1_kernel_arg_t[] begins; arg_count is the number of
@@ -235,55 +292,55 @@ typedef struct {
     uint32_t kernel_base_addr;   /* AXI-Lite base in R5 address space        */
     uint32_t arg_buffer_offset;  /* Byte offset into argument buffer          */
     uint16_t arg_count;          /* Number of (reg_offset, value) arg pairs   */
-    uint16_t ctrl_flags;         /* Bit 0: auto-restart                       */
+    uint8_t  ctrl_flags;         /* Reserved in phase 1; must be zero          */
+    uint8_t  _reserved;
     uint32_t timeout_cycles;     /* PMU ticks; 0 = firmware default           */
     uint32_t expected_image_id;  /* Image this kernel needs; 0 = no guard.
                                   * If non-zero and != the image last loaded
                                   * by PDI_LOAD, RP1 fails the node fast       */
-    uint8_t  _reserved[28];
 } rp1_payload_kernel_dispatch_t;
 
-/* SCALAR_WRITE (0x0011) -- up to 6 register writes, stop at first addr == 0. */
+/* SCALAR_WRITE -- up to two register writes, stop at first addr == 0. */
 typedef struct {
     uint32_t addr;
     uint32_t value;
 } rp1_write_pair_t;
 
-#define RP1_SCALAR_WRITE_MAX  6
+#define RP1_SCALAR_WRITE_MAX  2
 
 typedef struct {
     rp1_write_pair_t writes[RP1_SCALAR_WRITE_MAX];
+    uint8_t _reserved[4];
 } rp1_payload_scalar_write_t;
 
-/* SCALAR_READ (0x0012) */
+/* SCALAR_READ */
 typedef struct {
     uint32_t source_addr;    /* AXI-Lite address to read            */
-    uint32_t target_slot;    /* Signal array slot index (0-255)     */
-    uint8_t  _reserved[40];
+    uint8_t  target_slot;    /* Signal array slot index (0-255)     */
+    uint8_t  _reserved[3];
 } rp1_payload_scalar_read_t;
 
-/* SCALAR_COPY (0x0013) -- copy a signal slot's value into an AXI-Lite register.
+/* SCALAR_COPY -- copy a signal slot's value into an AXI-Lite register.
  *
  * The slot<->register inverse of SCALAR_READ: writes g_signals[source_slot] to
  * dest_addr.  Used to feed a loop-carried scalar held in a host-visible signal
  * slot into a body kernel's s_axilite input register each iteration, so the
  * carried value can flow through a kernel argument rather than a DDR buffer. */
 typedef struct {
-    uint32_t source_slot;    /* Signal array slot index to read     */
     uint32_t dest_addr;      /* AXI-Lite address to write           */
-    uint8_t  _reserved[40];
+    uint8_t  source_slot;    /* Signal array slot index to read     */
+    uint8_t  _reserved[3];
 } rp1_payload_scalar_copy_t;
 
-/* SIGNAL (0x0002) */
+/* SIGNAL */
 typedef struct {
-    uint32_t target_slot;    /* Signal array slot index (0-255)     */
     uint32_t value;
-    uint16_t operation;      /* rp1_sigop_t                         */
-    uint16_t _reserved0;
-    uint8_t  _reserved1[36];
+    uint8_t  target_slot;    /* Signal array slot index (0-255)     */
+    uint8_t  operation;      /* rp1_sigop_t                         */
+    uint8_t  _reserved[2];
 } rp1_payload_signal_t;
 
-/* WAIT (0x0001) -- block the node until a signal slot satisfies a condition.
+/* WAIT -- block the node until a signal slot satisfies a condition.
  *
  * The cross-queue rendezvous primitive: another command queue (a peer device's
  * RP1 graph, or the host writing over the BAR) raises @c condition_signal via
@@ -295,37 +352,95 @@ typedef struct {
  * outstanding the scanner keeps polling (it does not wfi), so host-written
  * signal updates are observed promptly. */
 typedef struct {
-    uint32_t condition_signal;  /* Signal array slot to poll           */
     uint32_t condition_value;   /* Comparison value                    */
-    uint16_t condition_op;      /* rp1_condop_t                        */
-    uint16_t _reserved0;
-    uint8_t  _reserved1[36];
+    uint8_t  condition_signal;  /* Signal array slot to poll           */
+    uint8_t  condition_op;      /* rp1_condop_t                        */
+    uint8_t  _reserved[2];
 } rp1_payload_wait_t;
 
-/* DMA_COPY (0x0020) */
+/* DMA_COPY */
 typedef struct {
     uint32_t src_addr_lo;
     uint32_t src_addr_hi;
     uint32_t dst_addr_lo;
     uint32_t dst_addr_hi;
-    uint32_t length;
-    uint16_t src_type;   /* 0=DDR, 1=HBM, 2=HOST */
-    uint16_t dst_type;
-    uint8_t  _reserved[24];
+    uint32_t length_types;
 } rp1_payload_dma_copy_t;
 
-/* DMA_FILL (0x0021) */
+#define RP1_DMA_LENGTH_MASK     0x0FFFFFFFu
+#define RP1_DMA_SRC_TYPE_SHIFT  28u
+#define RP1_DMA_DST_TYPE_SHIFT  30u
+#define RP1_DMA_TYPE_MASK       0x3u
+
+/**
+ * Return a packed DMA copy length and endpoint-type word.
+ *
+ * Values outside the 28-bit length and 2-bit type ranges are truncated.
+ */
+static inline uint32_t rp1_dma_pack(uint32_t length, uint8_t src_type,
+                                    uint8_t dst_type)
+{
+    return (length & RP1_DMA_LENGTH_MASK) |
+           (((uint32_t)src_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_SRC_TYPE_SHIFT) |
+           (((uint32_t)dst_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_DST_TYPE_SHIFT);
+}
+
+/** Return the byte length encoded in a packed DMA copy word. */
+static inline uint32_t rp1_dma_get_length(uint32_t packed)
+{
+    return packed & RP1_DMA_LENGTH_MASK;
+}
+
+/** Return the source memory type encoded in a packed DMA copy word. */
+static inline uint8_t rp1_dma_get_src_type(uint32_t packed)
+{
+    return (uint8_t)((packed >> RP1_DMA_SRC_TYPE_SHIFT) &
+                     RP1_DMA_TYPE_MASK);
+}
+
+/** Return the destination memory type encoded in a packed DMA copy word. */
+static inline uint8_t rp1_dma_get_dst_type(uint32_t packed)
+{
+    return (uint8_t)((packed >> RP1_DMA_DST_TYPE_SHIFT) &
+                     RP1_DMA_TYPE_MASK);
+}
+
+/** Replace the byte length in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_length(uint32_t packed, uint32_t length)
+{
+    return (packed & ~RP1_DMA_LENGTH_MASK) |
+           (length & RP1_DMA_LENGTH_MASK);
+}
+
+/** Replace the source memory type in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_src_type(uint32_t packed, uint8_t src_type)
+{
+    return (packed & ~(RP1_DMA_TYPE_MASK << RP1_DMA_SRC_TYPE_SHIFT)) |
+           (((uint32_t)src_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_SRC_TYPE_SHIFT);
+}
+
+/** Replace the destination memory type in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_dst_type(uint32_t packed, uint8_t dst_type)
+{
+    return (packed & ~(RP1_DMA_TYPE_MASK << RP1_DMA_DST_TYPE_SHIFT)) |
+           (((uint32_t)dst_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_DST_TYPE_SHIFT);
+}
+
+/* DMA_FILL */
 typedef struct {
     uint32_t dst_addr_lo;
     uint32_t dst_addr_hi;
     uint32_t length;
     uint32_t pattern;
-    uint16_t dst_type;
-    uint16_t _reserved0;
-    uint8_t  _reserved1[28];
+    uint8_t  dst_type;
+    uint8_t  _reserved[3];
 } rp1_payload_dma_fill_t;
 
-/* PDI_LOAD (0x0030) -- partial PDI reconfiguration via PMC IPI.
+/* PDI_LOAD -- partial PDI reconfiguration via PMC IPI.
  *
  * The host pre-stages a partial PDI in DDR at (pdi_addr_hi << 32 | pdi_addr_lo)
  * and submits this node.  When the node fires, RP1 issues the canonical
@@ -341,62 +456,57 @@ typedef struct {
     uint32_t image_id;        /* Image id this PDI installs; recorded as
                                * the active image so KERNEL_DISPATCH can
                                * guard against stale dispatches. 0 = none */
-    uint8_t  _reserved1[32];
+    uint8_t  _reserved[4];
 } rp1_payload_pdi_load_t;
 
-/* LOOP (0x0040) */
+/* LOOP */
 typedef struct {
-    uint32_t body_start;          /* First node index of loop body     */
-    uint32_t body_end;            /* Last node index (inclusive)        */
+    uint16_t body_start;          /* First node index of loop body     */
+    uint16_t body_end;            /* Last node index (inclusive)        */
     uint32_t max_iterations;      /* Hard cap (0 = condition-only)     */
-    uint32_t condition_signal;    /* Signal array slot to check        */
     uint32_t condition_value;     /* Exit when signal matches          */
-    uint16_t condition_op;        /* rp1_condop_t                      */
+    uint8_t  condition_signal;    /* Signal array slot to check        */
+    uint8_t  condition_op;        /* rp1_condop_t                      */
     uint8_t  bucket_clear_start;  /* First bucket to clear per iter    */
     uint8_t  bucket_clear_end;    /* Last bucket to clear (inclusive)  */
     uint8_t  loop_id;             /* Index into loop_iterations[]      */
-    uint8_t  _reserved[23];
+    uint8_t  _reserved[3];
 } rp1_payload_loop_t;
 
-/* COND (0x0041) */
+/* COND */
 typedef struct {
-    uint32_t condition_signal;    /* Signal slot to evaluate           */
     uint32_t condition_value;
-    uint16_t condition_op;        /* rp1_condop_t                      */
+    uint32_t done_mask;
+    uint16_t body_start;          /* First node index (inclusive)      */
+    uint16_t body_end;            /* Last node index (inclusive)       */
+    uint8_t  condition_signal;    /* Signal slot to evaluate           */
+    uint8_t  condition_op;        /* rp1_condop_t                      */
     uint8_t  bucket_clear_start;  /* First bucket to clear (inclusive) */
     uint8_t  bucket_clear_end;    /* Last bucket to clear (inclusive)  */
-    uint32_t body_start;          /* First node index (inclusive)      */
-    uint32_t body_end;            /* Last node index (inclusive)       */
     uint8_t  done_bucket;
-    uint8_t  _reserved0[3];
-    uint32_t done_mask;
-    uint8_t  _reserved1[20];
+    uint8_t  _reserved[3];
 } rp1_payload_cond_t;
 
-/* RERUN (0x0042) */
+/* RERUN */
 typedef struct {
-    uint32_t target_node;    /* Node index to reset DONE -> PENDING  */
-    uint16_t rerun_flags;    /* RP1_RERUN_CLEAR_STATE                */
+    uint16_t target_node;    /* Node index to reset DONE -> PENDING  */
+    uint8_t  rerun_flags;    /* RP1_RERUN_CLEAR_STATE                */
     uint8_t  loop_id;        /* Loop ID to clear (if CLEAR_STATE)    */
-    uint8_t  _reserved0[1];
-    uint8_t  _reserved1[40];
+    uint8_t  _reserved[16];
 } rp1_payload_rerun_t;
 
 /* =========================================================================
- * Node packet -- 64 bytes, 16-byte header + 48-byte payload
+ * Node packet -- 32 bytes, 12-byte header + 20-byte payload
  * ====================================================================== */
 
 typedef struct {
-    /* Header (16 bytes) */
-    uint16_t opcode;               /* rp1_opcode_t                          */
-    uint16_t flags;                /* RP1_FLAG_*                            */
-    uint32_t barrier_await_mask;   /* Which bits in await_bucket must be set */
-    uint32_t barrier_set_mask;     /* Which bits in set_bucket to raise      */
+    uint16_t control;              /* Packed opcode, flags, and status      */
     uint8_t  barrier_await_bucket; /* Which of 32 buckets to check (0-31)   */
     uint8_t  barrier_set_bucket;   /* Which of 32 buckets to write (0-31)   */
-    uint16_t status;               /* rp1_node_status_t, written by RP1     */
+    uint32_t barrier_await_mask;   /* Which bits in await_bucket must be set */
+    uint32_t barrier_set_mask;     /* Which bits in set_bucket to raise      */
 
-    /* Payload (48 bytes) */
+    /* Payload (20 bytes) */
     union {
         rp1_payload_kernel_dispatch_t kernel_dispatch;
         rp1_payload_scalar_write_t    scalar_write;
@@ -410,9 +520,85 @@ typedef struct {
         rp1_payload_loop_t            loop;
         rp1_payload_cond_t            cond;
         rp1_payload_rerun_t           rerun;
-        uint8_t raw[48];
+        uint8_t raw[20];
     } payload;
 } rp1_node_t;
+
+/**
+ * Build a control word from unshifted opcode, flag, and status values.
+ *
+ * Values are truncated to their four-bit fields and reserved bits are zero.
+ */
+static inline uint16_t rp1_node_make_control(uint16_t opcode, uint16_t flags,
+                                             uint16_t status)
+{
+    return (uint16_t)(((opcode << RP1_NODE_OPCODE_SHIFT) &
+                       RP1_NODE_OPCODE_MASK) |
+                      ((flags << RP1_NODE_FLAGS_SHIFT) &
+                       RP1_NODE_FLAGS_MASK) |
+                      ((status << RP1_NODE_STATUS_SHIFT) &
+                       RP1_NODE_STATUS_MASK));
+}
+
+/** Return the complete packed node control word. */
+static inline uint16_t rp1_node_get_control(const rp1_node_t *node)
+{
+    return node->control;
+}
+
+/** Replace the complete packed node control word. */
+static inline void rp1_node_set_control(rp1_node_t *node, uint16_t control)
+{
+    node->control = control;
+}
+
+/** Return the unshifted opcode nibble from a node. */
+static inline uint8_t rp1_node_get_opcode(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_OPCODE_MASK) >>
+                     RP1_NODE_OPCODE_SHIFT);
+}
+
+/** Replace the opcode nibble without changing flags, status, or reserved bits. */
+static inline void rp1_node_set_opcode(rp1_node_t *node, uint16_t opcode)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_OPCODE_MASK) |
+                   ((opcode << RP1_NODE_OPCODE_SHIFT) &
+                    RP1_NODE_OPCODE_MASK));
+}
+
+/** Return the unshifted flags nibble from a node. */
+static inline uint8_t rp1_node_get_flags(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_FLAGS_MASK) >>
+                     RP1_NODE_FLAGS_SHIFT);
+}
+
+/** Replace the flags nibble without changing opcode, status, or reserved bits. */
+static inline void rp1_node_set_flags(rp1_node_t *node, uint16_t flags)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_FLAGS_MASK) |
+                   ((flags << RP1_NODE_FLAGS_SHIFT) &
+                    RP1_NODE_FLAGS_MASK));
+}
+
+/** Return the unshifted status nibble from a node. */
+static inline uint8_t rp1_node_get_status(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_STATUS_MASK) >>
+                     RP1_NODE_STATUS_SHIFT);
+}
+
+/** Replace the status nibble without changing opcode, flags, or reserved bits. */
+static inline void rp1_node_set_status(rp1_node_t *node, uint16_t status)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_STATUS_MASK) |
+                   ((status << RP1_NODE_STATUS_SHIFT) &
+                    RP1_NODE_STATUS_MASK));
+}
 
 /* =========================================================================
  * Control block -- 4 KB DDR region at RP1_CTRL_PHYS_ADDR
@@ -420,19 +606,21 @@ typedef struct {
 
 #define RP1_CTRL_MAGIC  0x53515231UL  /* "SQR1" */
 
-/* Protocol-v4 firmware capabilities.  These bits describe support for the
- * reserved v4 contracts; host code must reject firmware missing any bit in
+/* Protocol-v6 firmware capabilities.  These bits describe support for the
+ * reserved v6 contracts; host code must reject firmware missing any bit in
  * RP1_REQUIRED_CAPABILITIES. */
 #define RP1_CAP_PLATFORM_PDI_IPI_CONFIG   (1u << 0)
 #define RP1_CAP_PMU_CYCLE_TIMEOUTS        (1u << 1)
-#define RP1_CAP_CQ_FLOW_CONTROL           (1u << 2)
 #define RP1_CAP_STRUCTURED_PDI_RESPONSE   (1u << 3)
 #define RP1_CAP_LATCHED_TERMINAL_ERRORS   (1u << 4)
+#define RP1_CAP_BTCM_TRACE_STAGING        (1u << 5)
+#define RP1_CAP_GRAPH_RESULT              (1u << 6)
 
 #define RP1_REQUIRED_CAPABILITIES                                      \
     (RP1_CAP_PLATFORM_PDI_IPI_CONFIG | RP1_CAP_PMU_CYCLE_TIMEOUTS |   \
-     RP1_CAP_CQ_FLOW_CONTROL | RP1_CAP_STRUCTURED_PDI_RESPONSE |      \
-     RP1_CAP_LATCHED_TERMINAL_ERRORS)
+     RP1_CAP_STRUCTURED_PDI_RESPONSE |                                \
+     RP1_CAP_LATCHED_TERMINAL_ERRORS | RP1_CAP_BTCM_TRACE_STAGING |   \
+     RP1_CAP_GRAPH_RESULT)
 
 #define RP1_PDI_IPI_PLATFORM_UNKNOWN  0u
 #define RP1_TERMINAL_ERROR_NODE_NONE  0xFFFFFFFFu
@@ -443,17 +631,16 @@ typedef struct {
     volatile uint32_t version;          /* 0x04: protocol version                */
     /* Host writes, RP1 reads */
     volatile uint32_t node_count;       /* 0x08: nodes in this graph             */
-    volatile uint32_t cq_size;          /* 0x0C: power of 2, <= MAX_CQ_ENTRIES   */
+    volatile uint32_t _reserved_cq_size;/* 0x0C: must be zero in protocol v6     */
     volatile uint32_t node_base_lo;     /* 0x10: node array base (low 32 bits)   */
     volatile uint32_t node_base_hi;     /* 0x14: node array base (high 32 bits)  */
-    volatile uint32_t cq_base_lo;       /* 0x18: CQ base (low 32 bits)           */
-    volatile uint32_t cq_base_hi;       /* 0x1C: CQ base (high 32 bits)          */
+    volatile uint32_t _reserved_cq_base_lo; /* 0x18: must be zero in v6           */
+    volatile uint32_t _reserved_cq_base_hi; /* 0x1C: must be zero in v6           */
     volatile uint32_t graph_seq;        /* 0x20: host increments per graph        */
     /* RP1 writes */
     volatile uint32_t graph_done_seq;   /* 0x24: last completed graph             */
-    volatile uint32_t cq_write_idx;     /* 0x28: next CQ write position          */
-    /* Host writes */
-    volatile uint32_t cq_read_idx;      /* 0x2C: next unread CQ position         */
+    volatile uint32_t _reserved_cq_write_idx; /* 0x28: zero in protocol v6         */
+    volatile uint32_t _reserved_cq_read_idx;  /* 0x2C: zero in protocol v6         */
     /* RP1 writes */
     volatile uint32_t rp1_state;        /* 0x30: rp1_state_t                     */
     volatile uint32_t rp1_error_code;   /* 0x34: last error code                 */
@@ -469,13 +656,15 @@ typedef struct {
     volatile uint32_t trace_base_hi;    /* 0x58: trace ring base (high 32 bits)  */
     volatile uint32_t trace_size;       /* 0x5C: trace entries (power of 2)      */
     volatile uint32_t trace_write_idx;  /* 0x60: next trace write position       */
-    /* RP1 writes: protocol-v4 contract publication and diagnostics */
+    /* RP1 writes: protocol-v6 contract publication and diagnostics */
     volatile uint32_t capabilities;          /* 0x64: RP1_CAP_*                    */
     volatile uint32_t pdi_ipi_platform_id;   /* 0x68: selected IPI/platform config */
     volatile uint32_t terminal_error_node;   /* 0x6C: latched failing node         */
     volatile uint32_t terminal_error_detail; /* 0x70: structured error detail      */
     volatile uint32_t terminal_error_aux;    /* 0x74: structured auxiliary detail  */
-    uint8_t _reserved[0x1000 - 0x78];
+    uint32_t _reserved_result_align[2];      /* 0x78-0x7F                       */
+    rp1_graph_result_t result;               /* 0x80-0xBF: committed graph result */
+    uint8_t _reserved[0x1000 - 0xC0];
 } rp1_ctrl_t;
 
 /* =========================================================================
@@ -490,23 +679,6 @@ typedef struct {
     volatile uint32_t last_writer_node; /* Node that last wrote               */
     volatile uint32_t flags;            /* RP1_SIG_FLAG_*                     */
 } rp1_signal_slot_t;
-
-/* =========================================================================
- * Completion queue entry -- 16 bytes
- * ====================================================================== */
-
-typedef enum {
-    RP1_CQ_OK      = 0,
-    RP1_CQ_ERROR   = 1,
-    RP1_CQ_TIMEOUT = 2,
-} rp1_cq_status_t;
-
-typedef struct {
-    volatile uint32_t node_index;    /* Which node completed               */
-    volatile uint32_t status;        /* rp1_cq_status_t                    */
-    volatile uint32_t error_detail;  /* Opcode-specific error code         */
-    volatile uint32_t timestamp;     /* PMU ticks since graph start        */
-} rp1_cq_entry_t;
 
 /* =========================================================================
  * Trace queue entry -- 16 bytes
@@ -540,18 +712,17 @@ typedef struct {
  * Compile-time size constants
  * ====================================================================== */
 
-#define RP1_MAX_NODES          4096
-#define RP1_MAX_CQ_ENTRIES     4096
+#define RP1_MAX_NODES          1024
 #define RP1_MAX_TRACE_ENTRIES  4096
 #define RP1_MAX_LOOPS            64
 #define RP1_MAX_INFLIGHT         32
 #define RP1_MAX_SIGNALS         256
 #define RP1_MAX_BUCKETS          32
 
-#define RP1_PROTOCOL_VERSION  4u
+#define RP1_PROTOCOL_VERSION  6u
 
 /* Cortex-R5 PMCCNTR is configured with PMCR.D, so one protocol PMU tick is
- * exactly 64 R5 core cycles. timeout_cycles and trace/CQ timestamps use this
+ * exactly 64 R5 core cycles. timeout_cycles and trace/result timestamps use this
  * unit. Hardware defaults are derived from the generated R5 clock frequency. */
 #define RP1_PMU_CYCLE_DIVISOR             64u
 #define RP1_DEFAULT_KERNEL_TIMEOUT_MS    1000u
@@ -569,41 +740,109 @@ typedef struct {
 #  define RP1_STATIC_ASSERT(cond, msg) _Static_assert((cond), msg)
 #endif
 
-/* Node packet must be exactly 64 bytes with payload at offset 16. */
-RP1_STATIC_ASSERT(sizeof(rp1_node_t) == 64,
-                  "rp1_node_t must be exactly 64 bytes");
-RP1_STATIC_ASSERT(offsetof(rp1_node_t, payload) == 16,
-                  "rp1_node_t payload must start at byte 16");
+/* Node packet must be exactly 32 bytes with payload at offset 12. */
+RP1_STATIC_ASSERT(sizeof(rp1_node_t) == 32,
+                  "rp1_node_t must be exactly 32 bytes");
+#if defined(__cplusplus)
+RP1_STATIC_ASSERT(alignof(rp1_node_t) == 4,
+                  "rp1_node_t must be naturally four-byte aligned");
+#else
+RP1_STATIC_ASSERT(_Alignof(rp1_node_t) == 4,
+                  "rp1_node_t must be naturally four-byte aligned");
+#endif
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, control) == 0,
+                  "rp1_node_t control must start at byte 0");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_await_bucket) == 2,
+                  "rp1_node_t await bucket must start at byte 2");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_set_bucket) == 3,
+                  "rp1_node_t set bucket must start at byte 3");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_await_mask) == 4,
+                  "rp1_node_t await mask must start at byte 4");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_set_mask) == 8,
+                  "rp1_node_t set mask must start at byte 8");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, payload) == 12,
+                  "rp1_node_t payload must start at byte 12");
 
 /* Kernel argument pair (protocol v2) must be exactly 8 bytes. */
 RP1_STATIC_ASSERT(sizeof(rp1_kernel_arg_t) == 8,
                   "rp1_kernel_arg_t must be exactly 8 bytes");
 
-/* Each payload variant must fit in the 48-byte payload union. */
-RP1_STATIC_ASSERT(sizeof(rp1_payload_kernel_dispatch_t) == 48,
-                  "kernel_dispatch payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_write_t)    == 48,
-                  "scalar_write payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_read_t)     == 48,
-                  "scalar_read payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_copy_t)     == 48,
-                  "scalar_copy payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_signal_t)          == 48,
-                  "signal payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_wait_t)            == 48,
-                  "wait payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_copy_t)        == 48,
-                  "dma_copy payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_fill_t)        == 48,
-                  "dma_fill payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_pdi_load_t)        == 48,
-                  "pdi_load payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_loop_t)            == 48,
-                  "loop payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_cond_t)            == 48,
-                  "cond payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_rerun_t)           == 48,
-                  "rerun payload must be 48 bytes");
+/* Every payload has its exact protocol-v6 natural size. */
+RP1_STATIC_ASSERT(sizeof(rp1_payload_kernel_dispatch_t) == 20,
+                  "kernel_dispatch payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_write_t)    == 20,
+                  "scalar_write payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_read_t)     == 8,
+                  "scalar_read payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_copy_t)     == 8,
+                  "scalar_copy payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_signal_t)          == 8,
+                  "signal payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_wait_t)            == 8,
+                  "wait payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_copy_t)        == 20,
+                  "dma_copy payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_fill_t)        == 20,
+                  "dma_fill payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_pdi_load_t)        == 20,
+                  "pdi_load payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_loop_t)            == 20,
+                  "loop payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_cond_t)            == 20,
+                  "cond payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_rerun_t)           == 20,
+                  "rerun payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(((rp1_node_t *)0)->payload.raw) == 20,
+                  "raw payload must be 20 bytes");
+
+/* Compact payload field offsets are part of the wire ABI. */
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, arg_count) == 8,
+                  "dispatch arg_count offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, ctrl_flags) == 10,
+                  "dispatch ctrl_flags offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, timeout_cycles) == 12,
+                  "dispatch timeout offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t,
+                           expected_image_id) == 16,
+                  "dispatch image offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_scalar_read_t, target_slot) == 4,
+                  "scalar_read target offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_scalar_copy_t, source_slot) == 4,
+                  "scalar_copy source offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_signal_t, target_slot) == 4,
+                  "signal target offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_signal_t, operation) == 5,
+                  "signal operation offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_wait_t, condition_signal) == 4,
+                  "wait signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_wait_t, condition_op) == 5,
+                  "wait operation offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_dma_copy_t, length_types) == 16,
+                  "dma_copy packed offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_dma_fill_t, dst_type) == 16,
+                  "dma_fill type offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_pdi_load_t, image_id) == 12,
+                  "pdi_load image offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, max_iterations) == 4,
+                  "loop maximum offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, condition_value) == 8,
+                  "loop value offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, condition_signal) == 12,
+                  "loop signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, loop_id) == 16,
+                  "loop id offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, done_mask) == 4,
+                  "cond done mask offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, body_start) == 8,
+                  "cond body offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, condition_signal) == 12,
+                  "cond signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, done_bucket) == 16,
+                  "cond done bucket offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_rerun_t, rerun_flags) == 2,
+                  "rerun flags offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_rerun_t, loop_id) == 3,
+                  "rerun loop offset");
 
 /* Control block must be exactly 4 KB. */
 RP1_STATIC_ASSERT(sizeof(rp1_ctrl_t) == 0x1000,
@@ -613,13 +852,13 @@ RP1_STATIC_ASSERT(sizeof(rp1_ctrl_t) == 0x1000,
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, magic)              == 0x00, "ctrl.magic offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, version)            == 0x04, "ctrl.version offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, node_count)         == 0x08, "ctrl.node_count offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_size)            == 0x0C, "ctrl.cq_size offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_size)  == 0x0C, "ctrl.reserved_cq_size offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, node_base_lo)       == 0x10, "ctrl.node_base_lo offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_base_lo)         == 0x18, "ctrl.cq_base_lo offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_base_lo) == 0x18, "ctrl.reserved_cq_base offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, graph_seq)          == 0x20, "ctrl.graph_seq offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, graph_done_seq)     == 0x24, "ctrl.graph_done_seq offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_write_idx)       == 0x28, "ctrl.cq_write_idx offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_read_idx)        == 0x2C, "ctrl.cq_read_idx offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_write_idx) == 0x28, "ctrl.reserved_cq_write offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_read_idx) == 0x2C, "ctrl.reserved_cq_read offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, rp1_state)          == 0x30, "ctrl.rp1_state offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, heartbeat)          == 0x3C, "ctrl.heartbeat offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, arg_buf_base_lo)    == 0x40, "ctrl.arg_buf_base_lo offset");
@@ -634,12 +873,13 @@ RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, pdi_ipi_platform_id)== 0x68, "ctrl.pdi_ip
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_node)== 0x6C, "ctrl.terminal_error_node offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_detail) == 0x70, "ctrl.terminal_error_detail offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_aux) == 0x74, "ctrl.terminal_error_aux offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, result)             == 0x80, "ctrl.result offset");
 
-/* Signal slot, CQ entry, inflight tracker sizes. */
+/* Result, signal slot, trace entry, and inflight tracker sizes. */
+RP1_STATIC_ASSERT(sizeof(rp1_graph_result_t) == 64,
+                  "rp1_graph_result_t must be 64 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_signal_slot_t) == 16,
                   "rp1_signal_slot_t must be 16 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_cq_entry_t) == 16,
-                  "rp1_cq_entry_t must be 16 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_trace_entry_t) == 16,
                   "rp1_trace_entry_t must be 16 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_inflight_t) == 24,
@@ -648,14 +888,6 @@ RP1_STATIC_ASSERT(offsetof(rp1_inflight_t, timeout_start) == 0x0C,
                   "inflight timeout_start offset");
 RP1_STATIC_ASSERT(offsetof(rp1_inflight_t, timeout_cycles) == 0x10,
                   "inflight timeout_cycles offset");
-RP1_STATIC_ASSERT(RP1_DEFAULT_CQ_OFFSET +
-                      RP1_MAX_CQ_ENTRIES * sizeof(rp1_cq_entry_t) <=
-                  RP1_DEFAULT_ARG_BUF_OFFSET,
-                  "maximum default CQ must not overlap argument buffer");
-RP1_STATIC_ASSERT(RP1_MAX_CQ_ENTRIES != 0 &&
-                      (RP1_MAX_CQ_ENTRIES &
-                       (RP1_MAX_CQ_ENTRIES - 1)) == 0,
-                  "maximum CQ entries must be a power of two");
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ This directory contains the example projects for VRT. Each example demonstrates 
 | `graph/00_multi_image_pipeline` | VRT graph FPGA backend (`vrt::graph`) | End-to-end HSA graph demo: CPU + FPGA kernels in one `vrt::graph::Graph`, one-call device bring-up via `Graph::addFpga(...)`, explicit `PDI_LOAD` reprogram nodes, and a fixed-count loop carrying state. See [graph/00_multi_image_pipeline/README.md](graph/00_multi_image_pipeline/README.md). |
 | `graph/01_edge_detection` | `vrt::graph` tutorial, Algorithm 1 | Basic graph authoring: CPU/FPGA kernels, buffers, scalars, and one reprogram gating three kernels (two of which run concurrently) in a single vbin image. See [graph/01_edge_detection/README.md](graph/01_edge_detection/README.md). |
 | `graph/02_sharpen_loop` | `vrt::graph` tutorial, Algorithm 2 | Loops and conditionals: a fixed-count loop carrying state through an FPGA kernel, run in parallel with a CPU reduction, followed by a post-loop conditional. See [graph/02_sharpen_loop/README.md](graph/02_sharpen_loop/README.md). |
+| `extra/rp1_latency` | RP1 command processor latency microbenchmarks | Not a tutorial: compares the RP1 dispatch path against the legacy host-driven VRT path on one no-op kernel. Standalone build, see [extra/rp1_latency/README.md](extra/rp1_latency/README.md). |
 
 ## How to run the examples
 

--- a/examples/extra/rp1_latency/CMakeLists.txt
+++ b/examples/extra/rp1_latency/CMakeLists.txt
@@ -1,0 +1,84 @@
+# ##################################################################################################
+#  The MIT License (MIT)
+#  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+#  and associated documentation files (the "Software"), to deal in the Software without restriction,
+#  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+#  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all copies or
+#  substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+#  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ##################################################################################################
+
+cmake_minimum_required(VERSION 3.20)
+project(rp1_latency LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(VRT_USE_REPO "Build VRT and its dependencies from this repository" OFF)
+option(BUILD_VBIN "Build the hardware vbin (requires Vivado/Vitis)" ON)
+
+if(VRT_USE_REPO)
+  get_filename_component(REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." REALPATH)
+  set(VRT_INCLUDE_VRTD ON CACHE BOOL "Build vrtd from the repository" FORCE)
+  set(VRTD_INCLUDE_LIBSLASH ON CACHE BOOL "Build libslash from the repository" FORCE)
+  add_subdirectory("${REPO_ROOT}/vrt" "${CMAKE_CURRENT_BINARY_DIR}/vrt")
+  set(_VRT_TARGET vrt)
+else()
+  find_package(vrt REQUIRED CONFIG)
+  set(_VRT_TARGET vrt::vrt)
+endif()
+
+add_executable(rp1_latency rp1_latency.cpp)
+target_link_libraries(rp1_latency PRIVATE ${_VRT_TARGET})
+target_compile_options(rp1_latency PRIVATE -Wall -Wextra)
+
+if(BUILD_VBIN)
+  if(VRT_USE_REPO)
+    list(APPEND CMAKE_MODULE_PATH "${REPO_ROOT}/cmake")
+    include(SlashTools)
+  else()
+    find_package(SlashTools REQUIRED)
+  endif()
+
+  set(DEVICE "xcv80-lsva4737-2MHP-e-S" CACHE STRING "Target device")
+  build_hls_dir(
+    TARGET      latency_hls
+    ROOT        "${CMAKE_CURRENT_SOURCE_DIR}/hls"
+    DEVICE      "${DEVICE}"
+    KERNELS     latency_kernel
+    OUT_KERNELS _KERNELS
+  )
+  add_vbin(
+    TARGET    rp1_latency_hw
+    PLATFORM  hw
+    CFG       "${CMAKE_CURRENT_SOURCE_DIR}/config.cfg"
+    KERNELS   ${_KERNELS}
+  )
+endif()
+
+include(CTest)
+if(BUILD_TESTING)
+  add_executable(rp1_latency_stats_test latency_stats_test.cpp)
+  target_compile_options(rp1_latency_stats_test PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME rp1_latency_stats COMMAND rp1_latency_stats_test)
+
+  add_executable(rp1_latency_trace_test rp1_latency_trace_test.cpp)
+  target_link_libraries(rp1_latency_trace_test PRIVATE ${_VRT_TARGET})
+  # The test includes the benchmark translation unit to exercise its private
+  # trace parser; hardware-only benchmark helpers are intentionally unused.
+  target_compile_options(
+    rp1_latency_trace_test PRIVATE -Wall -Wextra -Wno-unused-function
+  )
+  add_test(NAME rp1_latency_trace COMMAND rp1_latency_trace_test)
+endif()

--- a/examples/extra/rp1_latency/README.md
+++ b/examples/extra/rp1_latency/README.md
@@ -1,0 +1,193 @@
+# RP1 latency microbenchmarks
+
+This standalone hardware benchmark compares the RP1 command processor with the
+legacy VRT host-driven path on the same V80 and the same no-op HLS kernel. It
+targets latency and dispatch scaling, not application throughput.
+
+## What it measures
+
+- Setup without programming:
+  - `vrt.setup.no_program`
+  - `rp1.setup.add_fpga`
+- User-region programming:
+  - `vrt.program.design_write_reset` calls the vrtd design writer directly. It
+    includes vrtd's PF2 remove/rescan and BAR reopen, but not the legacy
+    `Device` constructor's fixed one-second post-program sleep.
+  - `rp1.program.first_with_staging` includes the first QDMA PDI staging plus
+    `PDI_LOAD`. Vbin extraction and reading the PDI into the graph image spec
+    already happened in `rp1.setup.add_fpga`.
+  - `rp1.program.cached_pdi` reuses the staged PDI and measures `PDI_LOAD`.
+- One no-op kernel:
+  - Legacy VRT `Kernel::start()`, `Kernel::wait()`, and their total.
+  - RP1 backend `launch()`, `wait()`, and their total.
+  - Raw `Rp1Submitter::submitAndWait()` host round trip. The projected backend
+    image includes its lifecycle `SIGNAL` sentinel, so this is a tiny graph
+    round trip rather than a bare one-packet doorbell.
+  - `rp1.result.kernel.graph_elapsed` is the firmware's uninstrumented
+    `Rp1GraphResult::graphElapsedTicks` for that graph.
+  - Instrumented RP1 graph-to-dispatch, launch-to-done, and graph duration in
+    protocol PMU ticks.
+- Sequential batches of 1, 10, and 100 launches by default:
+  - Legacy VRT performs `start()`/`wait()` for each launch.
+  - `vrt.batch.<N>.start_to_next_start` measures adjacent returned
+    `Kernel::start()` calls with the host monotonic clock.
+  - `vrt.batch.<N>.done_to_next_start` measures a returned `Kernel::wait()`
+    to the following returned `Kernel::start()`.
+  - RP1 submits one dependency chain and executes it without host intervention.
+  - `rp1.result.batch.<N>.graph_elapsed` reports the graph-result timing without
+    enabling tracing.
+  - `rp1.trace.batch.10.launch_to_next_launch` measures all nine adjacent
+    `KERNEL_LAUNCH(i)` to `KERNEL_LAUNCH(i+1)` intervals directly.
+  - `rp1.trace.batch.10.done_to_next_launch` summarizes all nine adjacent
+    `KERNEL_DONE(i)` to `KERNEL_LAUNCH(i+1)` handoffs per traced submission.
+  - The corresponding `*_excluding_flush` rows subtract any bracketed
+    `TRACE_FLUSH_START` to `TRACE_FLUSH_END` interval, while `trace_flush`
+    reports the blocking flush itself.
+- Transfers:
+  - Legacy VRT host-to-DDR and DDR-to-host QDMA sync.
+  - RP1 phase-1 DDR-to-DDR software `DMA_COPY`, reported both as host round-trip
+    time and graph-result elapsed ticks. Protocol v6 packs its byte count into
+    28 bits; this benchmark's 8 MiB scratch ranges impose the smaller limit.
+- Differential RP1 memory access tracing:
+  - Chains of 128 immediate nodes execute in one scanner pass, keeping every
+    `NODE_ACTIVATE` interval below the BTCM trace-page flush threshold.
+  - `nop_gap`, `dma_fill_gap`, and `dma_copy_gap` are raw adjacent activation
+    intervals in divided PMU ticks.
+  - `dma_fill_minus_nop` estimates DDR write completion cost.
+  - `dma_copy_minus_nop` estimates combined DDR read/write cost.
+  - `ddr_read_copy_minus_fill` estimates the additional DDR read cost.
+  - Differential rows aggregate the whole chain before dividing and report R5
+    core cycles, recovering sub-80-nanosecond mean resolution.
+  - Four-byte `scalar.write_*` and `scalar.read_*` rows characterize the actual
+    scalar opcodes; SCALAR_READ includes publication to its DDR signal slot.
+
+The transfer metrics are intentionally not presented as a speedup ratio. The
+current RP1 firmware only implements local DDR-to-DDR software copies; it does
+not implement the host/HBM DMA path. VRT buffer sync crosses PCIe, so these are
+different transfer domains.
+
+VRT transfer sizes are logical API byte counts. libvrtd rounds sub-page
+requests to a 4 KiB DMA page; a sub-page host-to-device sync also performs a
+bounce-buffer read/modify/write. The default 4-byte and 64-byte rows therefore
+characterize small-transfer API latency, not literal 4-byte or 64-byte PCIe
+transactions.
+
+## Build
+
+Host-only build on a machine without Vivado:
+
+```bash
+cmake -S examples/extra/rp1_latency -B examples/extra/rp1_latency/build \
+  -G Ninja -DVRT_USE_REPO=ON -DBUILD_VBIN=OFF
+cmake --build examples/extra/rp1_latency/build
+ctest --test-dir examples/extra/rp1_latency/build --output-on-failure
+```
+
+Hardware vbin build on the Vivado/Vitis build server:
+
+```bash
+cmake -S examples/extra/rp1_latency -B examples/extra/rp1_latency/build-hw \
+  -G Ninja -DVRT_USE_REPO=ON
+cmake --build examples/extra/rp1_latency/build-hw --target rp1_latency
+cmake --build examples/extra/rp1_latency/build-hw --target latency_hls
+cmake --build examples/extra/rp1_latency/build-hw --target rp1_latency_hw
+```
+
+The hardware artifact is `rp1_latency_hw.vbin`.
+
+## Run
+
+The FPGA host must run matching protocol-v6 RP1 firmware and vrtd. No other RP1
+submitter may use the card concurrently.
+
+```bash
+timeout --foreground 120s ./rp1_latency \
+  --bdf 0000:65:00.0 \
+  --vbin ./rp1_latency_hw.vbin
+```
+
+Useful overrides:
+
+```bash
+timeout --foreground 300s ./rp1_latency \
+  --bdf 0000:65:00.0 \
+  --vbin ./rp1_latency_hw.vbin \
+  --iterations 200 \
+  --warmup 20 \
+  --program-iterations 5 \
+  --transfer-iterations 50 \
+  --trace-iterations 20 \
+  --batch-sizes 1,10,100 \
+  --transfer-sizes 4,64,4096,1048576 \
+  --memory-sizes 4,64,256,4096 \
+  --memory-chain 128 \
+  --csv > latency.csv
+```
+
+Pass the generated R5 clock with `--r5-hz HZ` to add estimated-nanosecond rows
+for firmware timestamps. One protocol PMU tick is exactly 64 R5 core cycles.
+The benchmark always retains the raw tick rows.
+
+The external timeout is a safety boundary for legacy `Kernel::wait()`, which
+busy-polls without an internal timeout. An RP1 submission has its own 30-second
+timeout, but that timeout poisons the submitter and requires card recovery.
+
+## Reading the results
+
+Each row reports count, minimum, p50, p95, p99, maximum, and mean. Host times
+use `std::chrono::steady_clock` and nanoseconds.
+
+VRT buffer construction happens outside the transfer timers. The transfer rows
+therefore exclude daemon allocation, first-superblock provisioning, QDMA queue
+creation, registration, and mmap costs; they measure repeated `Buffer::sync()`.
+
+`rp1.backend.launch_thread` measures the backend's asynchronous worker launch;
+the RP1 doorbell is written by that worker. It is not the hardware dispatch
+timestamp. Use `rp1.trace.kernel.dispatch` for the firmware-side dispatch
+interval.
+
+Raw RP1 host round trips currently include the submitter's one-millisecond
+polling cadence. Fast graphs can therefore appear quantized near one
+millisecond even when firmware trace intervals are much smaller. Trace runs are
+reported separately because recording timestamps still adds firmware work.
+Every raw submission measures the complete `submitAndWait()` call, including
+firmware-contract preflight, BAR staging, polling, result reads, and protocol
+consistency validation. The benchmark then checks outcome, flags, active image,
+completed operation count, timing, trace state, and quiescence after the stop
+timestamp. Those benchmark-specific checks do not inflate the host-latency
+rows, but submitter validation does.
+
+`rp1.result.*.graph_elapsed` and
+`rp1.transfer.*.graph_elapsed` come from
+`Rp1GraphResult::graphElapsedTicks`. This interval starts when firmware accepts
+the graph and ends immediately after it emits `GRAPH_DONE`; it excludes final
+trace draining and result publication. The associated raw kernel/batch samples
+run with tracing disabled, while the separate `rp1.trace.*` rows intentionally
+measure instrumented executions.
+
+Normal events are staged in a 4 KiB BTCM page. When that page fills, firmware
+blocks to copy it to the shared DDR ring and brackets the copy with
+`TRACE_FLUSH_START/END`. The raw handoff metric includes such a flush when it
+falls between a completion and its successor; the adjusted metric removes it.
+Both metrics still include timestamp capture, dependency scheduling, node
+activation, and the next kernel's no-argument launch. At the V80 R5's 800 MHz
+clock, five microseconds is 62.5 protocol PMU ticks; pass `--r5-hz 800000000`
+to emit estimated-nanosecond rows.
+
+The RP1 transfer graph-result timing includes graph validation, scanner
+dispatch, the software copy, and graph completion. It is not a copy-only
+hardware timer. Programming rows also have intentionally different boundaries,
+as described above, and should not be interpreted as a pure PDI-loader speedup
+ratio.
+
+The memory-trace benchmark uses two private ranges near the end of RP1's
+64 MiB shared window. DMA_FILL and DMA_COPY use identical dependency chains,
+destinations, trace boundaries, and `dsb st` completion semantics. Their
+difference is therefore a practical latency estimate, not a physical DDR
+controller counter. Repeated addresses characterize the hot shared-window path
+used by RP1 telemetry and arguments; they do not model random-address DRAM.
+
+For less noisy host measurements, reserve the machine, pin the process to one
+CPU, use a fixed CPU frequency policy, and repeat the complete run. Programming
+samples modify the user region repeatedly; do not run applications on the same
+card at the same time.

--- a/examples/extra/rp1_latency/config.cfg
+++ b/examples/extra/rp1_latency/config.cfg
@@ -1,0 +1,23 @@
+# ##################################################################################################
+#  The MIT License (MIT)
+#  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+#  and associated documentation files (the "Software"), to deal in the Software without restriction,
+#  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+#  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all copies or
+#  substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+#  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ##################################################################################################
+
+[connectivity]
+shell=service
+nk=latency_kernel:1:latency_kernel_0

--- a/examples/extra/rp1_latency/hls/latency_kernel.cfg
+++ b/examples/extra/rp1_latency/hls/latency_kernel.cfg
@@ -1,0 +1,11 @@
+part=xcv80-lsva4737-2MHP-e-S
+
+[hls]
+flow_target=vivado
+
+syn.top=latency_kernel
+syn.file=latency_kernel.cpp
+clock=4ns
+
+package.output.format=ip_catalog
+package.output.syn=false

--- a/examples/extra/rp1_latency/hls/latency_kernel.cpp
+++ b/examples/extra/rp1_latency/hls/latency_kernel.cpp
@@ -1,0 +1,29 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @brief Complete with the minimum possible ap_ctrl_hs kernel latency.
+ *
+ * The empty body is deliberate: benchmark time should be dominated by
+ * dispatch and completion handling rather than useful kernel work.
+ */
+void latency_kernel() {
+#pragma HLS interface mode=s_axilite port=return
+}

--- a/examples/extra/rp1_latency/latency_stats.hpp
+++ b/examples/extra/rp1_latency/latency_stats.hpp
@@ -1,0 +1,127 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file latency_stats.hpp
+ * @brief Small, dependency-free summaries for latency samples.
+ */
+
+#ifndef RP1_LATENCY_STATS_HPP
+#define RP1_LATENCY_STATS_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace rp1_bench {
+
+/**
+ * @brief Summary of one non-empty set of unsigned latency samples.
+ */
+struct Summary {
+    /// Number of samples represented by this summary.
+    std::size_t count = 0;
+    /// Smallest observed sample.
+    std::uint64_t minimum = 0;
+    /// Nearest-rank 50th percentile.
+    std::uint64_t p50 = 0;
+    /// Nearest-rank 95th percentile.
+    std::uint64_t p95 = 0;
+    /// Nearest-rank 99th percentile.
+    std::uint64_t p99 = 0;
+    /// Largest observed sample.
+    std::uint64_t maximum = 0;
+    /// Arithmetic mean, retained as a floating-point value.
+    long double mean = 0;
+};
+
+/**
+ * @brief Summarize latency samples without modifying the caller's ordering.
+ *
+ * Percentiles use the nearest-rank definition. The function throws
+ * @c std::invalid_argument when @p samples is empty.
+ */
+inline Summary summarize(const std::vector<std::uint64_t>& samples) {
+    if (samples.empty()) {
+        throw std::invalid_argument("summarize: samples must not be empty");
+    }
+
+    std::vector<std::uint64_t> sorted = samples;
+    std::sort(sorted.begin(), sorted.end());
+
+    /*
+     * Nearest rank is stable for small microbenchmark sets and always returns
+     * an observed value. Integer arithmetic avoids rounding drift.
+     */
+    const auto percentile = [&sorted](std::size_t percentage) {
+        const std::size_t rank =
+            (percentage * sorted.size() + 99u) / 100u;
+        return sorted[rank == 0 ? 0 : rank - 1u];
+    };
+
+    long double total = 0;
+    for (std::uint64_t sample : samples) {
+        total += static_cast<long double>(sample);
+    }
+
+    return Summary{
+        samples.size(),
+        sorted.front(),
+        percentile(50),
+        percentile(95),
+        percentile(99),
+        sorted.back(),
+        total / static_cast<long double>(samples.size()),
+    };
+}
+
+/**
+ * @brief Count DDR records produced from normal events and flush markers.
+ *
+ * A staging page flushes after normal events consume all but its final slot.
+ * FLUSH_START occupies that slot and FLUSH_END occupies the first slot of the
+ * new page, so later pages accept one fewer normal event. The function throws
+ * for staging pages smaller than three entries or if the result overflows.
+ */
+inline std::size_t traceEntriesWithFlushMarkers(
+    std::size_t normalEntries, std::size_t stagingEntries = 256) {
+    if (stagingEntries < 3) {
+        throw std::invalid_argument(
+            "traceEntriesWithFlushMarkers: staging page is too small");
+    }
+    if (normalEntries < stagingEntries - 1) return normalEntries;
+
+    const std::size_t flushes =
+        1 + (normalEntries - (stagingEntries - 1)) /
+                (stagingEntries - 2);
+    if (flushes >
+        (std::numeric_limits<std::size_t>::max() - normalEntries) / 2) {
+        throw std::overflow_error(
+            "traceEntriesWithFlushMarkers: result overflows size_t");
+    }
+    return normalEntries + 2 * flushes;
+}
+
+}  // namespace rp1_bench
+
+#endif  // RP1_LATENCY_STATS_HPP

--- a/examples/extra/rp1_latency/latency_stats_test.cpp
+++ b/examples/extra/rp1_latency/latency_stats_test.cpp
@@ -1,0 +1,64 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "latency_stats.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+/**
+ * @brief Exercise ordering, nearest-rank percentiles, mean, and empty input.
+ */
+int main() {
+    const rp1_bench::Summary summary =
+        rp1_bench::summarize({100, 10, 40, 20, 30});
+
+    if (summary.count != 5 ||
+        summary.minimum != 10 ||
+        summary.p50 != 30 ||
+        summary.p95 != 100 ||
+        summary.p99 != 100 ||
+        summary.maximum != 100 ||
+        std::fabs(summary.mean - 40.0L) >= 0.0001L) {
+        return 1;
+    }
+
+    bool rejectedEmpty = false;
+    try {
+        (void)rp1_bench::summarize({});
+    } catch (const std::invalid_argument&) {
+        rejectedEmpty = true;
+    }
+    if (!rejectedEmpty) return 1;
+
+    if (rp1_bench::traceEntriesWithFlushMarkers(254) != 254 ||
+        rp1_bench::traceEntriesWithFlushMarkers(255) != 257 ||
+        rp1_bench::traceEntriesWithFlushMarkers(508) != 510 ||
+        rp1_bench::traceEntriesWithFlushMarkers(509) != 513) {
+        return 1;
+    }
+    try {
+        (void)rp1_bench::traceEntriesWithFlushMarkers(2, 2);
+    } catch (const std::invalid_argument&) {
+        return 0;
+    }
+    return 1;
+}

--- a/examples/extra/rp1_latency/rp1_latency.cpp
+++ b/examples/extra/rp1_latency/rp1_latency.cpp
@@ -1,0 +1,1693 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file rp1_latency.cpp
+ * @brief Compare RP1 command-processor latency with the legacy VRT path.
+ */
+
+#include "latency_stats.hpp"
+
+#include <slash/uapi/rp1_protocol.h>
+
+#include <vrt/buffer.hpp>
+#include <vrt/device.hpp>
+#include <vrt/graph/backend_executable.hpp>
+#include <vrt/graph/device/fpga/rp1_program.hpp>
+#include <vrt/graph/graph.hpp>
+#include <vrt/kernel.hpp>
+#include <vrt/utils/logger.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+/// Monotonic host clock used for every wall-clock sample.
+using Clock = std::chrono::steady_clock;
+
+/// Logical image name registered with the graph-side VRT device.
+constexpr const char* kImageName = "latency";
+/// CU name emitted by the benchmark connectivity configuration.
+constexpr const char* kKernelName = "latency_kernel_0";
+/// Per-submission timeout; a timeout poisons the RP1 submitter.
+constexpr std::chrono::milliseconds kRp1Timeout{30000};
+/// First private scratch range in the host-visible RP1 DDR window.
+constexpr std::uint32_t kScratchSourceOffset = 32u << 20;
+/// Second private scratch range in the host-visible RP1 DDR window.
+constexpr std::uint32_t kScratchDestinationOffset = 48u << 20;
+/// Maximum transfer size that keeps both scratch ranges disjoint.
+constexpr std::size_t kScratchCapacity = 8u << 20;
+static_assert(kScratchCapacity <= RP1_DMA_LENGTH_MASK);
+/// Largest chain supported by the lowering's 31-by-31 barrier-bit budget.
+constexpr std::size_t kMaxBatchSize = 961;
+static_assert(kMaxBatchSize + 1 <= RP1_MAX_NODES);
+static_assert(3u * kMaxBatchSize + 4u <= RP1_MAX_TRACE_ENTRIES);
+/// Default immediate-operation chain used to amortize 80 ns PMU ticks.
+constexpr std::size_t kMemoryChainLength = 128;
+/// Entries in firmware's fixed 4 KiB BTCM trace staging page.
+constexpr std::size_t kTraceStagingEntries =
+    4096u / sizeof(rp1_trace_entry_t);
+/// Largest chain whose activation events fit without a trace-page flush.
+constexpr std::size_t kMaxMemoryChainLength =
+    kTraceStagingEntries - 4u;
+static_assert(kMaxMemoryChainLength <= RP1_MAX_NODES);
+/// Signal slot reserved for the SCALAR_READ memory microbenchmark.
+constexpr std::uint8_t kMemorySignalSlot =
+    static_cast<std::uint8_t>(RP1_MAX_SIGNALS - 2u);
+/// Distinct fill pattern used to verify every DMA_FILL graph.
+constexpr std::uint32_t kFillPattern = 0xA5A5A5A5u;
+/// Distinct source pattern used to verify every DMA_COPY graph.
+constexpr std::uint32_t kCopyPattern = 0x5A5A5A5Au;
+
+/**
+ * @brief Immediate operation exercised by one memory-trace chain.
+ */
+enum class MemoryOperation {
+    /// Scanner-only baseline.
+    Nop,
+    /// Repeated DDR stores followed by DSB ST.
+    DmaFill,
+    /// Repeated DDR loads/stores followed by DSB ST.
+    DmaCopy,
+    /// One DDR store followed by DSB ST.
+    ScalarWrite,
+    /// One DDR load followed by signal-slot publication.
+    ScalarRead,
+};
+
+/**
+ * @brief User-selected benchmark dimensions and output format.
+ */
+struct Config {
+    /// Target device PCI BDF.
+    std::string bdf;
+    /// Hardware vbin containing the no-op kernel.
+    std::string vbin;
+    /// vrtd Unix socket used by both runtime paths.
+    std::string socket = "/run/vrtd.sock";
+    /// Samples for kernel and batch metrics.
+    std::size_t iterations = 50;
+    /// Untimed runs before kernel, batch, and transfer samples.
+    std::size_t warmup = 5;
+    /// Samples that reprogram the user region through each path.
+    std::size_t programIterations = 3;
+    /// Samples for each transfer size and direction.
+    std::size_t transferIterations = 10;
+    /// Instrumented submissions used for RP1 trace intervals.
+    std::size_t traceIterations = 5;
+    /// Sequential dispatch counts to compare.
+    std::vector<std::size_t> batchSizes{1, 10, 100};
+    /// Byte counts for VRT sync and RP1 local copies.
+    std::vector<std::size_t> transferSizes{4, 64, 4096, 1u << 20};
+    /// Byte counts for differential RP1 DDR tracing.
+    std::vector<std::size_t> memorySizes{4, 64, 256, 4096};
+    /// Immediate nodes in each memory-trace chain.
+    std::size_t memoryChainLength = kMemoryChainLength;
+    /// Optional R5 clock for converting 64-cycle PMU ticks.
+    std::optional<std::uint64_t> r5FrequencyHz;
+    /// Emit machine-readable CSV instead of aligned columns.
+    bool csv = false;
+};
+
+/**
+ * @brief Named samples sharing one unit and benchmark boundary.
+ */
+struct Measurement {
+    /// Stable metric identifier.
+    std::string name;
+    /// Unit shared by every sample.
+    std::string unit;
+    /// Raw observations summarized only at output time.
+    std::vector<std::uint64_t> samples;
+};
+
+/**
+ * @brief Separate host durations for a split launch/wait API.
+ */
+struct SplitSamples {
+    /// Time spent in the launch call.
+    std::vector<std::uint64_t> launch;
+    /// Time spent in the following wait call.
+    std::vector<std::uint64_t> wait;
+    /// Launch-to-completed wall-clock interval.
+    std::vector<std::uint64_t> total;
+};
+
+/**
+ * @brief Host duration paired with the immutable result returned by RP1.
+ */
+struct TimedGraphResult {
+    /// submitAndWait() wall-clock duration in nanoseconds.
+    std::uint64_t elapsed = 0;
+    /// Typed protocol-v6 result captured before the stop timestamp.
+    vrt::graph::fpga::Rp1GraphResult result;
+};
+
+/**
+ * @brief RP1 trace intervals expressed in protocol PMU ticks.
+ */
+struct TraceIntervals {
+    /// Graph-start to first kernel-launch interval.
+    std::uint32_t dispatch = 0;
+    /// First kernel-launch to last kernel-completion interval.
+    std::uint32_t kernelSpan = 0;
+    /// Graph-start to graph-done interval.
+    std::uint32_t graph = 0;
+    /// Each kernel launch to its dependent successor's launch.
+    std::vector<std::uint32_t> launchGaps;
+    /// Launch gaps after subtracting any bracketed BTCM-to-DDR flush.
+    std::vector<std::uint32_t> launchGapsExcludingFlush;
+    /// Each kernel completion to its dependent successor's launch.
+    std::vector<std::uint32_t> handoffGaps;
+    /// Handoff gaps after subtracting any bracketed BTCM-to-DDR flush.
+    std::vector<std::uint32_t> handoffGapsExcludingFlush;
+    /// Each blocking BTCM-to-DDR trace flush.
+    std::vector<std::uint32_t> flushDurations;
+};
+
+/**
+ * @brief Print command-line syntax and benchmark defaults.
+ */
+void printUsage(const char* argv0) {
+    std::cout
+        << "Usage: " << argv0 << " --bdf BDF --vbin FILE [options]\n"
+        << "\n"
+        << "Options:\n"
+        << "  --socket PATH              vrtd socket (default: /run/vrtd.sock)\n"
+        << "  --iterations N             kernel/batch samples (default: 50)\n"
+        << "  --warmup N                 untimed warmups (default: 5)\n"
+        << "  --program-iterations N     programming samples (default: 3)\n"
+        << "  --transfer-iterations N    transfer samples (default: 10)\n"
+        << "  --trace-iterations N       instrumented RP1 samples (default: 5)\n"
+        << "  --batch-sizes N,N,...      sequential kernels per batch\n"
+        << "  --transfer-sizes N,N,...   transfer bytes; multiples of four\n"
+        << "  --memory-sizes N,N,...     traced DDR bytes; multiples of four\n"
+        << "  --memory-chain N           immediate nodes per traced graph\n"
+        << "  --r5-hz HZ                 also convert PMU ticks to estimated ns\n"
+        << "  --csv                       emit CSV summaries\n"
+        << "  --help, -h                  show this help\n";
+}
+
+/**
+ * @brief Parse a bounded decimal size, optionally accepting zero.
+ *
+ * @throws std::runtime_error when @p text is malformed or out of range.
+ */
+std::size_t parseSize(
+    const std::string& text, const char* option, bool allowZero = false) {
+    try {
+        std::size_t consumed = 0;
+        if (text.empty() || text.front() == '-') {
+            throw std::invalid_argument("negative");
+        }
+        const unsigned long long value = std::stoull(text, &consumed, 10);
+        if (consumed != text.size() ||
+            value > std::numeric_limits<std::size_t>::max() ||
+            (!allowZero && value == 0)) {
+            throw std::out_of_range("size");
+        }
+        return static_cast<std::size_t>(value);
+    } catch (const std::exception&) {
+        throw std::runtime_error(
+            std::string("invalid value for ") + option + ": " + text);
+    }
+}
+
+/**
+ * @brief Parse a non-empty comma-separated list of positive sizes.
+ */
+std::vector<std::size_t> parseSizeList(
+    const std::string& text, const char* option) {
+    std::vector<std::size_t> values;
+    std::size_t begin = 0;
+    while (begin <= text.size()) {
+        const std::size_t comma = text.find(',', begin);
+        const std::size_t end =
+            comma == std::string::npos ? text.size() : comma;
+        values.push_back(parseSize(text.substr(begin, end - begin), option));
+        if (comma == std::string::npos) break;
+        begin = comma + 1;
+    }
+    return values;
+}
+
+/**
+ * @brief Parse CLI options and reject dimensions unsupported by RP1 buffers.
+ */
+Config parseArgs(int argc, char** argv) {
+    Config config;
+    for (int i = 1; i < argc; ++i) {
+        const std::string argument = argv[i];
+        const auto need = [&](const char* option) {
+            if (++i >= argc) {
+                throw std::runtime_error(
+                    std::string("missing argument to ") + option);
+            }
+            return std::string(argv[i]);
+        };
+
+        if (argument == "--bdf") {
+            config.bdf = need("--bdf");
+        } else if (argument == "--vbin") {
+            config.vbin = need("--vbin");
+        } else if (argument == "--socket") {
+            config.socket = need("--socket");
+        } else if (argument == "--iterations") {
+            config.iterations =
+                parseSize(need("--iterations"), "--iterations");
+        } else if (argument == "--warmup") {
+            config.warmup =
+                parseSize(need("--warmup"), "--warmup", true);
+        } else if (argument == "--program-iterations") {
+            config.programIterations = parseSize(
+                need("--program-iterations"), "--program-iterations");
+        } else if (argument == "--transfer-iterations") {
+            config.transferIterations = parseSize(
+                need("--transfer-iterations"), "--transfer-iterations");
+        } else if (argument == "--trace-iterations") {
+            config.traceIterations = parseSize(
+                need("--trace-iterations"), "--trace-iterations");
+        } else if (argument == "--batch-sizes") {
+            config.batchSizes =
+                parseSizeList(need("--batch-sizes"), "--batch-sizes");
+        } else if (argument == "--transfer-sizes") {
+            config.transferSizes =
+                parseSizeList(need("--transfer-sizes"), "--transfer-sizes");
+        } else if (argument == "--memory-sizes") {
+            config.memorySizes =
+                parseSizeList(need("--memory-sizes"), "--memory-sizes");
+        } else if (argument == "--memory-chain") {
+            config.memoryChainLength =
+                parseSize(need("--memory-chain"), "--memory-chain");
+        } else if (argument == "--r5-hz") {
+            config.r5FrequencyHz = static_cast<std::uint64_t>(
+                parseSize(need("--r5-hz"), "--r5-hz"));
+        } else if (argument == "--csv") {
+            config.csv = true;
+        } else if (argument == "--help" || argument == "-h") {
+            printUsage(argv[0]);
+            std::exit(0);
+        } else {
+            throw std::runtime_error("unknown argument: " + argument);
+        }
+    }
+
+    if (config.bdf.empty() || config.vbin.empty()) {
+        printUsage(argv[0]);
+        throw std::runtime_error("--bdf and --vbin are required");
+    }
+    for (std::size_t batch : config.batchSizes) {
+        /*
+         * The image builder has 31 work buckets with 31 usable bits each.
+         * This bound also makes the following node and trace arithmetic safe.
+         */
+        if (batch > kMaxBatchSize) {
+            throw std::runtime_error(
+                "batch size exceeds RP1 barrier capacity (" +
+                std::to_string(kMaxBatchSize) + "): " +
+                std::to_string(batch));
+        }
+    }
+    for (std::size_t bytes : config.transferSizes) {
+        if ((bytes & 3u) != 0 || bytes > kScratchCapacity) {
+            throw std::runtime_error(
+                "transfer sizes must be multiples of four and no larger than " +
+                std::to_string(kScratchCapacity) + " bytes");
+        }
+    }
+    for (std::size_t bytes : config.memorySizes) {
+        if ((bytes & 3u) != 0 || bytes > kScratchCapacity) {
+            throw std::runtime_error(
+                "memory sizes must be multiples of four and no larger than " +
+                std::to_string(kScratchCapacity) + " bytes");
+        }
+    }
+    if (config.memoryChainLength < 2u ||
+        config.memoryChainLength > kMaxMemoryChainLength) {
+        throw std::runtime_error(
+            "memory chain must be in [2, " +
+            std::to_string(kMaxMemoryChainLength) + "]");
+    }
+    return config;
+}
+
+/**
+ * @brief Run @p operation once and return elapsed host time in nanoseconds.
+ */
+template <class Operation>
+std::uint64_t elapsedNs(Operation&& operation) {
+    const Clock::time_point start = Clock::now();
+    std::forward<Operation>(operation)();
+    const Clock::time_point finish = Clock::now();
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            finish - start)
+            .count());
+}
+
+/**
+ * @brief Measure APIs whose launch and wait calls expose distinct host costs.
+ */
+template <class Launch, class Wait>
+SplitSamples measureSplit(
+    std::size_t warmup, std::size_t iterations,
+    Launch&& launch, Wait&& wait) {
+    for (std::size_t i = 0; i < warmup; ++i) {
+        launch();
+        wait();
+    }
+
+    SplitSamples samples;
+    samples.launch.reserve(iterations);
+    samples.wait.reserve(iterations);
+    samples.total.reserve(iterations);
+    for (std::size_t i = 0; i < iterations; ++i) {
+        const Clock::time_point start = Clock::now();
+        launch();
+        const Clock::time_point launched = Clock::now();
+        wait();
+        const Clock::time_point finished = Clock::now();
+        samples.launch.push_back(static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                launched - start)
+                .count()));
+        samples.wait.push_back(static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                finished - launched)
+                .count()));
+        samples.total.push_back(static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                finished - start)
+                .count()));
+    }
+    return samples;
+}
+
+/**
+ * @brief Return the smallest power-of-two ring that contains @p entries.
+ */
+std::uint32_t ringSize(std::size_t entries, std::uint32_t maximum) {
+    std::uint32_t size = 1;
+    while (size < entries && size < maximum) size <<= 1u;
+    if (size < entries || size > maximum) {
+        throw std::runtime_error("requested RP1 ring is too small");
+    }
+    return size;
+}
+
+/**
+ * @brief Time one complete @c submitAndWait() host round trip.
+ *
+ * The interval includes submitter preflight, staging, polling, result reads,
+ * and protocol consistency validation. Benchmark-specific semantic checks run
+ * after this function returns and remain outside the latency boundary.
+ */
+TimedGraphResult timedSubmission(
+    const std::shared_ptr<vrt::graph::fpga::Rp1Submitter>& submitter,
+    const vrt::graph::fpga::Rp1GraphImage& image) {
+    const Clock::time_point start = Clock::now();
+    vrt::graph::fpga::Rp1GraphResult result =
+        submitter->submitAndWait(image, kRp1Timeout);
+    const Clock::time_point finish = Clock::now();
+    return {
+        static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                finish - start)
+                .count()),
+        std::move(result),
+    };
+}
+
+/**
+ * @brief Require one clean benchmark result with the expected operation count.
+ *
+ * @throws std::runtime_error when terminal, image, timing, trace, or
+ * quiescence evidence is inconsistent with a reusable benchmark device.
+ */
+void validateGraphResult(
+    const vrt::graph::fpga::Rp1GraphResult& result,
+    std::size_t expectedOperations, bool traceExpected) {
+    constexpr std::uint32_t kKnownFlags =
+        RP1_RESULT_RECOVERY_REQUIRED |
+        RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+        RP1_RESULT_INFINITE_WORK_REMAINS |
+        RP1_RESULT_TRACE_ENABLED |
+        RP1_RESULT_TRACE_OVERFLOW |
+        RP1_RESULT_UNREACHED_NODES;
+    constexpr std::uint32_t kFailureFlags =
+        RP1_RESULT_RECOVERY_REQUIRED |
+        RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+        RP1_RESULT_INFINITE_WORK_REMAINS |
+        RP1_RESULT_TRACE_OVERFLOW |
+        RP1_RESULT_UNREACHED_NODES;
+
+    if (!result.succeeded() || result.terminal ||
+        (result.flags & ~kKnownFlags) != 0u ||
+        (result.flags & kFailureFlags) != 0u) {
+        throw std::runtime_error(
+            "RP1 benchmark received a failed or non-reusable graph result");
+    }
+    const bool traceEnabled =
+        result.hasFlags(RP1_RESULT_TRACE_ENABLED);
+    if (traceEnabled != traceExpected ||
+        (traceExpected && result.traceWriteIndex == 0u) ||
+        (!traceExpected && result.traceWriteIndex != 0u)) {
+        throw std::runtime_error(
+            "RP1 benchmark result has inconsistent trace evidence");
+    }
+    if (result.imageState != vrt::graph::fpga::Rp1ImageState::Known ||
+        result.activeImageId == 0u) {
+        throw std::runtime_error(
+            "RP1 benchmark result does not preserve a known active image");
+    }
+    if (expectedOperations > std::numeric_limits<std::uint32_t>::max() ||
+        result.completedOperations != expectedOperations) {
+        throw std::runtime_error(
+            "RP1 benchmark result has an unexpected completed-operation count");
+    }
+    if (result.publishElapsedTicks < result.graphElapsedTicks) {
+        throw std::runtime_error(
+            "RP1 benchmark result publication precedes graph completion");
+    }
+    if (result.quiescence.finiteDone != 0u ||
+        result.quiescence.finiteTimeout != 0u ||
+        result.quiescence.infinite != 0u) {
+        throw std::runtime_error(
+            "RP1 benchmark result required terminal quiescence");
+    }
+}
+
+/**
+ * @brief Build one direct RP1 PDI_LOAD program for the selected image.
+ */
+vrt::graph::Rp1QueueProgram makeReprogramProgram(
+    const std::string& deviceId,
+    const vrt::graph::FpgaImageHandle& image) {
+    vrt::graph::Rp1QueueProgram program;
+    program.device = vrt::graph::DeviceId(deviceId);
+
+    vrt::graph::Rp1ReprogramCommand load;
+    load.id = "load_" + image.id();
+    load.deviceId = deviceId;
+    load.imageId = image.id();
+    load.pdiPath = image.pdiPath();
+    program.commands.emplace_back(std::move(load));
+    return program;
+}
+
+/**
+ * @brief Build a dependency chain of no-argument dispatches to one FPGA CU.
+ */
+vrt::graph::Rp1QueueProgram makeKernelProgram(
+    const std::string& deviceId, const std::string& imageId,
+    std::size_t count) {
+    vrt::graph::Rp1QueueProgram program;
+    program.device = vrt::graph::DeviceId(deviceId);
+
+    std::string predecessor;
+    for (std::size_t i = 0; i < count; ++i) {
+        vrt::graph::Rp1KernelCommand kernel;
+        kernel.id = "kernel_" + std::to_string(i);
+        kernel.deviceId = deviceId;
+        kernel.kernel.name = kKernelName;
+        kernel.kernel.type = vrt::graph::DeviceType::FPGA;
+        kernel.kernel.image = imageId;
+        if (!predecessor.empty()) kernel.dependsOn.push_back(predecessor);
+        predecessor = kernel.id;
+        program.commands.emplace_back(std::move(kernel));
+    }
+    return program;
+}
+
+/**
+ * @brief Build one raw phase-1 DDR-to-DDR software-copy graph image.
+ */
+vrt::graph::fpga::Rp1GraphImage makeDmaImage(std::size_t bytes) {
+    if (bytes > RP1_DMA_LENGTH_MASK) {
+        throw std::invalid_argument(
+            "RP1 DMA_COPY length exceeds the protocol-v6 28-bit field");
+    }
+    vrt::graph::fpga::Rp1GraphImage image;
+    image.nodes.resize(1);
+    rp1_node_t& node = image.nodes.front();
+    rp1_node_set_opcode(&node, RP1_OP_DMA_COPY);
+    rp1_node_set_status(&node, RP1_NODE_PENDING);
+    node.payload.dma_copy.src_addr_lo =
+        RP1_CTRL_PHYS_ADDR + kScratchSourceOffset;
+    node.payload.dma_copy.dst_addr_lo =
+        RP1_CTRL_PHYS_ADDR + kScratchDestinationOffset;
+    node.payload.dma_copy.length_types = rp1_dma_pack(
+        static_cast<std::uint32_t>(bytes), 0u, 0u);
+    return image;
+}
+
+/**
+ * @brief Build one dependency chain of identical immediate memory operations.
+ *
+ * Every activation raises a unique barrier consumed by the following node, so
+ * the flat scanner executes the whole chain in one pass. Adjacent
+ * NODE_ACTIVATE timestamps therefore bracket the preceding operation without
+ * heartbeat, WAIT-scan, or outer-pass overhead.
+ */
+vrt::graph::fpga::Rp1GraphImage makeMemoryTraceImage(
+    MemoryOperation operation, std::size_t bytes, std::size_t nodeCount) {
+    if (nodeCount < 2u || nodeCount > kMaxMemoryChainLength) {
+        throw std::invalid_argument("memory trace node count is out of range");
+    }
+    if (bytes == 0u || (bytes & 3u) != 0u ||
+        bytes > kScratchCapacity) {
+        throw std::invalid_argument("memory trace byte count is out of range");
+    }
+    if ((operation == MemoryOperation::ScalarWrite ||
+         operation == MemoryOperation::ScalarRead) &&
+        bytes != sizeof(std::uint32_t)) {
+        throw std::invalid_argument("scalar memory trace must be four bytes");
+    }
+
+    vrt::graph::fpga::Rp1GraphImage image;
+    image.nodes.resize(nodeCount);
+    image.trace_enable = true;
+    image.trace_size_override = ringSize(
+        2u + nodeCount, RP1_MAX_TRACE_ENTRIES);
+
+    for (std::size_t i = 0u; i < nodeCount; ++i) {
+        rp1_node_t& node = image.nodes[i];
+        rp1_node_set_status(&node, RP1_NODE_PENDING);
+        if (i != 0u) {
+            const std::size_t predecessor = i - 1u;
+            node.barrier_await_bucket =
+                static_cast<std::uint8_t>(predecessor / 32u);
+            node.barrier_await_mask =
+                1u << static_cast<std::uint32_t>(predecessor % 32u);
+        }
+        node.barrier_set_bucket =
+            static_cast<std::uint8_t>(i / 32u);
+        node.barrier_set_mask =
+            1u << static_cast<std::uint32_t>(i % 32u);
+
+        switch (operation) {
+        case MemoryOperation::Nop:
+            rp1_node_set_opcode(&node, RP1_OP_NOP);
+            break;
+        case MemoryOperation::DmaFill:
+            rp1_node_set_opcode(&node, RP1_OP_DMA_FILL);
+            node.payload.dma_fill.dst_addr_lo =
+                RP1_CTRL_PHYS_ADDR + kScratchDestinationOffset;
+            node.payload.dma_fill.length =
+                static_cast<std::uint32_t>(bytes);
+            node.payload.dma_fill.pattern = kFillPattern;
+            break;
+        case MemoryOperation::DmaCopy:
+            rp1_node_set_opcode(&node, RP1_OP_DMA_COPY);
+            node.payload.dma_copy.src_addr_lo =
+                RP1_CTRL_PHYS_ADDR + kScratchSourceOffset;
+            node.payload.dma_copy.dst_addr_lo =
+                RP1_CTRL_PHYS_ADDR + kScratchDestinationOffset;
+            node.payload.dma_copy.length_types = rp1_dma_pack(
+                static_cast<std::uint32_t>(bytes), 0u, 0u);
+            break;
+        case MemoryOperation::ScalarWrite:
+            rp1_node_set_opcode(&node, RP1_OP_SCALAR_WRITE);
+            node.payload.scalar_write.writes[0].addr =
+                RP1_CTRL_PHYS_ADDR + kScratchDestinationOffset;
+            node.payload.scalar_write.writes[0].value = kFillPattern;
+            break;
+        case MemoryOperation::ScalarRead:
+            rp1_node_set_opcode(&node, RP1_OP_SCALAR_READ);
+            node.payload.scalar_read.source_addr =
+                RP1_CTRL_PHYS_ADDR + kScratchSourceOffset;
+            node.payload.scalar_read.target_slot = kMemorySignalSlot;
+            break;
+        }
+    }
+    if (operation == MemoryOperation::ScalarRead) {
+        image.clear_signal_slots.push_back(kMemorySignalSlot);
+    }
+    return image;
+}
+
+/**
+ * @brief Extract each adjacent NODE_ACTIVATE interval from one trace capture.
+ *
+ * @throws std::runtime_error for overflow, flush markers, duplicate/missing
+ * activation events, or missing graph lifecycle markers.
+ */
+std::vector<std::uint32_t> extractActivationGaps(
+    const vrt::graph::fpga::Rp1TraceCapture& trace,
+    std::size_t nodeCount) {
+    if (trace.overflow) {
+        throw std::runtime_error(
+            "RP1 memory trace overflowed during benchmark");
+    }
+
+    bool graphStart = false;
+    bool graphDone = false;
+    std::vector<std::optional<std::uint32_t>> activations(nodeCount);
+    for (const rp1_trace_entry_t& entry : trace.entries) {
+        if (entry.event == RP1_TRACE_GRAPH_START) {
+            graphStart = true;
+        } else if (entry.event == RP1_TRACE_GRAPH_DONE) {
+            graphDone = true;
+        } else if (entry.event == RP1_TRACE_FLUSH_START ||
+                   entry.event == RP1_TRACE_FLUSH_END) {
+            throw std::runtime_error(
+                "RP1 memory trace unexpectedly flushed");
+        } else if (entry.event == RP1_TRACE_NODE_ACTIVATE &&
+                   entry.node_index < nodeCount) {
+            if (activations[entry.node_index]) {
+                throw std::runtime_error(
+                    "RP1 memory trace contains duplicate activation");
+            }
+            activations[entry.node_index] = entry.timestamp;
+        }
+    }
+    if (!graphStart || !graphDone) {
+        throw std::runtime_error(
+            "RP1 memory trace is missing graph lifecycle events");
+    }
+
+    std::vector<std::uint32_t> gaps;
+    gaps.reserve(nodeCount - 1u);
+    for (std::size_t i = 0u; i < nodeCount; ++i) {
+        if (!activations[i]) {
+            throw std::runtime_error(
+                "RP1 memory trace is missing node activation " +
+                std::to_string(i));
+        }
+        if (i != 0u) {
+            gaps.push_back(*activations[i] - *activations[i - 1u]);
+        }
+    }
+    return gaps;
+}
+
+/**
+ * @brief Submit one traced immediate chain and return its activation gaps.
+ */
+std::vector<std::uint32_t> runMemoryTrace(
+    const std::shared_ptr<vrt::graph::fpga::Rp1Submitter>& submitter,
+    const vrt::graph::fpga::Rp1GraphImage& image) {
+    const vrt::graph::fpga::Rp1GraphResult result =
+        submitter->submitAndWait(image, kRp1Timeout);
+    validateGraphResult(
+        result, image.nodes.size(), /*traceExpected=*/true);
+    const vrt::graph::fpga::Rp1TraceCapture trace =
+        submitter->drainTrace();
+    if (result.traceWriteIndex != trace.written) {
+        throw std::runtime_error(
+            "RP1 memory result and trace cursor disagree");
+    }
+    return extractActivationGaps(trace, image.nodes.size());
+}
+
+/**
+ * @brief Extract wrap-safe kernel intervals from one non-overflowing trace.
+ */
+TraceIntervals extractTrace(
+    const vrt::graph::fpga::Rp1TraceCapture& trace,
+    std::size_t kernelCount) {
+    if (trace.overflow) {
+        throw std::runtime_error("RP1 trace overflowed during benchmark");
+    }
+
+    std::optional<std::uint32_t> graphStart;
+    std::optional<std::uint32_t> firstLaunch;
+    std::optional<std::uint32_t> lastDone;
+    std::optional<std::uint32_t> graphDone;
+    std::vector<std::optional<std::uint32_t>> launches(kernelCount);
+    std::vector<std::optional<std::uint32_t>> completions(kernelCount);
+    std::optional<std::uint32_t> flushStart;
+    std::vector<std::pair<std::uint32_t, std::uint32_t>> flushes;
+    for (const rp1_trace_entry_t& entry : trace.entries) {
+        if (entry.event == RP1_TRACE_GRAPH_START) {
+            graphStart = entry.timestamp;
+        } else if (
+            entry.event == RP1_TRACE_KERNEL_LAUNCH &&
+            entry.node_index < kernelCount) {
+            launches[entry.node_index] = entry.timestamp;
+            if (!firstLaunch) firstLaunch = entry.timestamp;
+        } else if (
+            entry.event == RP1_TRACE_KERNEL_DONE &&
+            entry.node_index < kernelCount) {
+            completions[entry.node_index] = entry.timestamp;
+            lastDone = entry.timestamp;
+        } else if (entry.event == RP1_TRACE_GRAPH_DONE) {
+            graphDone = entry.timestamp;
+        } else if (entry.event == RP1_TRACE_FLUSH_START) {
+            if (flushStart) {
+                throw std::runtime_error(
+                    "RP1 trace contains nested flush starts");
+            }
+            flushStart = entry.timestamp;
+        } else if (entry.event == RP1_TRACE_FLUSH_END) {
+            if (!flushStart) {
+                throw std::runtime_error(
+                    "RP1 trace flush end has no matching start");
+            }
+            flushes.emplace_back(*flushStart, entry.timestamp);
+            flushStart.reset();
+        }
+    }
+
+    if (!graphStart || !firstLaunch || !lastDone || !graphDone ||
+        flushStart) {
+        throw std::runtime_error(
+            "RP1 trace is missing graph or kernel lifecycle events");
+    }
+    for (std::size_t i = 0; i < kernelCount; ++i) {
+        if (!launches[i] || !completions[i]) {
+            throw std::runtime_error(
+                "RP1 trace is missing launch/completion for kernel node " +
+                std::to_string(i));
+        }
+    }
+
+    /*
+     * Protocol timestamps are uint32_t PMU ticks. Unsigned subtraction keeps
+     * intervals valid across one counter wrap.
+     */
+    const std::size_t adjacentCount =
+        kernelCount > 0 ? kernelCount - 1 : 0;
+    std::vector<std::uint32_t> launchGaps;
+    std::vector<std::uint32_t> launchGapsExcludingFlush;
+    std::vector<std::uint32_t> handoffGaps;
+    std::vector<std::uint32_t> handoffGapsExcludingFlush;
+    launchGaps.reserve(adjacentCount);
+    launchGapsExcludingFlush.reserve(adjacentCount);
+    handoffGaps.reserve(adjacentCount);
+    handoffGapsExcludingFlush.reserve(adjacentCount);
+    for (std::size_t i = 0; i + 1 < kernelCount; ++i) {
+        if (!completions[i] || !launches[i + 1]) {
+            throw std::runtime_error(
+                "RP1 trace is missing an adjacent kernel handoff");
+        }
+        const std::uint32_t launchGap =
+            *launches[i + 1] - *launches[i];
+        const std::uint32_t gap =
+            *launches[i + 1] - *completions[i];
+        std::uint32_t launchFlushTicks = 0;
+        std::uint32_t flushTicks = 0;
+        for (const auto& [start, end] : flushes) {
+            const std::uint32_t launchStartOffset =
+                start - *launches[i];
+            const std::uint32_t launchEndOffset =
+                end - *launches[i];
+            if (launchStartOffset <= launchGap &&
+                launchEndOffset >= launchStartOffset &&
+                launchEndOffset <= launchGap) {
+                launchFlushTicks += end - start;
+            }
+            const std::uint32_t startOffset =
+                start - *completions[i];
+            const std::uint32_t endOffset =
+                end - *completions[i];
+            if (startOffset <= gap && endOffset >= startOffset &&
+                endOffset <= gap) {
+                flushTicks += end - start;
+            }
+        }
+        if (launchFlushTicks > launchGap) {
+            throw std::runtime_error(
+                "RP1 trace flush exceeds its containing launch interval");
+        }
+        if (flushTicks > gap) {
+            throw std::runtime_error(
+                "RP1 trace flush exceeds its containing handoff");
+        }
+        launchGaps.push_back(launchGap);
+        launchGapsExcludingFlush.push_back(
+            launchGap - launchFlushTicks);
+        handoffGaps.push_back(gap);
+        handoffGapsExcludingFlush.push_back(gap - flushTicks);
+    }
+
+    std::vector<std::uint32_t> flushDurations;
+    flushDurations.reserve(flushes.size());
+    for (const auto& [start, end] : flushes) {
+        flushDurations.push_back(end - start);
+    }
+
+    return TraceIntervals{
+        static_cast<std::uint32_t>(*firstLaunch - *graphStart),
+        static_cast<std::uint32_t>(*lastDone - *firstLaunch),
+        static_cast<std::uint32_t>(*graphDone - *graphStart),
+        std::move(launchGaps),
+        std::move(launchGapsExcludingFlush),
+        std::move(handoffGaps),
+        std::move(handoffGapsExcludingFlush),
+        std::move(flushDurations),
+    };
+}
+
+/**
+ * @brief Add PMU-tick samples and an optional 64-cycle tick conversion.
+ */
+void addTicks(
+    std::vector<Measurement>& measurements, std::string name,
+    std::vector<std::uint64_t> ticks,
+    const std::optional<std::uint64_t>& r5FrequencyHz) {
+    measurements.push_back(
+        {name, "rp1_pmu_ticks", ticks});
+    if (!r5FrequencyHz) return;
+
+    std::vector<std::uint64_t> nanoseconds;
+    nanoseconds.reserve(ticks.size());
+    for (std::uint64_t tick : ticks) {
+        const long double value =
+            static_cast<long double>(tick) * 64.0L *
+            1'000'000'000.0L /
+            static_cast<long double>(*r5FrequencyHz);
+        nanoseconds.push_back(
+            static_cast<std::uint64_t>(std::llround(value)));
+    }
+    measurements.push_back(
+        {std::move(name) + ".estimated", "ns", std::move(nanoseconds)});
+}
+
+/**
+ * @brief Add core-cycle samples and an optional clock-derived conversion.
+ */
+void addCoreCycles(
+    std::vector<Measurement>& measurements, std::string name,
+    std::vector<std::uint64_t> cycles,
+    const std::optional<std::uint64_t>& r5FrequencyHz) {
+    measurements.push_back({name, "r5_cycles", cycles});
+    if (!r5FrequencyHz) return;
+
+    std::vector<std::uint64_t> nanoseconds;
+    nanoseconds.reserve(cycles.size());
+    for (std::uint64_t cycle : cycles) {
+        const long double value =
+            static_cast<long double>(cycle) * 1'000'000'000.0L /
+            static_cast<long double>(*r5FrequencyHz);
+        nanoseconds.push_back(
+            static_cast<std::uint64_t>(std::llround(value)));
+    }
+    measurements.push_back(
+        {std::move(name) + ".estimated", "ns", std::move(nanoseconds)});
+}
+
+/**
+ * @brief Append 32-bit PMU intervals to an aggregate measurement vector.
+ */
+void appendTicks(
+    std::vector<std::uint64_t>& destination,
+    const std::vector<std::uint32_t>& source) {
+    destination.insert(destination.end(), source.begin(), source.end());
+}
+
+/**
+ * @brief Return mean per-operation excess in core cycles over a paired chain.
+ *
+ * Aggregating before converting the divided PMU timestamps recovers
+ * sub-80-nanosecond mean resolution without claiming per-access raw timing.
+ */
+std::uint64_t meanExcessCycles(
+    const std::vector<std::uint32_t>& operation,
+    const std::vector<std::uint32_t>& baseline) {
+    if (operation.empty() || operation.size() != baseline.size()) {
+        throw std::runtime_error(
+            "RP1 memory trace gap vectors are incompatible");
+    }
+    std::uint64_t operationTicks = 0u;
+    std::uint64_t baselineTicks = 0u;
+    for (std::size_t i = 0u; i < operation.size(); ++i) {
+        operationTicks += operation[i];
+        baselineTicks += baseline[i];
+    }
+    if (operationTicks < baselineTicks) {
+        throw std::runtime_error(
+            "RP1 memory operation is faster than its NOP baseline");
+    }
+    const std::uint64_t excessTicks = operationTicks - baselineTicks;
+    return (excessTicks * 64u + operation.size() / 2u) /
+           operation.size();
+}
+
+/**
+ * @brief Print one summary row per measurement in human or CSV form.
+ */
+void printMeasurements(
+    const std::vector<Measurement>& measurements, bool csv) {
+    if (csv) {
+        std::cout << "metric,unit,count,min,p50,p95,p99,max,mean\n";
+    } else {
+        std::cout << std::left << std::setw(54) << "metric"
+                  << std::right << std::setw(8) << "count"
+                  << std::setw(14) << "min"
+                  << std::setw(14) << "p50"
+                  << std::setw(14) << "p95"
+                  << std::setw(14) << "p99"
+                  << std::setw(14) << "max"
+                  << std::setw(16) << "mean"
+                  << "  unit\n";
+    }
+
+    for (const Measurement& measurement : measurements) {
+        const rp1_bench::Summary summary =
+            rp1_bench::summarize(measurement.samples);
+        if (csv) {
+            std::cout << measurement.name << ',' << measurement.unit << ','
+                      << summary.count << ',' << summary.minimum << ','
+                      << summary.p50 << ',' << summary.p95 << ','
+                      << summary.p99 << ',' << summary.maximum << ','
+                      << std::fixed << std::setprecision(2)
+                      << summary.mean << '\n';
+        } else {
+            std::cout << std::left << std::setw(54) << measurement.name
+                      << std::right << std::setw(8) << summary.count
+                      << std::setw(14) << summary.minimum
+                      << std::setw(14) << summary.p50
+                      << std::setw(14) << summary.p95
+                      << std::setw(14) << summary.p99
+                      << std::setw(14) << summary.maximum
+                      << std::setw(16) << std::fixed << std::setprecision(2)
+                      << summary.mean << "  " << measurement.unit << '\n';
+        }
+    }
+}
+
+/**
+ * @brief Measure split legacy/RP1 backend calls and raw RP1 submissions.
+ */
+void benchmarkSingleKernel(
+    const Config& config, vrt::Device& legacy,
+    const std::shared_ptr<vrt::graph::FpgaDevice>& device,
+    std::vector<Measurement>& measurements) {
+    vrt::Kernel kernel(legacy, kKernelName);
+    const SplitSamples vrtSamples = measureSplit(
+        config.warmup, config.iterations,
+        [&] { kernel.start(); }, [&] { kernel.wait(); });
+    measurements.push_back(
+        {"vrt.kernel.start", "ns", vrtSamples.launch});
+    measurements.push_back(
+        {"vrt.kernel.wait", "ns", vrtSamples.wait});
+    measurements.push_back(
+        {"vrt.kernel.start_wait", "ns", vrtSamples.total});
+
+    const vrt::graph::Rp1QueueProgram program =
+        makeKernelProgram(device->id(), kImageName, 1);
+    {
+        auto plan = device->compileProgram(program);
+        const SplitSamples rp1Samples = measureSplit(
+            config.warmup, config.iterations,
+            [&] { plan->launch(); }, [&] { plan->wait(); });
+        measurements.push_back(
+            {"rp1.backend.launch_thread", "ns", rp1Samples.launch});
+        measurements.push_back(
+            {"rp1.backend.wait", "ns", rp1Samples.wait});
+        measurements.push_back(
+            {"rp1.backend.launch_wait", "ns", rp1Samples.total});
+    }
+
+    vrt::graph::fpga::Rp1GraphImage image =
+        device->projectProgram(program);
+    const auto submitter = device->submitter();
+    for (std::size_t i = 0; i < config.warmup; ++i) {
+        const vrt::graph::fpga::Rp1GraphResult result =
+            submitter->submitAndWait(image, kRp1Timeout);
+        validateGraphResult(
+            result, image.nodes.size(), /*traceExpected=*/false);
+    }
+
+    std::vector<std::uint64_t> host;
+    std::vector<std::uint64_t> resultGraph;
+    host.reserve(config.iterations);
+    resultGraph.reserve(config.iterations);
+    for (std::size_t i = 0; i < config.iterations; ++i) {
+        TimedGraphResult sample = timedSubmission(submitter, image);
+        host.push_back(sample.elapsed);
+        validateGraphResult(
+            sample.result, image.nodes.size(), /*traceExpected=*/false);
+        resultGraph.push_back(sample.result.graphElapsedTicks);
+    }
+    measurements.push_back(
+        {"rp1.raw.kernel_graph.submit_wait", "ns", std::move(host)});
+    addTicks(
+        measurements, "rp1.result.kernel.graph_elapsed",
+        std::move(resultGraph), config.r5FrequencyHz);
+
+    image.trace_enable = true;
+    image.trace_size_override = ringSize(
+        rp1_bench::traceEntriesWithFlushMarkers(
+            2u + image.nodes.size() + 2u),
+        RP1_MAX_TRACE_ENTRIES);
+    std::vector<std::uint64_t> dispatch;
+    std::vector<std::uint64_t> execute;
+    std::vector<std::uint64_t> graph;
+    for (std::size_t i = 0; i < config.traceIterations; ++i) {
+        const vrt::graph::fpga::Rp1GraphResult result =
+            submitter->submitAndWait(image, kRp1Timeout);
+        validateGraphResult(
+            result, image.nodes.size(), /*traceExpected=*/true);
+        const vrt::graph::fpga::Rp1TraceCapture trace =
+            submitter->drainTrace();
+        if (result.traceWriteIndex != trace.written) {
+            throw std::runtime_error(
+                "RP1 kernel result and trace cursor disagree");
+        }
+        const TraceIntervals intervals = extractTrace(trace, 1);
+        dispatch.push_back(intervals.dispatch);
+        execute.push_back(intervals.kernelSpan);
+        graph.push_back(intervals.graph);
+    }
+    addTicks(
+        measurements, "rp1.trace.kernel.dispatch", std::move(dispatch),
+        config.r5FrequencyHz);
+    addTicks(
+        measurements, "rp1.trace.kernel.launch_to_done",
+        std::move(execute), config.r5FrequencyHz);
+    addTicks(
+        measurements, "rp1.trace.kernel.graph", std::move(graph),
+        config.r5FrequencyHz);
+}
+
+/**
+ * @brief Compare sequential batches through one legacy CU and one RP1 graph.
+ */
+void benchmarkBatches(
+    const Config& config, vrt::Device& legacy,
+    const std::shared_ptr<vrt::graph::FpgaDevice>& device,
+    std::vector<Measurement>& measurements) {
+    vrt::Kernel kernel(legacy, kKernelName);
+    const auto submitter = device->submitter();
+
+    for (std::size_t batch : config.batchSizes) {
+        const std::string suffix = std::to_string(batch);
+        const auto runVrt = [&] {
+            for (std::size_t i = 0; i < batch; ++i) {
+                kernel.start();
+                kernel.wait();
+            }
+        };
+        for (std::size_t i = 0; i < config.warmup; ++i) runVrt();
+
+        std::vector<std::uint64_t> vrtHost;
+        vrtHost.reserve(config.iterations);
+        for (std::size_t i = 0; i < config.iterations; ++i) {
+            vrtHost.push_back(elapsedNs(runVrt));
+        }
+        measurements.push_back({
+            "vrt.batch." + suffix + ".start_wait",
+            "ns",
+            std::move(vrtHost),
+        });
+
+        /*
+         * Timestamp each returned start and wait call. Adjacent start
+         * differences approximate host-issued ap_start to ap_start, while
+         * wait(i) return to start(i+1) return matches RP1's observed-completion
+         * to next-launch boundary.
+         */
+        std::vector<std::uint64_t> vrtStartGaps;
+        std::vector<std::uint64_t> vrtHandoffGaps;
+        vrtStartGaps.reserve(
+            config.traceIterations * (batch > 0 ? batch - 1 : 0));
+        vrtHandoffGaps.reserve(
+            config.traceIterations * (batch > 0 ? batch - 1 : 0));
+        for (std::size_t sample = 0;
+             sample < config.traceIterations; ++sample) {
+            std::optional<Clock::time_point> previousStart;
+            std::optional<Clock::time_point> previousDone;
+            for (std::size_t i = 0; i < batch; ++i) {
+                kernel.start();
+                const Clock::time_point started = Clock::now();
+                if (previousStart) {
+                    vrtStartGaps.push_back(
+                        static_cast<std::uint64_t>(
+                            std::chrono::duration_cast<
+                                std::chrono::nanoseconds>(
+                                started - *previousStart)
+                                .count()));
+                }
+                if (previousDone) {
+                    vrtHandoffGaps.push_back(
+                        static_cast<std::uint64_t>(
+                            std::chrono::duration_cast<
+                                std::chrono::nanoseconds>(
+                                started - *previousDone)
+                                .count()));
+                }
+                previousStart = started;
+                kernel.wait();
+                previousDone = Clock::now();
+            }
+        }
+        if (!vrtStartGaps.empty()) {
+            measurements.push_back({
+                "vrt.batch." + suffix + ".start_to_next_start",
+                "ns",
+                std::move(vrtStartGaps),
+            });
+        }
+        if (!vrtHandoffGaps.empty()) {
+            measurements.push_back({
+                "vrt.batch." + suffix + ".done_to_next_start",
+                "ns",
+                std::move(vrtHandoffGaps),
+            });
+        }
+
+        const vrt::graph::Rp1QueueProgram program =
+            makeKernelProgram(device->id(), kImageName, batch);
+        vrt::graph::fpga::Rp1GraphImage image =
+            device->projectProgram(program);
+        for (std::size_t i = 0; i < config.warmup; ++i) {
+            const vrt::graph::fpga::Rp1GraphResult result =
+                submitter->submitAndWait(image, kRp1Timeout);
+            validateGraphResult(
+                result, image.nodes.size(), /*traceExpected=*/false);
+        }
+
+        std::vector<std::uint64_t> rp1Host;
+        std::vector<std::uint64_t> resultGraph;
+        rp1Host.reserve(config.iterations);
+        resultGraph.reserve(config.iterations);
+        for (std::size_t i = 0; i < config.iterations; ++i) {
+            TimedGraphResult sample = timedSubmission(submitter, image);
+            rp1Host.push_back(sample.elapsed);
+            validateGraphResult(
+                sample.result, image.nodes.size(), /*traceExpected=*/false);
+            resultGraph.push_back(sample.result.graphElapsedTicks);
+        }
+        measurements.push_back({
+            "rp1.raw.batch." + suffix + ".submit_wait",
+            "ns",
+            std::move(rp1Host),
+        });
+        addTicks(
+            measurements,
+            "rp1.result.batch." + suffix + ".graph_elapsed",
+            std::move(resultGraph), config.r5FrequencyHz);
+
+        image.trace_enable = true;
+        image.trace_size_override = ringSize(
+            rp1_bench::traceEntriesWithFlushMarkers(
+                2u + image.nodes.size() + 2u * batch),
+            RP1_MAX_TRACE_ENTRIES);
+        std::vector<std::uint64_t> dispatch;
+        std::vector<std::uint64_t> kernelSpan;
+        std::vector<std::uint64_t> graph;
+        std::vector<std::uint64_t> launchGaps;
+        std::vector<std::uint64_t> launchGapsExcludingFlush;
+        std::vector<std::uint64_t> handoffGaps;
+        std::vector<std::uint64_t> handoffGapsExcludingFlush;
+        std::vector<std::uint64_t> flushDurations;
+        for (std::size_t i = 0; i < config.traceIterations; ++i) {
+            const vrt::graph::fpga::Rp1GraphResult result =
+                submitter->submitAndWait(image, kRp1Timeout);
+            validateGraphResult(
+                result, image.nodes.size(), /*traceExpected=*/true);
+            const vrt::graph::fpga::Rp1TraceCapture trace =
+                submitter->drainTrace();
+            if (result.traceWriteIndex != trace.written) {
+                throw std::runtime_error(
+                    "RP1 batch result and trace cursor disagree");
+            }
+            const TraceIntervals intervals =
+                extractTrace(trace, batch);
+            dispatch.push_back(intervals.dispatch);
+            kernelSpan.push_back(intervals.kernelSpan);
+            graph.push_back(intervals.graph);
+            launchGaps.insert(
+                launchGaps.end(),
+                intervals.launchGaps.begin(),
+                intervals.launchGaps.end());
+            launchGapsExcludingFlush.insert(
+                launchGapsExcludingFlush.end(),
+                intervals.launchGapsExcludingFlush.begin(),
+                intervals.launchGapsExcludingFlush.end());
+            handoffGaps.insert(
+                handoffGaps.end(),
+                intervals.handoffGaps.begin(),
+                intervals.handoffGaps.end());
+            handoffGapsExcludingFlush.insert(
+                handoffGapsExcludingFlush.end(),
+                intervals.handoffGapsExcludingFlush.begin(),
+                intervals.handoffGapsExcludingFlush.end());
+            flushDurations.insert(
+                flushDurations.end(),
+                intervals.flushDurations.begin(),
+                intervals.flushDurations.end());
+        }
+        addTicks(
+            measurements, "rp1.trace.batch." + suffix + ".dispatch",
+            std::move(dispatch), config.r5FrequencyHz);
+        addTicks(
+            measurements, "rp1.trace.batch." + suffix + ".kernel_span",
+            std::move(kernelSpan), config.r5FrequencyHz);
+        addTicks(
+            measurements, "rp1.trace.batch." + suffix + ".graph",
+            std::move(graph), config.r5FrequencyHz);
+        if (!launchGaps.empty()) {
+            addTicks(
+                measurements,
+                "rp1.trace.batch." + suffix +
+                    ".launch_to_next_launch",
+                std::move(launchGaps), config.r5FrequencyHz);
+            addTicks(
+                measurements,
+                "rp1.trace.batch." + suffix +
+                    ".launch_to_next_launch_excluding_flush",
+                std::move(launchGapsExcludingFlush),
+                config.r5FrequencyHz);
+        }
+        if (!handoffGaps.empty()) {
+            addTicks(
+                measurements,
+                "rp1.trace.batch." + suffix +
+                    ".done_to_next_launch",
+                std::move(handoffGaps), config.r5FrequencyHz);
+            addTicks(
+                measurements,
+                "rp1.trace.batch." + suffix +
+                    ".done_to_next_launch_excluding_flush",
+                std::move(handoffGapsExcludingFlush),
+                config.r5FrequencyHz);
+        }
+        if (!flushDurations.empty()) {
+            addTicks(
+                measurements,
+                "rp1.trace.batch." + suffix + ".trace_flush",
+                std::move(flushDurations), config.r5FrequencyHz);
+        }
+    }
+}
+
+/**
+ * @brief Measure differential RP1 DDR access latency with immediate chains.
+ *
+ * NOP, DMA_FILL, and DMA_COPY graphs share identical barrier topology and
+ * trace boundaries. Per-submission aggregate subtraction removes scanner and
+ * trace overhead, while COPY-minus-FILL approximates one additional DDR read.
+ */
+void benchmarkMemoryAccesses(
+    const Config& config,
+    const std::shared_ptr<vrt::graph::FpgaDevice>& device,
+    std::vector<Measurement>& measurements) {
+    const auto submitter = device->submitter();
+    const auto window = device->window();
+
+    for (std::size_t bytes : config.memorySizes) {
+        const std::string prefix =
+            "rp1.trace.memory." + std::to_string(bytes) + "B.";
+        const auto nopImage = makeMemoryTraceImage(
+            MemoryOperation::Nop, bytes, config.memoryChainLength);
+        const auto fillImage = makeMemoryTraceImage(
+            MemoryOperation::DmaFill, bytes, config.memoryChainLength);
+        const auto copyImage = makeMemoryTraceImage(
+            MemoryOperation::DmaCopy, bytes, config.memoryChainLength);
+
+        std::vector<std::uint32_t> source(bytes / sizeof(std::uint32_t),
+                                          kCopyPattern);
+        std::vector<std::uint32_t> readback(source.size(), 0u);
+        window->writeAt(
+            kScratchSourceOffset, source.data(), bytes);
+        window->zeroAt(kScratchDestinationOffset, bytes);
+
+        for (std::size_t i = 0u; i < config.warmup; ++i) {
+            (void)runMemoryTrace(submitter, nopImage);
+            (void)runMemoryTrace(submitter, fillImage);
+            (void)runMemoryTrace(submitter, copyImage);
+        }
+
+        std::vector<std::uint64_t> nopGaps;
+        std::vector<std::uint64_t> fillGaps;
+        std::vector<std::uint64_t> copyGaps;
+        std::vector<std::uint64_t> fillExcess;
+        std::vector<std::uint64_t> copyExcess;
+        std::vector<std::uint64_t> readEstimate;
+        const std::size_t gapSamples =
+            config.traceIterations * (config.memoryChainLength - 1u);
+        nopGaps.reserve(gapSamples);
+        fillGaps.reserve(gapSamples);
+        copyGaps.reserve(gapSamples);
+        fillExcess.reserve(config.traceIterations);
+        copyExcess.reserve(config.traceIterations);
+        readEstimate.reserve(config.traceIterations);
+
+        for (std::size_t i = 0u; i < config.traceIterations; ++i) {
+            const std::vector<std::uint32_t> nop =
+                runMemoryTrace(submitter, nopImage);
+            const std::vector<std::uint32_t> fill =
+                runMemoryTrace(submitter, fillImage);
+            const std::vector<std::uint32_t> copy =
+                runMemoryTrace(submitter, copyImage);
+            appendTicks(nopGaps, nop);
+            appendTicks(fillGaps, fill);
+            appendTicks(copyGaps, copy);
+            fillExcess.push_back(meanExcessCycles(fill, nop));
+            copyExcess.push_back(meanExcessCycles(copy, nop));
+            readEstimate.push_back(meanExcessCycles(copy, fill));
+        }
+
+        /*
+         * Verify each mutating operation with untimed submissions so BAR reads
+         * cannot perturb the paired timing sequence above.
+         */
+        (void)runMemoryTrace(submitter, fillImage);
+        window->readAt(
+            kScratchDestinationOffset, readback.data(), bytes);
+        if (!std::all_of(
+                readback.begin(), readback.end(),
+                [](std::uint32_t value) {
+                    return value == kFillPattern;
+                })) {
+            throw std::runtime_error(
+                "RP1 DMA_FILL memory benchmark verification failed");
+        }
+        (void)runMemoryTrace(submitter, copyImage);
+        window->readAt(
+            kScratchDestinationOffset, readback.data(), bytes);
+        if (readback != source) {
+            throw std::runtime_error(
+                "RP1 DMA_COPY memory benchmark verification failed");
+        }
+
+        addTicks(
+            measurements, prefix + "nop_gap", std::move(nopGaps),
+            config.r5FrequencyHz);
+        addTicks(
+            measurements, prefix + "dma_fill_gap", std::move(fillGaps),
+            config.r5FrequencyHz);
+        addTicks(
+            measurements, prefix + "dma_copy_gap", std::move(copyGaps),
+            config.r5FrequencyHz);
+        addCoreCycles(
+            measurements, prefix + "dma_fill_minus_nop",
+            std::move(fillExcess), config.r5FrequencyHz);
+        addCoreCycles(
+            measurements, prefix + "dma_copy_minus_nop",
+            std::move(copyExcess), config.r5FrequencyHz);
+        addCoreCycles(
+            measurements, prefix + "ddr_read_copy_minus_fill",
+            std::move(readEstimate), config.r5FrequencyHz);
+    }
+
+    /*
+     * Scalar operations have fixed four-byte payloads. Their excess metrics
+     * retain the real SCALAR_READ signal publication rather than pretending it
+     * is a pure load.
+     */
+    const auto nopImage = makeMemoryTraceImage(
+        MemoryOperation::Nop, sizeof(std::uint32_t),
+        config.memoryChainLength);
+    const auto writeImage = makeMemoryTraceImage(
+        MemoryOperation::ScalarWrite, sizeof(std::uint32_t),
+        config.memoryChainLength);
+    const auto readImage = makeMemoryTraceImage(
+        MemoryOperation::ScalarRead, sizeof(std::uint32_t),
+        config.memoryChainLength);
+    window->writeAt(
+        kScratchSourceOffset, &kCopyPattern, sizeof(kCopyPattern));
+    window->zeroAt(
+        kScratchDestinationOffset, sizeof(std::uint32_t));
+
+    for (std::size_t i = 0u; i < config.warmup; ++i) {
+        (void)runMemoryTrace(submitter, nopImage);
+        (void)runMemoryTrace(submitter, writeImage);
+        (void)runMemoryTrace(submitter, readImage);
+    }
+
+    std::vector<std::uint64_t> scalarNopGaps;
+    std::vector<std::uint64_t> scalarWriteGaps;
+    std::vector<std::uint64_t> scalarReadGaps;
+    std::vector<std::uint64_t> scalarWriteExcess;
+    std::vector<std::uint64_t> scalarReadExcess;
+    for (std::size_t i = 0u; i < config.traceIterations; ++i) {
+        const std::vector<std::uint32_t> nop =
+            runMemoryTrace(submitter, nopImage);
+        const std::vector<std::uint32_t> write =
+            runMemoryTrace(submitter, writeImage);
+        const std::vector<std::uint32_t> read =
+            runMemoryTrace(submitter, readImage);
+        appendTicks(scalarNopGaps, nop);
+        appendTicks(scalarWriteGaps, write);
+        appendTicks(scalarReadGaps, read);
+        scalarWriteExcess.push_back(meanExcessCycles(write, nop));
+        scalarReadExcess.push_back(meanExcessCycles(read, nop));
+    }
+
+    (void)runMemoryTrace(submitter, writeImage);
+    std::uint32_t written = 0u;
+    window->readAt(
+        kScratchDestinationOffset, &written, sizeof(written));
+    if (written != kFillPattern) {
+        throw std::runtime_error(
+            "RP1 SCALAR_WRITE memory benchmark verification failed");
+    }
+    (void)runMemoryTrace(submitter, readImage);
+    rp1_signal_slot_t signal{};
+    window->readSignal(kMemorySignalSlot, signal);
+    if (signal.value != kCopyPattern ||
+        signal.last_writer_node != config.memoryChainLength - 1u) {
+        throw std::runtime_error(
+            "RP1 SCALAR_READ memory benchmark verification failed");
+    }
+
+    addTicks(
+        measurements, "rp1.trace.memory.scalar.nop_gap",
+        std::move(scalarNopGaps), config.r5FrequencyHz);
+    addTicks(
+        measurements, "rp1.trace.memory.scalar.write_gap",
+        std::move(scalarWriteGaps), config.r5FrequencyHz);
+    addTicks(
+        measurements, "rp1.trace.memory.scalar.read_gap",
+        std::move(scalarReadGaps), config.r5FrequencyHz);
+    addCoreCycles(
+        measurements, "rp1.trace.memory.scalar.write_minus_nop",
+        std::move(scalarWriteExcess), config.r5FrequencyHz);
+    addCoreCycles(
+        measurements, "rp1.trace.memory.scalar.read_minus_nop",
+        std::move(scalarReadExcess), config.r5FrequencyHz);
+}
+
+/**
+ * @brief Measure VRT host-device DMA and RP1 local DDR software copies.
+ *
+ * These transfer domains are deliberately reported as separate metrics:
+ * phase-1 RP1 has no host/HBM DMA path, so a speedup ratio would be invalid.
+ */
+void benchmarkTransfers(
+    const Config& config, vrt::Device& legacy,
+    const std::shared_ptr<vrt::graph::FpgaDevice>& device,
+    std::vector<Measurement>& measurements) {
+    const auto submitter = device->submitter();
+    const auto window = device->window();
+
+    for (std::size_t bytes : config.transferSizes) {
+        const std::string suffix = std::to_string(bytes) + "B";
+
+        vrt::Buffer<std::uint8_t> buffer(
+            legacy, bytes, vrt::MemoryRangeType::DDR);
+        std::fill(buffer.get(), buffer.get() + bytes, std::uint8_t{0x5a});
+        for (std::size_t i = 0; i < config.warmup; ++i) {
+            buffer.sync(vrt::SyncType::HOST_TO_DEVICE);
+            buffer.sync(vrt::SyncType::DEVICE_TO_HOST);
+        }
+
+        std::vector<std::uint64_t> h2d;
+        std::vector<std::uint64_t> d2h;
+        h2d.reserve(config.transferIterations);
+        d2h.reserve(config.transferIterations);
+        for (std::size_t i = 0; i < config.transferIterations; ++i) {
+            h2d.push_back(elapsedNs([&] {
+                buffer.sync(vrt::SyncType::HOST_TO_DEVICE);
+            }));
+            d2h.push_back(elapsedNs([&] {
+                buffer.sync(vrt::SyncType::DEVICE_TO_HOST);
+            }));
+        }
+        measurements.push_back({
+            "vrt.transfer.logical_" + suffix + ".host_to_ddr",
+            "ns",
+            std::move(h2d),
+        });
+        measurements.push_back({
+            "vrt.transfer.logical_" + suffix + ".ddr_to_host",
+            "ns",
+            std::move(d2h),
+        });
+
+        std::vector<std::uint8_t> source(bytes, 0xa5);
+        std::vector<std::uint8_t> destination(bytes, 0);
+        window->writeAt(
+            kScratchSourceOffset, source.data(), source.size());
+        window->zeroAt(kScratchDestinationOffset, bytes);
+
+        vrt::graph::fpga::Rp1GraphImage image = makeDmaImage(bytes);
+        for (std::size_t i = 0; i < config.warmup; ++i) {
+            const vrt::graph::fpga::Rp1GraphResult result =
+                submitter->submitAndWait(image, kRp1Timeout);
+            validateGraphResult(
+                result, image.nodes.size(), /*traceExpected=*/false);
+        }
+
+        std::vector<std::uint64_t> rp1Host;
+        std::vector<std::uint64_t> rp1Device;
+        rp1Host.reserve(config.transferIterations);
+        rp1Device.reserve(config.transferIterations);
+        for (std::size_t i = 0; i < config.transferIterations; ++i) {
+            /*
+             * Alternate the payload so every timed command must overwrite the
+             * prior destination. BAR staging and verification remain untimed.
+             */
+            std::fill(
+                source.begin(), source.end(),
+                (i & 1u) == 0u ? std::uint8_t{0x5a}
+                               : std::uint8_t{0xa5});
+            window->writeAt(
+                kScratchSourceOffset, source.data(), source.size());
+            TimedGraphResult sample = timedSubmission(submitter, image);
+            rp1Host.push_back(sample.elapsed);
+            validateGraphResult(
+                sample.result, image.nodes.size(), /*traceExpected=*/false);
+            rp1Device.push_back(sample.result.graphElapsedTicks);
+            window->readAt(
+                kScratchDestinationOffset,
+                destination.data(), destination.size());
+            if (destination != source) {
+                throw std::runtime_error(
+                    "RP1 DMA_COPY verification failed for " +
+                    std::to_string(bytes) + " bytes at iteration " +
+                    std::to_string(i));
+            }
+        }
+
+        measurements.push_back({
+            "rp1.transfer." + suffix + ".ddr_copy_host_round_trip",
+            "ns",
+            std::move(rp1Host),
+        });
+        addTicks(
+            measurements,
+            "rp1.transfer." + suffix + ".graph_elapsed",
+            std::move(rp1Device), config.r5FrequencyHz);
+    }
+}
+
+}  // namespace
+
+#ifndef RP1_LATENCY_TESTING
+/**
+ * @brief Run all latency microbenchmarks and print aggregate summaries.
+ */
+int main(int argc, char** argv) try {
+    const Config config = parseArgs(argc, argv);
+    if (::setenv("VRTD_SOCKET", config.socket.c_str(), 1) != 0) {
+        throw std::runtime_error("failed to set VRTD_SOCKET");
+    }
+    vrt::utils::Logger::setLogLevel(vrt::utils::LogLevel::WARN);
+
+    std::vector<Measurement> measurements;
+
+    vrt::Device legacy;
+    const std::uint64_t vrtSetup = elapsedNs([&] {
+        legacy = vrt::Device(
+            config.bdf, config.vbin, /*program=*/false);
+    });
+    measurements.push_back(
+        {"vrt.setup.no_program", "ns", {vrtSetup}});
+
+    /*
+     * Compare the legacy programming RPC before constructing the RP1 path.
+     * addFpga() then revalidates firmware and obtains a fresh BAR mapping.
+     */
+    std::vector<std::uint64_t> vrtPrograms;
+    vrtPrograms.reserve(config.programIterations);
+    for (std::size_t i = 0; i < config.programIterations; ++i) {
+        vrtPrograms.push_back(elapsedNs(
+            [&] { legacy.getHandle()->programDevice(); }));
+    }
+    measurements.push_back(
+        {"vrt.program.design_write_reset", "ns", std::move(vrtPrograms)});
+
+    vrt::graph::Graph graph = vrt::graph::Graph::withDefaults();
+    vrt::graph::FpgaHandle fpga;
+    const std::uint64_t rp1Setup = elapsedNs([&] {
+        vrt::graph::FpgaSpec spec;
+        spec.bdf = config.bdf;
+        spec.socket = config.socket;
+        spec.images.push_back({kImageName, config.vbin});
+        spec.waitTimeout = kRp1Timeout;
+        fpga = graph.addFpga(spec);
+    });
+    measurements.push_back(
+        {"rp1.setup.add_fpga", "ns", {rp1Setup}});
+
+    const vrt::graph::FpgaImageHandle image =
+        fpga.image(kImageName);
+    const auto device = fpga.device();
+
+    /*
+     * Program through RP1 after the legacy samples. This both measures
+     * PDI_LOAD and synchronizes firmware's expected-image guard.
+     */
+    auto programPlan = device->compileProgram(
+        makeReprogramProgram(device->id(), image));
+    std::vector<std::uint64_t> rp1Programs;
+    rp1Programs.reserve(config.programIterations);
+    for (std::size_t i = 0; i < config.programIterations; ++i) {
+        rp1Programs.push_back(elapsedNs([&] {
+            programPlan->launch();
+            programPlan->wait();
+        }));
+    }
+    measurements.push_back({
+        "rp1.program.first_with_staging",
+        "ns",
+        {rp1Programs.front()},
+    });
+    if (rp1Programs.size() > 1) {
+        measurements.push_back({
+            "rp1.program.cached_pdi",
+            "ns",
+            std::vector<std::uint64_t>(
+                rp1Programs.begin() + 1, rp1Programs.end()),
+        });
+    }
+    programPlan.reset();
+
+    benchmarkSingleKernel(config, legacy, device, measurements);
+    benchmarkBatches(config, legacy, device, measurements);
+    benchmarkMemoryAccesses(config, device, measurements);
+    benchmarkTransfers(config, legacy, device, measurements);
+
+    printMeasurements(measurements, config.csv);
+    return 0;
+} catch (const std::exception& error) {
+    std::cerr << "rp1_latency: " << error.what() << '\n';
+    return 1;
+}
+#endif

--- a/examples/extra/rp1_latency/rp1_latency_trace_test.cpp
+++ b/examples/extra/rp1_latency/rp1_latency_trace_test.cpp
@@ -1,0 +1,162 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#define RP1_LATENCY_TESTING
+#include "rp1_latency.cpp"
+
+/**
+ * @brief Verify packed DMA, result validation, flush accounting, and PMU wrap.
+ */
+int main() {
+    const auto dmaImage = makeDmaImage(4096u);
+    const rp1_node_t& dmaNode = dmaImage.nodes.front();
+    if (rp1_node_get_opcode(&dmaNode) != RP1_OP_DMA_COPY ||
+        rp1_dma_get_length(dmaNode.payload.dma_copy.length_types) != 4096u ||
+        rp1_dma_get_src_type(dmaNode.payload.dma_copy.length_types) != 0u ||
+        rp1_dma_get_dst_type(dmaNode.payload.dma_copy.length_types) != 0u) {
+        return 1;
+    }
+    try {
+        (void)makeDmaImage(
+            static_cast<std::size_t>(RP1_DMA_LENGTH_MASK) + 1u);
+        return 1;
+    } catch (const std::invalid_argument&) {
+    }
+
+    const auto memoryImage = makeMemoryTraceImage(
+        MemoryOperation::DmaCopy, 64u, 4u);
+    if (!memoryImage.trace_enable ||
+        memoryImage.nodes.size() != 4u ||
+        rp1_node_get_opcode(&memoryImage.nodes[0]) != RP1_OP_DMA_COPY ||
+        memoryImage.nodes[0].barrier_await_mask != 0u ||
+        memoryImage.nodes[1].barrier_await_mask != 1u ||
+        memoryImage.nodes[1].barrier_set_mask != 2u ||
+        rp1_dma_get_length(
+            memoryImage.nodes[3].payload.dma_copy.length_types) != 64u) {
+        return 1;
+    }
+
+    vrt::graph::fpga::Rp1GraphResult result;
+    result.flags = RP1_RESULT_TRACE_ENABLED;
+    result.activeImageId = 1u;
+    result.imageState = vrt::graph::fpga::Rp1ImageState::Known;
+    result.completedOperations = 3u;
+    result.graphElapsedTicks = 161u;
+    result.publishElapsedTicks = 170u;
+    result.traceWriteIndex = 10u;
+    try {
+        validateGraphResult(result, 3u, /*traceExpected=*/true);
+    } catch (const std::runtime_error&) {
+        return 1;
+    }
+
+    result.flags |= RP1_RESULT_RECOVERY_REQUIRED;
+    try {
+        validateGraphResult(result, 3u, /*traceExpected=*/true);
+        return 1;
+    } catch (const std::runtime_error&) {
+        result.flags &= ~RP1_RESULT_RECOVERY_REQUIRED;
+    }
+
+    result.flags |= RP1_RESULT_INFINITE_WORK_REMAINS;
+    try {
+        validateGraphResult(result, 3u, /*traceExpected=*/true);
+        return 1;
+    } catch (const std::runtime_error&) {
+        result.flags &= ~RP1_RESULT_INFINITE_WORK_REMAINS;
+    }
+
+    vrt::graph::fpga::Rp1TraceCapture capture;
+    const auto add = [&](std::uint16_t event, std::uint16_t node,
+                         std::uint32_t timestamp) {
+        capture.entries.emplace_back();
+        rp1_trace_entry_t& entry = capture.entries.back();
+        entry.event = event;
+        entry.node_index = node;
+        entry.timestamp = timestamp;
+    };
+
+    const std::uint32_t max = std::numeric_limits<std::uint32_t>::max();
+    add(RP1_TRACE_GRAPH_START, 0xFFFFu, max - 100u);
+    add(RP1_TRACE_KERNEL_LAUNCH, 0u, max - 90u);
+    add(RP1_TRACE_KERNEL_DONE, 0u, max - 80u);
+    add(RP1_TRACE_FLUSH_START, 0xFFFFu, max - 70u);
+    add(RP1_TRACE_FLUSH_END, 0xFFFFu, 10u);
+    add(RP1_TRACE_KERNEL_LAUNCH, 1u, 20u);
+    add(RP1_TRACE_KERNEL_DONE, 1u, 30u);
+    add(RP1_TRACE_KERNEL_LAUNCH, 2u, 40u);
+    add(RP1_TRACE_KERNEL_DONE, 2u, 50u);
+    add(RP1_TRACE_GRAPH_DONE, 0xFFFFu, 60u);
+
+    const TraceIntervals intervals = extractTrace(capture, 3);
+    if (intervals.dispatch != 10u ||
+        intervals.kernelSpan != 141u ||
+        intervals.graph != 161u ||
+        intervals.launchGaps !=
+            std::vector<std::uint32_t>({111u, 20u}) ||
+        intervals.launchGapsExcludingFlush !=
+            std::vector<std::uint32_t>({30u, 20u}) ||
+        intervals.handoffGaps !=
+            std::vector<std::uint32_t>({101u, 10u}) ||
+        intervals.handoffGapsExcludingFlush !=
+            std::vector<std::uint32_t>({20u, 10u}) ||
+        intervals.flushDurations !=
+            std::vector<std::uint32_t>({81u})) {
+        return 1;
+    }
+
+    vrt::graph::fpga::Rp1TraceCapture activationCapture;
+    const auto addActivation = [&](
+                                   std::uint16_t event, std::uint16_t node,
+                                   std::uint32_t timestamp) {
+        activationCapture.entries.emplace_back();
+        rp1_trace_entry_t& entry = activationCapture.entries.back();
+        entry.event = event;
+        entry.node_index = node;
+        entry.timestamp = timestamp;
+    };
+    addActivation(RP1_TRACE_GRAPH_START, 0xFFFFu, max - 10u);
+    addActivation(RP1_TRACE_NODE_ACTIVATE, 0u, max - 5u);
+    addActivation(RP1_TRACE_NODE_ACTIVATE, 1u, max - 1u);
+    addActivation(RP1_TRACE_NODE_ACTIVATE, 2u, 3u);
+    addActivation(RP1_TRACE_GRAPH_DONE, 0xFFFFu, 4u);
+    if (extractActivationGaps(activationCapture, 3u) !=
+            std::vector<std::uint32_t>({4u, 5u}) ||
+        meanExcessCycles(
+            std::vector<std::uint32_t>({5u, 7u}),
+            std::vector<std::uint32_t>({3u, 3u})) != 192u) {
+        return 1;
+    }
+
+    capture.entries.erase(
+        std::remove_if(
+            capture.entries.begin(), capture.entries.end(),
+            [](const rp1_trace_entry_t& entry) {
+                return entry.event == RP1_TRACE_KERNEL_DONE &&
+                       entry.node_index == 2u;
+            }),
+        capture.entries.end());
+    try {
+        (void)extractTrace(capture, 3);
+    } catch (const std::runtime_error&) {
+        return 0;
+    }
+    return 1;
+}

--- a/examples/graph/README.md
+++ b/examples/graph/README.md
@@ -46,7 +46,7 @@ On a prepared V80 host, run exactly one script:
 
 ```bash
 ARTIFACT_DIR="$PWD/tmp/graph-hardware-acceptance/manual-run" \
-  ./scripts/test-graph-hardware.sh 0000:65:00.0
+  ./scripts/extra/test-graph-hardware.sh 0000:65:00.0
 ```
 
 The script deliberately performs no reset and does not restart `vrtd`. In one
@@ -61,11 +61,17 @@ continuous device session it runs:
 
 A read-only RP1 dump follows every application. Each case runs under GNU
 `timeout --foreground` with a configurable `CASE_TIMEOUT` and `KILL_GRACE`.
-The script forces `VRT_RP1_TRACE=1` and `VRT_RP1_CQ=1`, then rejects missing
-host-reference PASS output, missing or failed PDI CQ/trace records, missing
-successful `GRAPH_DONE`, trace overflow, a non-advancing `graph_done_seq`, an
-incompatible protocol-v4 capability/platform identity, or latched terminal
-errors.
+The script forces `VRT_RP1_TRACE=1` and `VRT_RP1_RESULT=1`. It validates every
+sequence-tagged result as a clean `SUCCESS` with a known image, completed
+operations, ordered graph/publication timing, a non-empty trace, and zero
+quiescence. It also rejects missing host-reference PASS output, too few
+successful PDI trace records, missing successful `GRAPH_DONE`, trace overflow,
+a result sequence that disagrees with the following read-only dump, a
+non-advancing `graph_done_seq`, an incompatible protocol-v6
+capability/platform identity, or terminal error/recovery evidence.
+`UNREACHED_NODES` is allowed on success because an unchosen conditional branch
+legitimately remains pending; the runtime's lifecycle sentinel proves that all
+intended leaves joined.
 
 Per-case logs, RP1 snapshots, escaped commands, source revision/dirty status,
 input binary/vbin hashes, and final artifact hashes are written under
@@ -73,13 +79,13 @@ input binary/vbin hashes, and final artifact hashes are written under
 controls are documented by:
 
 ```bash
-./scripts/test-graph-hardware.sh --help
+./scripts/extra/test-graph-hardware.sh --help
 ```
 
 The acceptance harness itself has a hardware-free test. It creates all fake
 executables and vbins under the repository's ignored `tmp/` directory and
-checks the success, missing-PDI, missing-graph-completion, trace-overflow, and
-watchdog paths:
+checks the success, missing/failed-result, missing-PDI,
+missing-graph-completion, trace-overflow, and watchdog paths:
 
 ```bash
 ./scripts/test-graph-hardware-local.sh

--- a/linker/slashkit/emit/hw/project_gen.py
+++ b/linker/slashkit/emit/hw/project_gen.py
@@ -64,6 +64,12 @@ _RP1_REQUIRED_RESOURCES = (
     "include/slash/uapi/rp1_protocol.h",
     "tools/generate_platform_config.py",
 )
+# Packaged custom-PLM build used to carry the XilPLMI sparse-IPI fix.
+_PLM_RESOURCE_DIRECTORY = "plm"
+_PLM_REQUIRED_RESOURCES = (
+    "build-plm.sh",
+    "tools/patch_xilplmi.py",
+)
 
 
 # Host toolchain flags injected by dpkg-buildpackage (e.g. -mno-omit-leaf-frame-pointer,
@@ -207,6 +213,35 @@ def _rp1_resource_root():
     return root
 
 
+def _plm_resource_root():
+    """Return the complete packaged custom-PLM resource tree."""
+    try:
+        root = resources.files(_RP1_RESOURCE_PACKAGE)
+    except ModuleNotFoundError as error:
+        raise FileNotFoundError(
+            "Required packaged PLM firmware resources are unavailable; "
+            "reinstall slashkit from a complete wheel or source archive"
+        ) from error
+
+    root = root.joinpath(_PLM_RESOURCE_DIRECTORY)
+    if not root.is_dir():
+        raise FileNotFoundError(
+            "Required packaged PLM firmware resource tree is missing: "
+            f"{_PLM_RESOURCE_DIRECTORY}"
+        )
+
+    missing = [
+        name for name in _PLM_REQUIRED_RESOURCES
+        if not root.joinpath(*name.split("/")).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "Required packaged PLM firmware resources are missing: "
+            + ", ".join(missing)
+        )
+    return root
+
+
 def _copy_rp1_resource_tree(source, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     for entry in source.iterdir():
@@ -231,6 +266,41 @@ def _copy_rp1_sources_to_aved(aved_dir: Path) -> None:
     if rp1_dest_dir.exists():
         shutil.rmtree(rp1_dest_dir)
     _copy_rp1_resource_tree(rp1_resources, rp1_dest_dir)
+
+
+def _copy_plm_sources_to_aved(aved_dir: Path) -> None:
+    """Replace AVED's generated PLM build directory with packaged sources."""
+    plm_resources = _plm_resource_root()
+    plm_dest_dir = aved_dir / "fw" / "PLM"
+    if plm_dest_dir.exists():
+        shutil.rmtree(plm_dest_dir)
+    _copy_rp1_resource_tree(plm_resources, plm_dest_dir)
+
+
+def _build_patched_plm(aved_dir: Path, xsa: Path) -> Path:
+    """Build the custom PLM, reusing AMC's SDT when one already exists."""
+    plm_dir = aved_dir / "fw" / "PLM"
+    output = plm_dir / "build" / "plm.elf"
+    env = _clean_cross_build_env()
+    env["XSA"] = str(xsa)
+
+    amc_sdt = (
+        aved_dir / "fw" / "AMC" / "amc_bsp" /
+        "versal_sdt" / "system-top.dts"
+    )
+    if amc_sdt.is_file():
+        env["PLM_SDT"] = str(amc_sdt)
+
+    subprocess.run(
+        ["bash", "build-plm.sh"],
+        cwd=str(plm_dir),
+        env=env,
+        check=True,
+    )
+    if not output.is_file():
+        raise FileNotFoundError(
+            f"Expected patched PLM output not found: {output}")
+    return output
 
 
 def _add_init_files(path: Path) -> None:
@@ -283,15 +353,12 @@ def generate_base_pdi_with_aved(config: CommandConfiguration) -> tuple[Path, Pat
         "src" / "profiles" / "v80"
 
     _copy_rp1_sources_to_aved(aved_dir)
+    _copy_plm_sources_to_aved(aved_dir)
 
     logger.info("Starting AVED base build for %s", config.project_name)
     aved_build_dir.mkdir(parents=True, exist_ok=True)
 
     static_impl_dir = config.build_dir / "slash.runs" / "impl_1"
-    regenerated_top_wrapper_pdi = _generate_top_wrapper_pdi_with_bootgen(
-        static_impl_dir)
-    _copy_checked(regenerated_top_wrapper_pdi,
-                  aved_build_dir / "top_wrapper.pdi")
 
     files_to_copy = [("build_all.sh", aved_hw_dir), ("profile_hal.h", aved_fw_profile_dir),
                      ("pdi_combine.bif", aved_fpt_dir), (f"{AVED_DESIGN_NAME}.xsa", aved_build_dir)]
@@ -299,6 +366,19 @@ def generate_base_pdi_with_aved(config: CommandConfiguration) -> tuple[Path, Pat
     for (file_name, target_dir) in files_to_copy:
         with resources.path("slashkit.resources.aved", file_name) as in_path:
             _copy_checked(in_path, target_dir / file_name)
+
+    xsa = aved_build_dir / f"{AVED_DESIGN_NAME}.xsa"
+    patched_plm = _build_patched_plm(aved_dir, xsa)
+    _copy_checked(patched_plm, aved_build_dir / "plm.elf")
+    _copy_checked(
+        patched_plm,
+        static_impl_dir / "gen_files" / "plm.elf",
+    )
+
+    regenerated_top_wrapper_pdi = _generate_top_wrapper_pdi_with_bootgen(
+        static_impl_dir)
+    _copy_checked(regenerated_top_wrapper_pdi,
+                  aved_build_dir / "top_wrapper.pdi")
 
     # build_all.sh and the four files staged above all live in the AVED clone,
     # so offloading this step needs nothing installed on the execution host
@@ -779,6 +859,7 @@ def _install_static_shell_rp1_firmware(config: InstallerConfiguration,
         aved_build_dir / "top_wrapper.pdi",
         aved_build_dir / f"{AVED_DESIGN_NAME}.xsa",
         aved_build_dir / "amc.elf",
+        aved_build_dir / "plm.elf",
         aved_build_dir / "fpt.bin",
         aved_fpt_dir / "pdi_combine.bif",
         aved_fpt_dir / "fpt_pdi_gen.py",
@@ -806,7 +887,8 @@ def _install_static_shell_rp1_firmware(config: InstallerConfiguration,
 
     nofpt_pdi = aved_build_dir / f"{AVED_DESIGN_NAME}_nofpt.pdi"
     logger.info(
-        "Repacking %s with existing AMC/FPT and rebuilt RP1", nofpt_pdi.name)
+        "Repacking %s with existing PLM/AMC/FPT and rebuilt RP1",
+        nofpt_pdi.name)
     # As in _generate_top_wrapper_pdi_with_bootgen, the paths inside the BIF are
     # relative, so aved_hw_dir is part of the contract and travels in
     # SLASH_TOOL_CWD.

--- a/linker/slashkit/resources/aved/plm/build-plm.sh
+++ b/linker/slashkit/resources/aved/plm/build-plm.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Build a Versal PLM with SLASH's sparse-IPI dispatch fix.
+
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+build_dir=${PLM_BUILD_DIR:-"$root/build"}
+bsp_dir="$build_dir/plm_bsp"
+app_dir="$build_dir/plm"
+patcher="$root/tools/patch_xilplmi.py"
+sdt=${PLM_SDT:-}
+
+# Reuse the AMC-generated SDT in the normal AVED flow. Direct builds may
+# generate an equivalent SDT from the static-shell XSA.
+if [[ -z $sdt ]]; then
+    if [[ -z ${XSA:-} ]]; then
+        echo "ERROR: PLM build needs PLM_SDT or XSA" >&2
+        exit 1
+    fi
+    sdt_dir="$build_dir/versal_sdt"
+    rm -rf "$sdt_dir"
+    mkdir -p "$sdt_dir"
+    sdtgen -eval \
+        "sdtgen set_dt_param -xsa {$XSA} -dir {$sdt_dir}; generate_sdt"
+    sdt="$sdt_dir/system-top.dts"
+fi
+if [[ ! -f $sdt ]]; then
+    echo "ERROR: PLM SDT does not exist: $sdt" >&2
+    exit 1
+fi
+if [[ -z ${XILINX_VITIS:-} ]]; then
+    echo "ERROR: XILINX_VITIS must name the sourced Vitis installation" >&2
+    exit 1
+fi
+
+rm -rf "$bsp_dir" "$app_dir"
+mkdir -p "$build_dir"
+(
+    cd "$build_dir"
+    empyro repo -st "$XILINX_VITIS/data/embeddedsw"
+    empyro create_bsp \
+        -t versal_plm \
+        -w "$bsp_dir" \
+        -s "$sdt" \
+        -p psv_pmc_0 \
+        -o standalone
+)
+
+# Empyro copies XilPLMI into the BSP before compiling its libraries. Patch that
+# private copy so the installed Vitis tree and concurrent builds stay pristine.
+python3 "$patcher" --bsp-root "$bsp_dir"
+(
+    cd "$build_dir"
+    empyro build_bsp -d "$bsp_dir"
+    empyro create_app \
+        -d "$bsp_dir" \
+        -s "$app_dir/src" \
+        -t versal_plm \
+        -n plm \
+        --no_clangd True
+    empyro build_app \
+        -s "$app_dir/src" \
+        -b "$bsp_dir/versal_plm/build"
+)
+
+# Empyro's template controls the final subdirectory. Resolve the one PLM ELF
+# without baking that generated layout into SLASH.
+python3 - "$build_dir" "$build_dir/plm.elf" <<'PY'
+from pathlib import Path
+import shutil
+import sys
+
+root = Path(sys.argv[1])
+output = Path(sys.argv[2])
+candidates = [
+    path for path in root.rglob("plm.elf")
+    if path != output
+]
+if len(candidates) != 1:
+    rendered = ", ".join(str(path) for path in candidates) or "none"
+    raise SystemExit(
+        f"expected one Empyro PLM ELF, found {len(candidates)}: {rendered}")
+shutil.copy2(candidates[0], output)
+print(f"staged {output} from {candidates[0]}")
+PY

--- a/linker/slashkit/resources/aved/plm/tools/patch_xilplmi.py
+++ b/linker/slashkit/resources/aved/plm/tools/patch_xilplmi.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Patch XilPLMI 2025.1 to demultiplex sparse SDT IPI target masks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+# Relative suffix of the Versal implementation copied into an Empyro BSP.
+PLATFORM_SOURCE_SUFFIX = Path(
+    "xilplmi/src/versal/server/xplmi_plat.c").parts
+
+# Marker emitted only by the patched implementation.
+PATCH_MARKER = "IpiInstance->Config.TargetCount"
+
+# Stable declaration immediately before XilPLMI's faulty dispatch loop.
+DECLARATION = re.compile(
+    r"^(?P<indent>[ \t]*)u32 IpiIndexMask;$",
+    re.MULTILINE,
+)
+
+# XilPLMI 2025.1 masks all asserted sources, then incorrectly treats the
+# cardinality of a sparse target list as the highest valid IPI bit.
+FAULTY_LOOP = re.compile(
+    r"(?P<indent>[ \t]*)for \(IpiIndex = 0U; "
+    r"IpiIndex < XPLMI_IPI_MASK_COUNT; \+\+IpiIndex\) \{\s*"
+    r"IpiIndexMask = \(u32\)1U << IpiIndex;\s*"
+    r"if \(\(\(IpiIntrVal & IpiIndexMask\) != 0U\) &&\s*"
+    r"\(\(IpiMaskVal & IpiIndexMask\) == 0U\)\) \{\s*"
+    r"XPlmi_GicIntrAddTask\(XPlmi_GetIpiIntrId\(IpiIndex\)\);\s*"
+    r"\}\s*\}",
+    re.MULTILINE,
+)
+
+
+def find_platform_source(bsp_root: Path) -> Path:
+    """Return the one Versal XilPLMI platform source beneath @p bsp_root."""
+    matches = [
+        path
+        for path in bsp_root.rglob("xplmi_plat.c")
+        if path.parts[-len(PLATFORM_SOURCE_SUFFIX):]
+        == PLATFORM_SOURCE_SUFFIX
+    ]
+    if len(matches) != 1:
+        rendered = ", ".join(str(path) for path in matches) or "none"
+        raise RuntimeError(
+            "expected one Versal XilPLMI platform source, found "
+            f"{len(matches)}: {rendered}"
+        )
+    return matches[0]
+
+
+def patch_platform_source(path: Path) -> bool:
+    """Patch @p path in place; return false when it is already patched."""
+    text = path.read_text(encoding="utf-8")
+    if PATCH_MARKER in text:
+        return False
+    declarations = list(DECLARATION.finditer(text))
+    if len(declarations) != 1:
+        raise RuntimeError(
+            f"XilPLMI declaration context changed in {path}")
+
+    match = FAULTY_LOOP.search(text)
+    if match is None:
+        raise RuntimeError(
+            f"XilPLMI sparse IPI dispatch loop not found in {path}")
+
+    indent = match.group("indent")
+    replacement = (
+        f"{indent}IpiInstance = XPlmi_GetIpiInstance();\n"
+        f"{indent}/* SDT target masks are sparse; TargetCount is a "
+        "cardinality, not a bit bound. */\n"
+        f"{indent}for (IpiIndex = 0U;\n"
+        f"{indent}     IpiIndex < IpiInstance->Config.TargetCount;\n"
+        f"{indent}     ++IpiIndex) {{\n"
+        f"{indent} IpiIndexMask =\n"
+        f"{indent}  IpiInstance->Config.TargetList[IpiIndex].Mask;\n"
+        f"{indent} if (((IpiIntrVal & IpiIndexMask) != 0U) &&\n"
+        f"{indent}     ((IpiMaskVal & IpiIndexMask) == 0U)) {{\n"
+        f"{indent}  XPlmi_GicIntrAddTask(XPlmi_GetIpiIntrId(\n"
+        f"{indent}   IpiInstance->Config.TargetList[IpiIndex]."
+        "BufferIndex));\n"
+        f"{indent} }}\n"
+        f"{indent}}}"
+    )
+
+    text = text[:match.start()] + replacement + text[match.end():]
+    text = DECLARATION.sub(
+        lambda declaration: (
+            declaration.group(0)
+            + "\n"
+            + declaration.group("indent")
+            + "XIpiPsu *IpiInstance;"
+        ),
+        text,
+        count=1,
+    )
+    path.write_text(text, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    """Patch the generated BSP selected on the command line."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bsp-root",
+        type=Path,
+        required=True,
+        help="Empyro BSP directory containing libsrc/xilplmi",
+    )
+    args = parser.parse_args()
+
+    source = find_platform_source(args.bsp_root)
+    changed = patch_platform_source(source)
+    print(f"{'patched' if changed else 'already patched'} {source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/linker/slashkit/resources/aved/rp1/ARCHITECTURE.md
+++ b/linker/slashkit/resources/aved/rp1/ARCHITECTURE.md
@@ -1,1448 +1,781 @@
 # RP1 HSA Command Processor Architecture
 
-## Source and package staging
+## Status and source of truth
 
-The RP1 firmware tree is shipped as slashkit package data from
-`linker/slashkit/resources/aved/rp1`. The canonical protocol header remains
-`driver/libslash/include/slash/uapi/rp1_protocol.h`; stage it into the packaged
-tree with `python3 scripts/stage-rp1-protocol-header.py`, and use `--check` to
-verify that the two copies are synchronized.
+This document describes the implemented **protocol-v6** RP1 command processor.
+RP1 is Cortex-R5 core 1 on the AMD Alveo V80. It executes a host-built graph
+from shared DDR and publishes one rich, sequence-tagged result for the whole
+graph.
 
-## Context
+The canonical wire ABI is
+[`driver/libslash/include/slash/uapi/rp1_protocol.h`](../../../../../driver/libslash/include/slash/uapi/rp1_protocol.h).
+The firmware package contains a staged copy at
+[`include/slash/uapi/rp1_protocol.h`](include/slash/uapi/rp1_protocol.h).
+Update the canonical header first, then synchronize and check the packaged copy:
 
-The SLASH platform currently uses a host-driven dispatch model: the VRT runtime writes kernel arguments and control registers over PCIe BAR MMIO, one kernel at a time, synchronously polling for completion. Every register write is a PCIe round-trip (~1-2us). For a kernel launch with 8 arguments, that's ~18 PCIe transactions (8 arg writes + control write + polling reads).
-
-RP1 (ARM Cortex-R5 core 1) sits **on-die** with single-digit-nanosecond access to all AXI peripherals. By making RP1 a command processor, we eliminate PCIe latency from the critical dispatch path. The host submits computation graphs to shared DDR, and RP1 executes them autonomously -- kernel dispatch, DMA orchestration, loops, and conditionals -- with no host intervention until the entire graph completes.
-
-### Execution Model Guarantees
-
-**Single user region.** All kernels referenced by a graph must be resident in the FPGA fabric simultaneously. The graph operates on a static hardware layout -- there is no dynamic partial reconfiguration between nodes. The host programs the bitstream once, then submits graphs against that fixed set of kernels.
-
-**Explicit parallelism.** If a node's barrier dependencies are satisfied, RP1 **will** dispatch it. This is a hard guarantee, not best-effort. It matters because kernels may communicate via AXI-Stream interfaces while co-executing. A stream producer kernel started before its consumer can block on backpressure, and the guarantee ensures the consumer will be started -- preventing deadlock. Kernels connected by streams must be designed for backpressure tolerance, but they can rely on RP1 dispatching both ends once barriers are met.
-
-**Explicit reprogram points (`PDI_LOAD`, opcode `0x0030`).** A graph can include a `PDI_LOAD` node that asks the PMC to partial-reconfigure the fabric from a host-staged DDR PDI; see Section A. The host MUST gate the node behind barriers that drain every kernel resident in the to-be-reconfigured region -- RP1 does not validate the drain. RP1 does, however, track the image last installed by `PDI_LOAD` (its `image_id`) and rejects a `KERNEL_DISPATCH` whose non-zero `expected_image_id` does not match, so a stale dispatch fails fast instead of hanging on an absent kernel. Updating the R5 kernel-base table to reach kernels that only exist in the new design is the graph creator's responsibility (it can be done by `SCALAR_WRITE` nodes or by re-submitting a fresh graph against the new layout).
-
-**Future: graph regions.** For very large graphs (thousands of nodes), the host may partition the graph into regions with guaranteed non-overlapping execution. This also provides a natural boundary for partial reconfiguration. The flat scanner scales to current graph sizes; regions are the path for scaling further.
-
----
-
-## Hardware Prerequisites
-
-### 1. RPU -> User Region AXI-Lite Path -- wired in the base block design
-
-**Problem:** R5's `M_AXI_LPD` needs a path to the kernel AXI-Lite slaves in
-the user region, which live at `0x0202_0000_0000+` on the PCIe-visible NoC
-address map.
-
-**Solution (landed):** `rpu_sc` (the RPU-side smartconnect) has a third
-master port (`NUM_MI {3}`, `M02_AXI`) wired through the NoC into the user
-kernel region, and the NoC ingress `S_AXILITE_INI` carries a
-`REMAPS {M04_INI {{0x8800_0000 0x202_0000_0000 0x8000000}}}` entry that
-mirrors the PCIe-visible `0x0202_0000_0000` user-region window into the R5's
-32-bit address space at `0x8800_0000` (128MB). This is what the
-`r5_addr = xml_addr - 0x0202'0000'0000 + 0x8800'0000` formula (used in
-Section H) converts between. See
-`linker/slashkit/resources/base/service/scripts/top.tcl` (`rpu_sc`, `M02_AXI`,
-`REMAPS`).
-
-**Remaining gap:** the linker does not yet emit an R5-address table
-alongside `system_map.xml`. `linker/slashkit/emit/hw/tcl_gen.py` assigns
-kernel instances into the NoC address space (`S_AXILITE_INI` at
-`0x0202_0000_0000`) for the PCIe/host view only; there is no separate
-R5-visible address emission step. Until that lands, `FpgaKernelLocation`
-addresses are supplied by the caller (see Section H) -- either hand-derived
-with the formula above, or (for `FpgaVbinSpec`-backed devices) computed
-from the vbin's `system_map` at runtime.
-
-### 2. RPU -> HBM/DDR Data Path (DMA)
-
-**Problem:** R5's `LPD_AXI_NOC_0` only reaches DDR4 (0x0-0x8000_0000). HBM is not addressable. There is no CDMA or hardware DMA engine accessible to the R5.
-
-**Solution (phased):**
-- **Phase 1 (SW DMA):** R5 does software memcpy via AXI for DDR-DDR transfers and uses kernel-mediated transfers for HBM. For host-device DMA, the host still performs QDMA transfers before/after submitting the graph. RP1 commands reference pre-staged buffers.
-- **Phase 2 (HW DMA):** Add an AXI CDMA IP connected to R5 via M_AXI_LPD, with master ports reaching both DDR and HBM via the NoC. R5 programs CDMA descriptors, CDMA does the heavy lifting.
-- **Phase 3 (Full):** Add HBM slave ports to `LPD_AXI_NOC_0` so R5 can issue HBM reads/writes directly (for small transfers and scatter-gather).
-
-**For this architecture, we design for Phase 1 with hooks for Phase 2.**
-
----
-
-## A. Command Packet Format
-
-### Fixed 64-byte nodes
-
-Every graph node is a 64-byte (16-word) packet, naturally aligned. 16-byte header + 48-byte payload.
-
+```bash
+python3 scripts/stage-rp1-protocol-header.py
+python3 scripts/stage-rp1-protocol-header.py --check
 ```
+
+The header is freestanding and shared by firmware, VRT, SMI, and tests.
+Compile-time assertions fix every structure size and critical offset.
+
+Protocol v6 makes these deliberate choices:
+
+- There is one graph in flight per RP1.
+- Dependency scheduling is private to RP1 and uses BTCM barriers.
+- The active node prefix is snapshotted into BTCM before packet validation or
+  execution; DDR node packets are never read or written on the execution path.
+- There is **no per-node completion queue**.
+- Every node error is fail-fast and stops new activation.
+- Firmware publishes one 64-byte `rp1_graph_result_t` per accepted graph.
+- Optional tracing carries per-node history and profiling detail.
+- A failed graph is not transactional; its outputs must be treated as invalid.
+- `graph_done_seq` is the final release point for the committed result.
+
+## Why RP1 exists
+
+The legacy VRT path drives each kernel synchronously from the host. Argument and
+control writes cross PCIe, and the host polls for completion before launching
+the next kernel. RP1 is on-die and can access the user-region AXI-Lite network
+without PCIe round trips. The host stages a complete graph once; RP1 then
+launches kernels, moves local DDR data, evaluates control flow, and performs
+partial reconfiguration without host intervention.
+
+The execution model has four important guarantees:
+
+1. **Explicit parallelism.** Every barrier-ready node is eligible in the next
+   scanner pass. Independent kernels can be in flight together.
+2. **Static graph storage.** Firmware takes one immutable BTCM node snapshot;
+   shared arguments and other graph data remain firmware-owned from the
+   `graph_seq` doorbell until exact-sequence completion.
+3. **Fail-fast errors.** The first validation, dispatch, timeout, image, or PDI
+   error stops all later activation and starts terminal quiescence.
+4. **Non-transactional effects.** Kernels, DMA, scalar writes, signals, and PDI
+   loads completed before an error are not rolled back.
+
+Kernels connected by AXI streams must still tolerate backpressure. RP1 starts
+all barrier-ready endpoints, but it cannot repair a graph whose dependency
+barriers make a stream consumer unreachable.
+
+## Hardware paths
+
+### RPU to the user region
+
+The R5 uses `M_AXI_LPD` through `rpu_sc` and the NoC to reach user-region
+AXI-Lite slaves. The base design maps the PCIe-visible user range
+`0x0202_0000_0000` into the R5's 32-bit address space at `0x8800_0000`.
+For a kernel address from `system_map.xml`:
+
+```text
+r5_addr = xml_addr - 0x0202_0000_0000 + 0x8800_0000
+```
+
+The linker does not yet emit a separate R5 address table. `FpgaVbinSpec`
+performs this conversion at runtime; lower-level callers may provide an
+explicit `FpgaKernelLocationLookup`.
+
+### RPU to memory
+
+The implemented phase-1 data path reaches DDR:
+
+- `DMA_COPY` is an R5 software word copy between DDR addresses.
+- `DMA_FILL` is an R5 software word fill in DDR.
+- Host transfers still use QDMA before or after graph execution.
+- Direct HBM and host-memory DMA from RP1 are not implemented.
+
+The packet ABI reserves high address words and memory-type fields for later
+hardware-DMA phases. Current firmware uses the low 32-bit addresses. Lengths
+must be multiples of four; phase-1 firmware processes `length / 4` words.
+
+### Partial reconfiguration
+
+`PDI_LOAD` sends the Versal load-PDI request to the PMC through the R5_1-owned
+IPI. Hardware builds generate `rp1_platform_config.h` from the R5_1 standalone
+BSP. It defines the source agent, target mask, request/response buffers,
+trigger register, observation register, and a non-zero platform identity.
+QEMU uses an explicit fixture.
+
+The host must order a PDI node after every kernel using the region being
+reconfigured. RP1 tracks in-flight kernels, but it does not infer a safe
+reconfiguration boundary from physical connectivity.
+
+A PDI timeout can leave the IPI observation bit asserted while the PMC still
+owns the request. Firmware therefore marks the image `UNKNOWN`, publishes
+`RP1_RESULT_RECOVERY_REQUIRED`, and enters reset-only `ERROR`. The host must
+quarantine graph storage and recover the card before another submission.
+
+## Shared DDR layout
+
+The host-visible RP1 aperture is 64 MiB at RP1 physical address
+`0x3000_0000`. The default layout is:
+
+```text
+RP1 address       Size       Purpose
+----------------  ---------  --------------------------------------------
+0x3000_0000       4 KiB      Control block
+0x3000_1000       256 KiB    Reserved node region; v6 uses at most 32 KiB
+0x3004_1000       64 KiB     Reserved legacy-v4 gap; unused by v6
+0x3005_1000       1 MiB      Packed kernel argument records
+0x3015_1000       4 KiB      256 host-visible signal slots
+0x3015_2000       up to 64K  Optional 4096-entry (64 KiB) trace ring
+```
+
+The corresponding `RP1_DEFAULT_*_OFFSET` values are conventions. Host code may
+choose other aligned ranges inside the aperture and program the control block,
+but firmware validates all shared ranges before converting them to pointers.
+The legacy gap is intentionally not reclaimed in v6, so argument, signal, and
+trace offsets remain stable.
+
+## Protocol-v6 control block
+
+`rp1_ctrl_t` occupies exactly 4 KiB. Ownership is per field:
+
+```text
+Offset  Field                         Writer       Meaning
+------  ----------------------------  -----------  -----------------------------
+0x00    magic                         RP1          Boot contract commit "SQR1"
+0x04    version                       RP1          Must be 6
+0x08    node_count                    Host         Submitted packet count
+0x0c    _reserved_cq_size             Host         Must be zero
+0x10    node_base_lo/hi               Host         Node-array address
+0x18    _reserved_cq_base_lo/hi       Host         Must be zero
+0x20    graph_seq                     Host         Submission doorbell
+0x24    graph_done_seq                RP1          Final completed sequence
+0x28    _reserved_cq_write_idx        RP1          Must remain zero
+0x2c    _reserved_cq_read_idx         RP1          Must remain zero
+0x30    rp1_state                     RP1          INIT/READY/RUNNING/ERROR/HALTED
+0x34    rp1_error_code                RP1          Live first-error diagnostic
+0x38    rp1_current_node              RP1          Last activated node
+0x3c    heartbeat                     RP1          Liveness counter
+0x40    arg_buf_base_lo/hi            Host         Argument-buffer address
+0x48    sig_array_base_lo/hi          Host         Signal-array address
+0x50    trace_enable                  Host         Non-zero enables tracing
+0x54    trace_base_lo/hi              Host         Trace-ring address
+0x5c    trace_size                    Host         Power-of-two entry capacity
+0x60    trace_write_idx               RP1          Per-graph trace producer count
+0x64    capabilities                  RP1          Implemented RP1_CAP_* mask
+0x68    pdi_ipi_platform_id           RP1          Generated platform identity
+0x6c    terminal_error_node           RP1          Live first failing node
+0x70    terminal_error_detail         RP1          Live primary detail
+0x74    terminal_error_aux            RP1          Live auxiliary detail
+0x78    reserved alignment            —            Zero/reserved
+0x80    result                        RP1          Committed 64-byte graph result
+0xc0    reserved                      —            Rest of the 4 KiB block
+```
+
+The host must zero all v6 reserved words. Non-zero legacy words fail
+configuration validation with `RP1_ERR_INVALID_CONFIG` and
+`RP1_CONFIG_RESERVED_CQ`.
+
+Firmware advertises the exact required behavior with
+`RP1_REQUIRED_CAPABILITIES`:
+
+- generated platform/IPI configuration;
+- PMU-cycle timeouts;
+- structured PDI responses;
+- first-error-wins terminal diagnostics;
+- BTCM-staged trace events; and
+- the sequence-tagged graph result.
+
+VRT and SMI reject missing capability bits, a version other than 6, or a zero
+platform identity.
+
+## Graph result ABI
+
+`rp1_graph_result_t` is a fixed 64-byte record embedded at control offset
+`0x80`. It is rewritten for every accepted sequence.
+
+```text
+Offset  Field                  Meaning
+------  ---------------------  ----------------------------------------------
+0x00    magic                  Commit marker "RSLT", written last
+0x04    graph_seq              Exact accepted sequence
+0x08    outcome                NONE, SUCCESS, FAILED, or HALTED
+0x0c    flags                  RP1_RESULT_* bit mask
+0x10    error_code             First terminal RP1_ERR_* code
+0x14    terminal_node          Failing/HALT node, or UINT32_MAX
+0x18    terminal_opcode        Opcode, or UINT32_MAX
+0x1c    error_detail           Error-specific primary value
+0x20    error_aux              Error-specific auxiliary value
+0x24    active_image_id        Final known image id, otherwise zero
+0x28    image_state            NONE, KNOWN, or UNKNOWN
+0x2c    completed_operations   Successful executions, including repeats
+0x30    graph_elapsed_ticks    Graph start through GRAPH_DONE
+0x34    publish_elapsed_ticks  Through trace drain/result preparation
+0x38    trace_write_idx        Final trace producer count
+0x3c    quiescence             Packed finite-done/timeout/infinite counts
+```
+
+### Outcomes
+
+- `NONE` exists only before a result is committed.
+- `SUCCESS` means the scanner reached natural completion without a firmware
+  error. It does not imply transaction rollback or that every packet ran;
+  inspect flags and the VRT lifecycle sentinel.
+- `FAILED` carries a non-zero first error and places firmware in reset-only
+  `ERROR`.
+- `HALTED` identifies an explicit `RP1_OP_HALT`, carries error code zero, and
+  places firmware in reset-only `HALTED`.
+
+`FAILED` and `HALTED` are determinate graph results. A host-side timeout before
+exact-sequence completion is different: firmware may still own the graph, so
+VRT poisons the submitter and requires device recovery.
+
+### Result flags
+
+- `RP1_RESULT_RECOVERY_REQUIRED`: finite work timed out during quiescence or
+  infinite work could not be stopped. Card reset/recovery is mandatory.
+- `RP1_RESULT_EFFECTS_MAY_BE_PARTIAL`: a non-success outcome occurred after at
+  least one node began activation.
+- `RP1_RESULT_INFINITE_WORK_REMAINS`: an infinite kernel remains or was found
+  during terminal quiescence.
+- `RP1_RESULT_TRACE_ENABLED`: this graph recorded trace events.
+- `RP1_RESULT_TRACE_OVERFLOW`: the producer count exceeded ring capacity and
+  older entries were overwritten.
+- `RP1_RESULT_UNREACHED_NODES`: at least one packet remained pending,
+  dispatched, or waiting at terminal classification.
+
+Failure invalidates application outputs even when
+`EFFECTS_MAY_BE_PARTIAL` is clear. The flag distinguishes pre-activation
+validation rejection from a graph that may already have changed hardware or
+memory; it is not a transaction guarantee.
+
+### Quiescence counts
+
+`quiescence` packs three 8-bit protocol counts into one word:
+
+- bits 0-7: finite kernels that completed while terminal quiescence waited;
+- bits 8-15: finite kernels that reached their deadline during quiescence;
+- bits 16-23: infinite kernels that could not be quiesced.
+
+The first error record never changes during quiescence. Secondary inability to
+stop work is represented by counts and `RECOVERY_REQUIRED`.
+
+### Timing
+
+The Cortex-R5 PMU runs with the divide-by-64 bit enabled. One protocol tick is
+exactly 64 R5 core cycles. Unsigned subtraction is valid across one 32-bit PMU
+wrap.
+
+`graph_elapsed_ticks` starts before shared-store validation and ends after
+`GRAPH_DONE` is staged. It includes validation, scanner work, kernels, local
+DMA, PDI waits, and any periodic trace flushes encountered during execution.
+It excludes the final partial trace drain.
+
+`publish_elapsed_ticks` is the final result payload word. It includes the final
+trace drain and result preparation, but not the later commit-magic, state, and
+`graph_done_seq` stores.
+
+## Node packets
+
+Every node is a naturally four-byte-aligned 32-byte `rp1_node_t`:
+
+```text
 Offset  Size  Field
-------  ----  -----
-0x00    2B    opcode              (uint16_t)
-0x02    2B    flags               (uint16_t) -- universal flags, shared across opcodes
-0x04    4B    barrier_await_mask  (uint32_t) -- which barriers in await_bucket must be set
-0x08    4B    barrier_set_mask    (uint32_t) -- which barriers in set_bucket to raise on completion
-0x0C    1B    barrier_await_bucket (uint8_t) -- which of 32 buckets to check (0-31)
-0x0D    1B    barrier_set_bucket   (uint8_t) -- which of 32 buckets to write (0-31)
-0x0E    2B    status              (uint16_t) -- written by RP1: 0=PENDING, 1=DISPATCHED, 2=DONE, 0xFF=ERROR
-0x10    48B   payload             (varies)
-```
-
-### Barrier System
-
-The barrier system is **flat and global**: one `completed_barriers[32]` array (32 buckets x 32 bits = 1024 barriers), stored in BTCM (128 bytes).
-
-**Scheduling check (per node):**
-```
-if (completed_barriers[node.await_bucket] & node.await_mask) == node.await_mask:
-    // all dependencies met -- execute this node
-```
-
-**On node completion:**
-```
-completed_barriers[node.set_bucket] |= node.set_mask
-```
-
-This is one indexed load + one AND + one CMP from BTCM. Single-cycle access.
-
-**AND logic:** A node with multiple bits set in `await_mask` waits for ALL of them. Each bit is set by a different predecessor.
-
-**OR logic:** Multiple nodes can `set` the **same bit** in the same bucket. The first to complete sets it. A downstream node awaiting that bit unblocks as soon as any one predecessor fires.
-
-**Cross-bucket bridging:** A NOP node with `await_bucket=A, set_bucket=B` gathers signals from bucket A and publishes into bucket B. NOP nodes execute immediately (just set their barriers), making them free bridge/reduction nodes.
-
-**AND-of-ORs:** Combine both patterns. A node awaits multiple bits, each of which can be set by any of several producers via NOP bridges.
-
-### Flags (Universal)
-
-Flags are shared across all opcodes. Opcode-specific configuration goes in the payload.
-
-```
-Bit 0: HALT_ON_ERROR  -- abort graph processing if this node fails
-Bit 1: SILENT         -- suppress CQ entry for this node
-Bit 2: INFINITE       -- (KERNEL_DISPATCH only) node immediately DONE, kernel monitored for errors
-Bit 3-15: reserved
-```
-
-**INFINITE flag:** When set on a KERNEL_DISPATCH, the node transitions to DONE immediately after launching the kernel, and its barriers are set. The kernel is still added to the inflight list for error monitoring, but it does not block graph completion. If the kernel's `ap_done` fires unexpectedly, it is silently dropped from the inflight list. This is designed for stream producers and other long-running kernels that should not prevent the graph from halting. Consumers can backpressure them and they will stall naturally when the graph completes.
-
-### Opcodes
-
-```
-0x0000  NOP              -- Immediately DONE. Use as barrier bridge/reduction node.
-0x0001  WAIT             -- Park until a signal slot satisfies a condition.
-0x0002  SIGNAL           -- Write a value to a signal array slot.
-0x0010  KERNEL_DISPATCH  -- Set args + start a kernel on the FPGA.
-0x0011  SCALAR_WRITE     -- Write immediate values to kernel AXI-Lite registers.
-0x0012  SCALAR_READ      -- Read kernel register -> signal array slot.
-0x0013  SCALAR_COPY      -- Copy a signal slot's value into a kernel AXI-Lite register.
-0x0020  DMA_COPY         -- Memory transfer (DDR-DDR phase 1, DDR-HBM phase 2).
-0x0021  DMA_FILL         -- Fill a memory region with a pattern.
-0x0030  PDI_LOAD         -- Trigger a partial PDI reload from DDR via the PMC.
-0x0040  LOOP    -- Clear body state + buckets for next loop iteration.
-0x0041  COND    -- Evaluate condition, set then_bucket or else_bucket barriers.
-0x0042  RERUN            -- Clear DONE state of a target node back to PENDING.
-0x00FF  HALT             -- Stop graph processing (supplemental, for early exits).
-```
-
-Unrecognized opcodes are not rejected: the scanner's `default` case treats
-them as a no-op immediate completion (marked `DONE`, own `barrier_set_mask`
-applied, `RP1_CQ_OK` written) rather than raising `rp1_state = ERROR`. See
-Section G.
-
-### Packet Payloads
-
-#### KERNEL_DISPATCH (0x0010)
-
-```
-0x10    4B    kernel_base_addr    -- AXI-Lite base address (R5 address space)
-0x14    4B    arg_buffer_offset   -- Offset into DDR arg buffer for staged arguments
-0x18    2B    arg_count           -- Number of (reg_offset, value) argument pairs
-0x1A    2B    ctrl_flags          -- Bit 0: auto-restart
-0x1C    4B    timeout_cycles      -- PMU-tick deadline (0 = frequency-derived default)
-0x20    4B    expected_image_id   -- Image this kernel needs; 0 = no guard
-0x24    28B   reserved
-```
-
-**Expected-image guard.** When `expected_image_id` is non-zero, RP1 compares it
-against `g_active_image_id` -- the image id recorded by the most recent
-successful `PDI_LOAD` -- before launching. On mismatch the node fails fast:
-status `ERROR`, `rp1_error_code = RP1_ERR_IMAGE_MISMATCH (4)`, a `RP1_CQ_ERROR`
-CQ entry whose `error_detail` carries the active image id, and (when
-`HALT_ON_ERROR` is set) the scanner aborts. This is belt-and-braces behind the
-host compiler's static image-safety proof, so a stale dispatch fails instead of
-poking an absent kernel and hanging. `expected_image_id = 0` disables the check
-(no-image kernels and the mock/lookup host path).
-
-The host pre-stages kernel arguments in the argument buffer as an array of
-`rp1_kernel_arg_t` `(reg_offset, value)` pairs (protocol v2). RP1 reads
-`arg_count` pairs from `arg_buffer_offset` and writes each `value` to
-`kernel_base_addr + reg_offset`. This honours the non-contiguous register
-layout real HLS `s_axilite` maps produce (e.g. `n@0x10`, `in@0x1c`, `out@0x28`
-with reserved gaps); a 64-bit argument is two consecutive pairs. Before
-writing arguments, RP1 first reads `kernel_base_addr + 0x00` once to clear
-any stale, sticky `ap_done` left over from a *previous* dispatch of the same
-kernel (HLS `ap_ctrl_hs` status bits are clear-on-read); it then writes the
-arguments and writes 0x01 to `kernel_base_addr + 0x00` (ap_start).
-
-All kernel dispatches are non-blocking from the scanner's perspective. The scanner launches the kernel, marks the node DISPATCHED (or DONE if INFINITE), and continues scanning. When `ap_done` fires (detected by `check_inflight_kernels()`), the node transitions to DONE and its barriers are set.
-
-#### SCALAR_WRITE (0x0011)
-
-```
-0x10    48B   writes[6]           -- Array of (addr, value) pairs
-              Each pair: 4B addr + 4B value = 8 bytes
-              Stop at first addr == 0
-```
-
-Batches up to 6 register writes. Completes immediately (DONE).
-
-#### SCALAR_READ (0x0012)
-
-```
-0x10    4B    source_addr         -- AXI-Lite address to read
-0x14    4B    target_slot         -- Signal array slot to store value (0-255)
-0x18    40B   reserved
-```
-
-Reads a kernel register and stores the value in the signal array. This bridges hardware register space to the signal array, enabling LOOP exit conditions and COND decisions based on kernel-computed values.
-
-#### SCALAR_COPY (0x0013)
-
-```
-0x10    4B    source_slot         -- Signal array slot index to read
-0x14    4B    dest_addr           -- AXI-Lite address to write
-0x18    40B   reserved
-```
-
-The inverse of SCALAR_READ: writes `signal_array[source_slot].value` to
-`dest_addr`. Completes immediately (DONE). Used to feed a loop-carried
-scalar held in a host-visible signal slot into a body kernel's `s_axilite`
-input register each iteration, so the carried value can flow through a
-kernel argument rather than a DDR buffer.
-
-#### SIGNAL (0x0002)
-
-```
-0x10    4B    target_slot         -- Signal array slot index (0-255)
-0x14    4B    value               -- Value to write
-0x18    2B    operation           -- 0=SET, 1=ADD, 2=OR, 3=AND
-0x1A    2B    reserved
-0x1C    36B   reserved
-```
-
-Writes to `signal_array[target_slot].value`. Completes immediately (DONE).
-
-#### WAIT (0x0001)
-
-```
-0x10    4B    condition_signal    -- Signal array slot to poll
-0x14    4B    condition_value     -- Comparison value
-0x18    2B    condition_op        -- 0=EQ, 1=NE, 2=LT, 3=GE, 4=AND_NZ, 5=AND_Z
-0x1A    2B    reserved
-0x1C    36B   reserved
-```
-
-The cross-queue rendezvous primitive. Unlike a barrier (BTCM, private to one
-graph execution), the signal array is host-visible DDR, so a WAIT can gate on
-a producer outside this graph -- a peer device's RP1 graph, or the host
-writing over the BAR. When a WAIT node's barriers are met but its condition
-does not yet hold, the node status becomes `RP1_NODE_WAITING` (not
-`PENDING`/`DISPATCHED`); `check_waits()` re-evaluates every `WAITING` node
-each scan pass and completes it (sets `DONE`, raises `barrier_set_mask`) as
-soon as `compare(signal_array[condition_signal].value, condition_op,
-condition_value)` holds. While any node is `WAITING` the scanner does not
-`wfi()` -- a host BAR write does not raise an R5 wake event, so the core must
-busy-poll to observe it promptly. This supersedes the older `LOOP`+`RERUN`
-polling idiom for semaphores; see the `AWAIT_SEMAPHORE` pattern in Section F,
-which now lowers to a single WAIT node instead of two.
-
-#### DMA_COPY (0x0020)
-
-```
-0x10    4B    src_addr_lo         -- Source physical address, low 32 bits
-0x14    4B    src_addr_hi         -- Source physical address, high 32 bits
-0x18    4B    dst_addr_lo         -- Destination physical address, low 32 bits
-0x1C    4B    dst_addr_hi         -- Destination physical address, high 32 bits
-0x20    4B    length              -- Transfer size in bytes
-0x24    2B    src_type            -- 0=DDR, 1=HBM, 2=HOST
-0x26    2B    dst_type            -- 0=DDR, 1=HBM, 2=HOST
-0x28    24B   reserved
-```
-
-Phase 1 implementation: DDR-DDR only, R5 software word-copy using only the
-`_lo` halves (32-bit addressing). HOST/HBM and 64-bit addressing via the
-`_hi` halves are deferred to Phase 2.
-
-#### DMA_FILL (0x0021)
-
-```
-0x10    4B    dst_addr_lo         -- Destination physical address, low 32 bits
-0x14    4B    dst_addr_hi         -- Destination physical address, high 32 bits
-0x18    4B    length              -- Fill size in bytes
-0x1C    4B    pattern             -- 32-bit fill pattern
-0x20    2B    dst_type            -- 0=DDR, 1=HBM
-0x22    2B    reserved
-0x24    28B   reserved
-```
-
-Phase 1 implementation uses only `dst_addr_lo` (32-bit addressing).
-
-#### PDI_LOAD (0x0030)
-
-```
-0x10    4B    pdi_addr_lo         -- DDR physical address of partial PDI (low 32)
-0x14    4B    pdi_addr_hi         -- DDR physical address of partial PDI (high 32)
-0x18    4B    timeout_cycles      -- PMU-tick deadline (0 = frequency-derived default)
-0x1C    4B    image_id            -- Image this PDI installs; recorded as active
-0x20    32B   reserved
-```
-
-On success RP1 records `image_id` in `g_active_image_id`, which the
-`KERNEL_DISPATCH` expected-image guard checks. This state reflects physical
-reconfiguration and therefore **persists across graph submissions** (it is not
-cleared by the per-graph BTCM reset); only another `PDI_LOAD` changes it, and it
-starts at 0 (no image) at firmware boot. `image_id = 0` records "no image".
-
-Triggers a partial PDI reconfiguration by asking the PMC (PLM) to load
-the PDI staged at `(pdi_addr_hi << 32) | pdi_addr_lo` in DDR. Physical IPI
-selection is platform-derived: the hardware build generates
-`rp1_platform_config.h` from the AVED XSA's **R5_1 standalone BSP**
-`xparameters.h`. The generator resolves the one buffered source IPI owned by
-R5_1, the buffered PMC target mask/index, source trigger/observation registers,
-and source-to-PMC request/response addresses. It therefore does not assume that
-the AVED assignment is IPI3 (or replace it with a guessed IPI5).
-
-QEMU/unit builds use the explicit `config/qemu/rp1_platform_config.h` fixture.
-Non-QEMU CMake builds reject a fixture or missing generated header.
-
-Per the Versal IPI contract, the observation bit clears after PLM has
-processed the request and populated the response buffer. RP1 then reads
-both 32-bit response words. Status zero confirms success; non-zero status and
-the full detail word are preserved without signed conversion (including a set
-status high bit). A fatal PDI record stores status in
-`terminal_error_detail`, detail in `terminal_error_aux`, and status in the PDI
-CQ entry's `error_detail`.
-
-The host MUST also drain any in-flight kernels that live in the
-to-be-reconfigured region by gating the `PDI_LOAD` node behind their
-barriers.  The "single user region" guarantee makes this trivial in the
-common case: every kernel in the graph is in the active region, so the
-`PDI_LOAD` simply awaits the graph's join barrier.
-
-`timeout_cycles` is elapsed Cortex-R5 PMU ticks, not scanner polls. Zero selects
-the frequency-derived protocol default. On timeout RP1 marks the node `ERROR`, sets
-`rp1_error_code = RP1_ERR_PDI_TIMEOUT (3)`, and emits a `RP1_CQ_TIMEOUT` CQ
-entry.  If `HALT_ON_ERROR` is set, the graph aborts; otherwise the node's
-`barrier_set_mask` is still raised so downstream nodes can run.
-If PLM returns a non-zero response status, RP1 instead sets
-`RP1_ERR_PDI_FAILED (5)` and emits `RP1_CQ_ERROR` with that status in
-`error_detail`.
-
-#### LOOP (0x0040)
-
-```
-0x10    4B    body_start          -- First node index of loop body
-0x14    4B    body_end            -- Last node index (inclusive)
-0x18    4B    max_iterations      -- Hard cap (0 = condition-only)
-0x1C    4B    condition_signal    -- Signal array slot to check for exit
-0x20    4B    condition_value     -- Exit when signal matches this value
-0x24    2B    condition_op        -- 0=EQ, 1=NE, 2=LT, 3=GE, 4=AND_NZ, 5=AND_Z
-0x26    1B    bucket_clear_start  -- First bucket to clear each iteration
-0x27    1B    bucket_clear_end    -- Last bucket to clear (inclusive)
-0x28    1B    loop_id             -- Index into in-flight loops array (assigned by graph creator)
-0x29    23B   reserved
-```
+------  ----  ----------------------------------------------------------
+0x00    2     packed control
+0x02    1     barrier_await_bucket
+0x03    1     barrier_set_bucket
+0x04    4     barrier_await_mask
+0x08    4     barrier_set_mask
+0x0c    20    opcode-specific payload union
+```
+
+The control word has four nibbles:
+
+```text
+Bits   Meaning
+-----  ------------------------------------------------------------
+0-3    Dense opcode
+4-7    Flags
+8-11   Status: PENDING=0, DISPATCHED=1, DONE=2, WAITING=3, ERROR=4
+12-15  Reserved
+```
+
+The shared header provides C/C++-safe mask/shift helpers; the ABI uses no
+compiler bitfields. Flag bit 0 is
+`RP1_FLAG_INFINITE` for `KERNEL_DISPATCH`: the node becomes complete
+immediately after launch and does not block natural graph completion. RP1 still
+tracks the kernel while the graph runs so an observed `ap_done` can remove it.
+Flag bits 1-3 are reserved. There is no per-node error policy flag; all errors
+terminate the graph. Packet validation rejects non-zero reserved control or
+flag bits and rejects `INFINITE` on every opcode except `KERNEL_DISPATCH`.
+
+After validating `node_count` and the complete DDR source range, firmware
+executes a barrier and copies the active prefix word-by-word into the
+authoritative `rp1_node_t g_nodes[1024]` array in BTCM. It then resets each
+packed BTCM status to `PENDING`. Packet validation, LOOP/COND/RERUN re-arming,
+wait polling, quiescence, and error reporting use only that snapshot. Firmware
+does not reread or write any DDR node word during execution.
+
+Defined opcodes are:
+
+```text
+0   NOP
+1   WAIT
+2   SIGNAL
+3   KERNEL_DISPATCH
+4   SCALAR_WRITE
+5   SCALAR_READ
+6   SCALAR_COPY
+7   DMA_COPY
+8   DMA_FILL
+9   PDI_LOAD
+10  LOOP
+11  COND
+12  RERUN
+13  HALT
+```
+
+Unknown opcodes fail whole-graph validation with `RP1_ERR_INVALID_NODE`; they
+are never executed as no-ops.
+
+Payload layouts are naturally aligned within the 20-byte union:
+
+```text
+Opcode             Payload fields in byte order
+-----------------  -----------------------------------------------------------
+KERNEL_DISPATCH    base u32, arg offset u32, arg count u16, ctrl flags u8,
+                   reserved u8, timeout u32, expected image u32
+SCALAR_WRITE       two {address u32, value u32} pairs, reserved[4]
+SCALAR_READ        source u32, target slot u8, reserved[3]
+SCALAR_COPY        destination u32, source slot u8, reserved[3]
+SIGNAL             value u32, target slot u8, operation u8, reserved[2]
+WAIT               condition value u32, signal u8, operation u8, reserved[2]
+DMA_COPY           source lo/hi u32, destination lo/hi u32, length/types u32
+DMA_FILL           destination lo/hi u32, length u32, pattern u32,
+                   destination type u8, reserved[3]
+PDI_LOAD           address lo/hi u32, timeout u32, image u32, reserved[4]
+LOOP               body start/end u16, max u32, value u32, signal/op/clear
+                   start/clear end/loop id u8, reserved[3]
+COND               value u32, done mask u32, body start/end u16,
+                   signal/op/clear start/clear end/done bucket u8, reserved[3]
+RERUN              target u16, flags u8, loop id u8, reserved[16]
+```
+
+`DMA_COPY.length_types` uses bits 0-27 for byte length, bits 28-29 for source
+type, and bits 30-31 for destination type. Shared helpers pack, read, and
+replace each field without bitfields.
+
+### Kernel dispatch
+
+The 20-byte payload carries:
+
+- R5-visible AXI-Lite base address;
+- byte offset into the shared argument buffer;
+- count of `rp1_kernel_arg_t` register-offset/value pairs;
+- control flags;
+- PMU-tick timeout, with zero selecting the generated default; and
+- expected image id, with zero disabling the image guard.
+
+On a CU's first launch after firmware startup or a PDI attempt, RP1 reads the
+HLS control register to clear stale clear-on-read `ap_done`, followed by
+`dmb sy`. Completion polling performs that clear for later launches, so RP1
+caches the clean CU base and skips the redundant read and barrier. It then
+writes each non-contiguous argument register, uses `dmb st` for store-to-store
+ordering, and writes `ap_start`. Dispatches to the same CU serialize even when
+graph barriers are independent. Finite kernels remain `DISPATCHED` until
+`ap_done`. A timeout is fatal; the timed-out tracker remains available to
+terminal quiescence.
 
-When LOOP fires (barriers met), it:
-1. Increments `loop_iterations[loop_id]`
-2. Checks exit condition: `signal_array[condition_signal].value` against `condition_value`, or `loop_iterations[loop_id] > max_iterations`
-3. If exiting: marks itself DONE, sets barriers. Loop is over.
-4. If continuing: clears `completed_barriers[bucket_clear_start..bucket_clear_end]`, resets node statuses in `[body_start..body_end]` to PENDING, marks itself DONE, sets barriers. Body nodes become runnable and are picked up by the flat scanner.
+Before touching a CU, a non-zero `expected_image_id` must match a `KNOWN`
+active image. Mismatch fails fast, so stale code cannot launch against an
+absent hardware design.
 
-The LOOP node is non-blocking. It does not call a nested scheduler. It just clears state and lets the flat scanner do its job. The loop body runs naturally as part of the same scan pass.
+### Immediate operations
 
-A RERUN node at the end of the loop body re-triggers the LOOP by clearing its DONE state back to PENDING. On the next scan, the loop node fires again, checks the condition, and either continues or exits.
+- `NOP` has no side effect beyond completion and barrier publication.
+- `SIGNAL` applies SET, ADD, OR, or AND to one signal slot and records the
+  writing node.
+- `SCALAR_WRITE` performs up to two address/value writes, stopping at address
+  zero.
+- `SCALAR_READ` reads one AXI-Lite register into a signal slot.
+- `SCALAR_COPY` writes one signal-slot value to an AXI-Lite register.
+- `DMA_COPY` copies phase-1 DDR words.
+- `DMA_FILL` fills phase-1 DDR words with one 32-bit pattern.
 
-#### COND (0x0041)
+These operations finish in the activation pass. Side effects complete before
+the node's barrier-set mask becomes visible to later packets.
 
-```
-0x10    4B    condition_signal    -- Signal array slot to evaluate
-0x14    4B    condition_value     -- Comparison value
-0x18    2B    condition_op        -- 0=EQ, 1=NE, 2=LT, 3=GE, 4=AND_NZ, 5=AND_Z
-0x1A    1B    bucket_clear_start  -- First bucket to clear on continue
-0x1B    1B    bucket_clear_end    -- Last bucket to clear (inclusive)
-0x1C    4B    body_start          -- First node to reset on continue
-0x20    4B    body_end            -- Last node to reset (inclusive)
-0x24    1B    done_bucket         -- Bucket to set on done
-0x25    3B    reserved
-0x28    4B    done_mask           -- Barrier mask to set on done
-0x2C    20B   reserved
-```
-
-COND evaluates `signal_array[condition_signal].value` against `condition_value`. The node always becomes DONE immediately and its own `barrier_set_mask` is always applied.
-
-- **Continue (condition not met):** clears `completed_barriers[bucket_clear_start..bucket_clear_end]`, resets node statuses in `[body_start..body_end]` to PENDING. Body nodes become runnable and are picked up by the flat scanner.
-- **Done (condition met):** sets `completed_barriers[done_bucket] |= done_mask`. No body clearing.
-
-This is the general control flow primitive. Combined with RERUN:
-- **While-loop:** COND checks exit condition. Continue = re-run body. Done = set done barriers, unblock downstream. RERUN at end of body resets COND to PENDING.
-- **If/else:** Two CONDs with complementary conditions, each with its own body range. Or a single COND (continue = then-branch body) with done_bucket enabling else-branch nodes.
-
-#### RERUN (0x0042)
-
-```
-0x10    4B    target_node         -- Node index to reset from DONE to PENDING
-0x14    2B    rerun_flags         -- Bit 0: CLEAR_STATE (reset loop iteration counter)
-0x16    1B    loop_id             -- Loop ID to clear (if CLEAR_STATE set)
-0x17    41B   reserved
-```
+### PDI load
 
-RERUN does one thing: clears the DONE state of `target_node` back to PENDING. On the next scan pass, the target node's barriers will be re-evaluated and it will fire again if dependencies are met.
+The payload supplies a 64-bit staged-DDR PDI address, timeout, and image id.
+RP1 writes the four-word IPI request, orders it before the trigger with
+`dmb st`, completes the trigger store with `dsb st`, waits for the PMC
+observation bit to clear, then orders the response reads with `dmb sy`. Every
+attempt invalidates cached CU-clean state because the fabric may have changed
+even when PLM reports rejection or timeout.
 
-**Loop end pattern:** A RERUN at the end of a loop body targets the LOOP node. When the RERUN fires (all body nodes done), it resets the loop node to PENDING. The loop node fires again, increments iteration count, checks exit condition, and either clears the body for another iteration or exits.
+On success:
 
-- `CLEAR_STATE` flag: resets `loop_iterations[loop_id]` to zero. Used when entering a loop fresh (e.g., the first time, or when re-entering from an outer loop).
-- Without `CLEAR_STATE`: the iteration counter is preserved. This is the normal loop-end case.
+- the node completes;
+- `active_image_id` becomes the requested id;
+- image state is `KNOWN` for a non-zero id or `NONE` for zero; and
+- downstream barriers may run.
 
-#### HALT (0x00FF)
+On timeout or PMC rejection:
 
-No payload. Immediately stops graph processing. Supplemental -- normal graph completion is detected automatically when no further progress is possible (see Section D). HALT is for early exits or creative graph patterns.
+- activation stops immediately;
+- image id becomes zero and image state becomes `UNKNOWN`;
+- the result records `RP1_ERR_PDI_TIMEOUT` or `RP1_ERR_PDI_FAILED`; and
+- the firmware enters reset-only `ERROR` after quiescence/publication.
 
----
+A later error after a successful PDI does not erase that success. The final
+result still reports the installed `KNOWN` image, allowing VRT to reconcile
+host image state before it surfaces graph failure.
 
-## B. Graph Submission Protocol
+### WAIT and signals
 
-### Shared UAPI
+The signal array has 256 fixed 16-byte slots:
 
-The on-wire layout described below (control block, node packets, signal
-slots, CQ entries, opcodes, payload structs) is defined once in the
-shared header
-[`driver/libslash/include/slash/uapi/rp1_protocol.h`](../../../../driver/libslash/include/slash/uapi/rp1_protocol.h).
-Both the RP1 firmware (Cortex-R5 baremetal) and host code (libslash, SMI,
-VRT FpgaDevice) include this header, and `_Static_assert` checks at the
-bottom of the file enforce all sizes and critical offsets at compile
-time on both sides. Any change to the protocol must land in that header.
-
-### Memory Layout
-
-The host-visible BAR window is a 64MB aperture at `0x3000_0000`. All
-host/RP1 shared control, queue, argument, and signal structures must live in
-that window. DDR below `0x3000_0000` is available for RP1-private storage.
-
-```
-DDR Address        Size      Purpose
----------------    ----      -------
-0x3000_0000        4KB       Control Block           (RP1_CTRL_BAR_OFFSET)
-0x3000_1000        256KB     Node Array -- up to 4096 x 64-byte nodes    (RP1_DEFAULT_NODE_ARRAY_OFFSET)
-0x3004_1000        64KB      Completion Queue (CQ) -- 4096 x 16-byte entries  (RP1_DEFAULT_CQ_OFFSET)
-0x3005_1000        1MB       Argument Buffer -- pre-staged kernel arguments   (RP1_DEFAULT_ARG_BUF_OFFSET)
-0x3015_1000        4KB       Signal Array -- 256 x 16-byte value slots        (RP1_DEFAULT_SIG_ARRAY_OFFSET)
-0x3015_2000        ...       Optional trace ring -- 16-byte event entries     (RP1_DEFAULT_TRACE_OFFSET)
+```text
+Offset  Field
+------  ----------------------------------------------------
+0x00    value
+0x04    reserved
+0x08    last_writer_node
+0x0c    flags
 ```
 
-The offsets above are the `RP1_DEFAULT_*_OFFSET` constants in
-`rp1_protocol.h` and what `Rp1Submitter::ensureReady()` programs into the
-control block on first use. They are a convention, not hard protocol --
-firmware reads whatever base addresses the host writes into the control
-block -- so a host is free to lay the sub-regions out differently as long as
-it programs the corresponding `*_base_lo/_hi` fields consistently.
+Signals carry values; they do not schedule dependencies. A `WAIT` first becomes
+eligible through barriers, then compares a signal using EQ, NE, LT, GE,
+AND-nonzero, or AND-zero. If false, it moves to BTCM `WAITING` state and is
+rechecked every pass. RP1 does not sleep because a host BAR write does not yet
+wake the R5.
 
-### Control Block (0x3000_0000, 4KB)
+There is no firmware-wide graph deadline. A permanently false `WAIT` remains
+in flight until the host's `submitAndWait()` timeout. That timeout is
+indeterminate and poisons the VRT device; adding a firmware graph deadline is a
+separate feature.
 
-```
-Offset  Size  Field              Writer  Reader
-------  ----  -----              ------  ------
-0x00    4B    magic              RP1     Host    -- 0x53515231 ("SQR1")
-0x04    4B    version            RP1     Host    -- Protocol version (RP1_PROTOCOL_VERSION = 4)
-0x08    4B    node_count         Host    RP1     -- Number of nodes in this graph
-0x0C    4B    cq_size            Host    RP1     -- Number of CQ entries (power of 2)
-0x10    4B    node_base_lo       Host    RP1     -- Node array base address (low 32)
-0x14    4B    node_base_hi       Host    RP1     -- Node array base address (high 32)
-0x18    4B    cq_base_lo         Host    RP1     -- CQ base address (low 32)
-0x1C    4B    cq_base_hi         Host    RP1     -- CQ base address (high 32)
-0x20    4B    graph_seq          Host    RP1     -- Graph sequence number (host increments)
-0x24    4B    graph_done_seq     RP1     Host    -- Last completed graph sequence
-0x28    4B    cq_write_idx       RP1     Host    -- Next CQ write position
-0x2C    4B    cq_read_idx        Host    RP1     -- Monotonic next-unread CQ cursor
-0x30    4B    rp1_state          RP1     Host    -- 0=INIT, 1=READY, 2=RUNNING, 3=ERROR, 4=HALTED
-0x34    4B    rp1_error_code     RP1     Host    -- Last error code
-0x38    4B    rp1_current_node   RP1     Host    -- Current node being processed (debug)
-0x3C    4B    heartbeat          RP1     Host    -- Incrementing counter (liveness)
-0x40    4B    arg_buf_base_lo    Host    RP1     -- Argument buffer base address
-0x44    4B    arg_buf_base_hi    Host    RP1
-0x48    4B    sig_array_base_lo  Host    RP1     -- Signal array base address
-0x4C    4B    sig_array_base_hi  Host    RP1
-0x50    4B    trace_enable       Host    RP1     -- Non-zero enables trace queue writes
-0x54    4B    trace_base_lo      Host    RP1     -- Trace queue base address
-0x58    4B    trace_base_hi      Host    RP1
-0x5C    4B    trace_size         Host    RP1     -- Trace entries (power of 2 recommended)
-0x60    4B    trace_write_idx    RP1     Host    -- Next trace write position
-0x64    4B    capabilities       RP1     Host    -- Implemented RP1_CAP_* bits
-0x68    4B    pdi_ipi_platform_id RP1    Host    -- Non-zero generated/fixture config id
-0x6C    4B    terminal_error_node RP1    Host    -- First failing node, or UINT32_MAX
-0x70    4B    terminal_error_detail RP1  Host    -- First error's primary detail
-0x74    4B    terminal_error_aux RP1     Host    -- First error's auxiliary detail
-0x78    ...   reserved
-```
+### LOOP, COND, and RERUN
 
-### Submission Protocol
-
-The current implementation (both `rp1_run.c` on the firmware side and
-`Rp1Submitter` on the host side) is **polling-based on both ends**; the GCQ
-doorbell/IRQ path described in earlier drafts of this document
-(`irq_sq`/`irq_cq`) is not wired yet -- see "Not Yet Implemented" below.
-
-1. **Host writes** graph nodes to the node array
-2. **Host writes** kernel arguments to the argument buffer
-3. **Host clears** signal array slots used by this graph (`clearSignalSlots()`,
-   or the `submitAndWait()` image's `clear_signal_slots`)
-4. **Host records** the current monotonic CQ cursor, memory-fences, then writes
-   `node_count` and increments `graph_seq`, memory-fences again
-5. **RP1**, polling in `rp1_run()`'s outer loop (no `wfi()` until a real IRQ
-   wake path exists), notices
-   `graph_seq != graph_done_seq`
-6. **RP1 validates** node count, every shared base/range, CQ size/cursors,
-   trace config, barrier indices, opcode-specific ranges, and every
-   signal-bearing packet slot before activation. It then resolves DDR pointers,
-   resets per-graph BTCM state, and sets `rp1_state = RUNNING`.
-7. **RP1 processes** the graph via `rp1_loop()` (Section D)
-8. **RP1 writes** CQ entries for completed/failed nodes as it goes (skipped
-   for `SILENT` nodes), and if `trace_enable != 0`, writes trace-ring events
-   for graph, scheduling, wait, control-flow, PDI, and kernel lifecycle points
-9. A non-silent completion is activated/finalized only when
-   `cq_write_idx - cq_read_idx != cq_size`; a full CQ stalls that work instead
-   of overwriting unread entries. The host drains and advances `cq_read_idx`
-   during `waitForGraphDone()`, retaining copied entries for final validation,
-   so loop executions may produce more completions than the ring capacity.
-10. On a terminal failure RP1 stops activation/sentinel work, latches the first
-    `(code,node,detail,aux)`, and quiesces tracked finite kernels. Infinite or
-    expired work sets `RP1_ERR_RECOVERY_REQUIRED`.
-11. RP1 publishes CQ and trace writes and the error record, then publishes
-    `READY`/`ERROR`/`HALTED`, executes a barrier, and finally writes the exact
-    accepted sequence to `graph_done_seq`. `ERROR` and `HALTED` are reset-only
-    and reject later graph sequences.
-12. **Host polls** at ~1ms cadence using equality (`graph_done_seq == wanted`)
-    so sequence wrap is valid. It also checks terminal state each poll and
-    surfaces the full terminal record immediately, even in the publication
-    interval before `graph_done_seq`.
-
-### Not Yet Implemented
-
-- **GCQ doorbell / IRQ handoff.** Ringing `S01_AXI` to raise `irq_cq` and
-  waking the host without polling is a `TODO` left in `rp1_run.c`; the
-  symmetric host->RP1 `irq_sq` doorbell and a host-side `eventfd` consumer
-  for `irq_cq` are not implemented either. Today both sides poll a DDR word.
-- **Host trace consumer.** The optional trace ring ABI exists and the firmware
-  can write it, but `Rp1Submitter`/SMI do not yet drain or decode it.
-
-### Completion Queue Entry (16 bytes)
-
-```
-Offset  Size  Field
-------  ----  -----
-0x00    4B    node_index          -- Which node this completes
-0x04    4B    status              -- 0=OK, 1=ERROR, 2=TIMEOUT
-0x08    4B    error_detail        -- Command-specific error code
-0x0C    4B    timestamp           -- 64-cycle PMU ticks since graph start
-```
+`LOOP` increments its `loop_id` counter, then exits when its condition is true
+or the current implementation's counter exceeds `max_iterations`. On continue,
+it clears the configured barrier buckets and resets a contiguous body range to
+`PENDING`; it deliberately withholds its output barrier. A body-end `RERUN`
+resets the loop node so the next iteration can evaluate.
 
-Nodes with the SILENT flag set do not generate CQ entries.
+`COND` evaluates one signal. A true condition publishes `done_mask`; a false
+condition clears a configured bucket/body range so that branch can run. The
+COND node itself always completes and publishes its ordinary set mask.
 
-`timestamp` is written by the firmware as `PMCCNTR - g_graph_start_cycles`.
-The R5 PMU divider is enabled, so one protocol PMU tick is exactly 64 R5 core
-cycles. Kernel/PDI `timeout_cycles`, CQ timestamps, and trace timestamps all use
-this same unit. Unsigned elapsed subtraction is wrap-safe. Zero timeouts select
-durations expressed in protocol milliseconds and converted using the generated
-`RP1_R5_FREQ_HZ`.
+`RERUN` resets one target node to `PENDING`. Its optional
+`RP1_RERUN_CLEAR_STATE` flag also resets one loop counter.
 
-CQ size is a power of two in `[1, 4096]`. Both cursors are monotonically
-incrementing `uint32_t` values; occupancy is unsigned `write - read`, full is
-**equality** with capacity, and an occupancy greater than capacity is
-corruption. Ring addressing alone uses `cursor & (size - 1)`.
+`HALT` completes its own operation, records its node/opcode, stops activation,
+quiesces tracked kernels, and publishes `HALTED`. It is an explicit non-success
+result, not a firmware error code.
 
-### Optional Trace Queue Entry (16 bytes)
+## Barrier scheduler
 
-When `trace_enable != 0`, RP1 writes trace events into the ring described by
-`trace_base_lo/hi`, `trace_size`, and `trace_write_idx`. The ring uses the same
-monotonic-index convention as the CQ:
+RP1 keeps 32 buckets of 32 bits in BTCM: 1024 dependency signals total. A node
+is ready when:
 
+```text
+(barriers[await_bucket] & barrier_await_mask) == barrier_await_mask
 ```
-Offset  Size  Field
-------  ----  -----
-0x00    4B    timestamp           -- 64-cycle PMU ticks since graph start
-0x04    2B    event               -- rp1_trace_event_t
-0x06    2B    node_index          -- Node index, or 0xFFFF for graph events
-0x08    4B    aux0                -- Event-specific detail
-0x0C    4B    aux1                -- Event-specific detail
-```
 
-Current firmware events:
+Successful completion applies:
 
-```
-RP1_TRACE_GRAPH_START
-RP1_TRACE_NODE_ACTIVATE
-RP1_TRACE_KERNEL_LAUNCH
-RP1_TRACE_KERNEL_DONE
-RP1_TRACE_KERNEL_TIMEOUT
-RP1_TRACE_LOOP_ITER
-RP1_TRACE_COND_EVAL
-RP1_TRACE_WAIT_PARK
-RP1_TRACE_WAIT_WAKE
-RP1_TRACE_PDI_LOAD
-RP1_TRACE_IMAGE_MISMATCH
-RP1_TRACE_GRAPH_DONE
+```text
+barriers[set_bucket] |= barrier_set_mask
 ```
-
-The firmware resets `trace_write_idx` at each graph submission. This keeps the
-first trace entry for a submission at index 0; a cumulative cross-graph trace
-can be added later when a host-side drainer exists.
-
-### Memory Ordering
 
-R5 Cortex-R5 is weakly ordered. All writes to shared DDR must be followed by
-`DSB SY`. The host completes packet/config writes before `graph_seq`. RP1
-publishes CQ entry contents before `cq_write_idx`; terminal ordering is
-CQ/trace/error record, terminal state, `DSB SY`, then `graph_done_seq`.
-
----
-
-## C. Signal Array
-
-256 value-carrying slots in DDR, each 16 bytes:
-
-```
-Offset  Size  Field
-------  ----  -----
-0x00    4B    value               -- Current 32-bit value
-0x04    4B    reserved
-0x08    4B    last_writer_node    -- Which node last wrote this slot
-0x0C    4B    flags               -- Bit 0: host-visible (triggers CQ entry on change)
-```
+One node can await up to 32 bits from one bucket. Multiple producers may set
+the same bit to express OR. A `NOP` can gather bits from one bucket and publish
+a reduction bit in another bucket. VRT allocates bucket ranges per reset
+domain and inserts bridge/reduction nodes as needed.
 
-The signal array is **entirely separate from the barrier system**. It carries **values** for control flow:
+The scanner performs these phases every pass:
 
-- **LOOP** reads a slot value to decide whether to continue iterating
-- **COND** reads a slot value to decide which branch to take
-- **SCALAR_READ** writes kernel register values into slots
-- **SIGNAL** writes explicit values (initialization, aggregation)
+1. Scan `PENDING` nodes and activate all barrier-ready packets.
+2. Poll in-flight kernels for completion or timeout.
+3. Re-evaluate parked waits.
+4. Repeat while work made progress or a kernel/wait can still progress.
 
-The signal array is never consulted for dependency scheduling. Barriers handle that.
+Natural completion occurs when a pass makes no progress and no node is
+`DISPATCHED` or `WAITING`. Permanently blocked `PENDING` nodes do not keep the
+scanner alive. The result marks `UNREACHED_NODES`; VRT's trailing lifecycle
+`SIGNAL` sentinel provides an independent success check that all intended graph
+leaves joined.
 
-| System | Storage | Size | Purpose |
-|--------|---------|------|---------|
-| Barriers (`completed_barriers[32]`) | BTCM | 128B | Dependency scheduling (binary: done/not-done) |
-| Signal array | DDR | 4KB | Value-carrying communication (for loop/cond decisions) |
+`completed_operations` counts successful executions, not unique packets.
+Repeated LOOP, COND, RERUN, and body executions each contribute.
 
----
+## Validation and fail-fast errors
 
-## D. Command Processing Engine
+Validation has two layers before activation:
 
-### Flat Graph Scanner
+1. Shared configuration proves non-zero/bounded counts, zero reserved words,
+   aligned in-window bases, and a valid optional trace ring.
+2. Packet validation scans the whole graph for barrier buckets, signal slots,
+   conditions, kernel argument ranges, loop/body ranges, targets, and defined
+   opcodes.
 
-The engine is a single flat loop that scans all nodes every pass. There are no nested scheduler calls. LOOP and COND are non-blocking -- they modify barrier/node state and return immediately. Loop bodies and conditional branches execute naturally as part of the same flat scan.
+A failure in either layer executes no graph packet. Runtime errors stop
+activation at the first failing node. The first error wins even if quiescence
+later discovers additional stuck work.
 
-This maps onto two source files: `rp1_run.c` (the outer graph_seq poll loop,
-`rp1_main` below) and `rp1_loop.c` (the flat scanner itself, `run_graph`
-below -- named `rp1_loop()`/`activate_nodes()`/`check_inflight()`/
-`check_waits()` in the real source).
+Implemented base error codes are:
 
-```
-uint32_t completed_barriers[32];     // g_barriers -- 128 bytes in BTCM, flat, global
-uint8_t  node_status[MAX_NODES];     // g_node_status -- 1 byte per node in BTCM
-uint32_t loop_iterations[MAX_LOOPS]; // g_loop_iters -- iteration counter per loop ID
-
-struct inflight_kernel {
-    uint32_t base_addr;
-    uint32_t node_index;
-    uint32_t set_bucket;
-    uint32_t set_mask;
-    uint32_t timeout_start;               // PMU tick at launch
-    uint32_t timeout_cycles;              // elapsed PMU-tick deadline
-    uint8_t  infinite;                // INFINITE flag -- don't block halt
-    uint8_t  settle_polls;            // reserved for future stale-ap_done tolerance
-};
-inflight_kernel inflight[32];         // g_inflight, 24 bytes/entry
-
-rp1_main():                            // rp1_run()
-    magic          = RP1_CTRL_MAGIC
-    version        = RP1_PROTOCOL_VERSION
-    capabilities   = implemented RP1_CAP_* mask
-    platform_id    = generated RP1_PLATFORM_ID
-    rp1_state      = READY
-    graph_done_seq = 0
-
-    while (true):
-        if graph_seq == graph_done_seq:
-            heartbeat++
-            continue
-
-        // New graph submitted
-        rp1_store_init()                 // resolve DDR pointers, zero all BTCM state
-        rp1_state = RUNNING
-        rp1_error_code = 0
-
-        result = run_graph()
-
-        rp1_state = (result == ERR) ? ERROR : (result == HALT) ? HALTED : READY
-        DSB()
-        graph_done_seq = accepted_graph_seq
-        // TODO: ring GCQ CQ doorbell once the block design wires it
-
-
-run_graph():                            // rp1_loop()
-    while (true):
-        activated  = activate_nodes()    // one flat scan pass, PENDING nodes only
-        if activated < 0: return ERR     // inflight-full / HALT_ON_ERROR abort
-        if activated == HALT: return HALT
-
-        inflight_progress = check_inflight_kernels()
-        if inflight_progress < 0: return ERR   // HALT_ON_ERROR timeout abort
-
-        wait_progress = check_waits()    // re-poll every RP1_NODE_WAITING node
-        made_progress = activated || inflight_progress || wait_progress
-
-        // Halt condition: no DISPATCHED/WAITING nodes, no progress made
-        if !made_progress:
-            has_dispatched = any(node_status[i] == DISPATCHED for i in 0..node_count)
-            has_waiting    = any(node_status[i] == WAITING    for i in 0..node_count)
-            if !has_dispatched && !has_waiting:
-                return DONE  // graph complete (or deadlocked -- we trust the graph creator)
-            // Poll all outstanding work until IRQ wake paths are implemented.
-
-        heartbeat++
-
-
-activate_nodes():                       // one flat scan pass over PENDING nodes
-    made_progress = false
-
-    for i in [0 .. node_count):
-        if node_status[i] != PENDING:
-            continue
-
-        pkt = read_packet(i)
-
-        if (completed_barriers[pkt.await_bucket] & pkt.await_mask) != pkt.await_mask:
-            continue    // deps not met
-
-        match pkt.opcode:
-            KERNEL_DISPATCH:
-                // Expected-image guard (fails fast instead of poking an
-                // absent kernel) -- see the KERNEL_DISPATCH payload section.
-                if pkt.expected_image_id != 0 && pkt.expected_image_id != g_active_image_id:
-                    node_status[i] = ERROR
-                    report_error(i, ERR_IMAGE_MISMATCH, detail=g_active_image_id)
-                    if pkt.flags & HALT_ON_ERROR: return ERR
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask  // non-fatal
-                    made_progress = true
-                    break
-                if inflight_count >= 32:
-                    report_error(i, ERR_INFLIGHT_FULL)
-                    return ERR
-                launch_kernel(pkt)          // clears stale ap_done, writes args, pulses ap_start
-                if pkt.flags & INFINITE:
-                    node_status[i] = DONE
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                    write_cq_entry(i, OK)
-                else:
-                    node_status[i] = DISPATCHED
-                add_to_inflight(pkt, i)
-                made_progress = true
-
-            PDI_LOAD:
-                ok = rp1_pdi_load(pkt.pdi_addr_lo, pkt.pdi_addr_hi, pkt.timeout_cycles)
-                if ok:
-                    g_active_image_id = pkt.image_id   // persists across graphs
-                    node_status[i] = DONE
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                    write_cq_entry(i, OK)
-                else:
-                    node_status[i] = ERROR
-                    report_error(i, ERR_PDI_TIMEOUT)
-                    if pkt.flags & HALT_ON_ERROR: return ERR
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask  // non-fatal
-                made_progress = true
-
-            LOOP:
-                loop_iterations[pkt.loop_id]++
-                // Check exit condition
-                val = signal_array[pkt.condition_signal].value
-                if (pkt.max_iterations > 0 && loop_iterations[pkt.loop_id] > pkt.max_iterations)
-                   || compare(val, pkt.condition_op, pkt.condition_value):
-                    // Loop done -- mark DONE, set barriers, do NOT clear body
-                    node_status[i] = DONE
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                    write_cq_entry(i, OK)
-                else:
-                    // Continue looping -- clear body state, mark self DONE
-                    for b in [pkt.bucket_clear_start .. pkt.bucket_clear_end]:
-                        completed_barriers[b] = 0
-                    for n in [pkt.body_start .. pkt.body_end]:
-                        node_status[n] = PENDING
-                    node_status[i] = DONE
-                    // Do NOT set barrier_set -- body must complete + RERUN must fire first
-                made_progress = true
-
-            COND:
-                val = signal_array[pkt.condition_signal].value
-                if compare(val, pkt.condition_op, pkt.condition_value):
-                    // Done -- set done barriers
-                    completed_barriers[pkt.done_bucket] |= pkt.done_mask
-                else:
-                    // Continue -- clear body state
-                    for b in [pkt.bucket_clear_start .. pkt.bucket_clear_end]:
-                        completed_barriers[b] = 0
-                    for n in [pkt.body_start .. pkt.body_end]:
-                        node_status[n] = PENDING
-                node_status[i] = DONE
-                completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                write_cq_entry(i, OK)
-                made_progress = true
-
-            RERUN:
-                node_status[pkt.target_node] = PENDING
-                if pkt.rerun_flags & CLEAR_STATE:
-                    loop_iterations[pkt.loop_id] = 0
-                node_status[i] = DONE
-                completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                write_cq_entry(i, OK)
-                made_progress = true
-
-            WAIT:
-                val = signal_array[pkt.condition_signal].value
-                if compare(val, pkt.condition_op, pkt.condition_value):
-                    node_status[i] = DONE
-                    completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                    write_cq_entry(i, OK)
-                    made_progress = true
-                else:
-                    node_status[i] = WAITING   // parked; check_waits() re-polls it
-
-            HALT:
-                node_status[i] = DONE
-                write_cq_entry(i, OK)
-                return HALT
-
-            default:  // NOP, SIGNAL, SCALAR_WRITE, SCALAR_READ, SCALAR_COPY, DMA_COPY, DMA_FILL
-                execute_immediate(pkt)         // unrecognized opcodes: no-op here too
-                node_status[i] = DONE
-                completed_barriers[pkt.set_bucket] |= pkt.set_mask
-                write_cq_entry(i, OK)
-                made_progress = true
-
-    return made_progress
-
-
-check_inflight_kernels():                // check_inflight() -- also handles per-kernel timeout
-    made_progress = false
-    for each inflight kernel k (iterated with in-place removal):
-        if AXI_READ(k.base_addr + 0x00) & 0x2:     // ap_done
-            if k.infinite:
-                // INFINITE kernel finished unexpectedly -- silently drop
-                remove k from inflight list
-            else:
-                node_status[k.node_index] = DONE
-                completed_barriers[k.set_bucket] |= k.set_mask
-                write_cq_entry(k.node_index, OK)
-                remove k from inflight list
-            made_progress = true
-        else:
-            if (PMCCNTR - k.timeout_start) >= k.timeout_cycles:
-                node_status[k.node_index] = ERROR
-                report_error(k.node_index, ERR_KERNEL_TIMEOUT)
-                if node_flags(k.node_index) & HALT_ON_ERROR:
-                    remove k from inflight list
-                    return ERR
-                completed_barriers[k.set_bucket] |= k.set_mask  // non-fatal
-                remove k from inflight list
-                made_progress = true
-    return made_progress
-
-
-check_waits():                            // re-polls every RP1_NODE_WAITING node
-    made_progress = false
-    for i in [0 .. node_count):
-        if node_status[i] != WAITING:
-            continue
-        pkt = read_packet(i)
-        if compare(signal_array[pkt.condition_signal].value, pkt.condition_op, pkt.condition_value):
-            node_status[i] = DONE
-            completed_barriers[pkt.set_bucket] |= pkt.set_mask
-            write_cq_entry(i, OK)
-            made_progress = true
-    return made_progress
+```text
+Code  Symbol                    Primary detail / auxiliary detail
+----  ------------------------  --------------------------------------------
+1     RP1_ERR_INFLIGHT_FULL     current count / maximum count
+2     RP1_ERR_KERNEL_TIMEOUT    kernel base / timeout ticks
+3     RP1_ERR_PDI_TIMEOUT       zero / timeout ticks
+4     RP1_ERR_IMAGE_MISMATCH    expected image / active image
+5     RP1_ERR_PDI_FAILED        PMC status / PMC detail
+6     RP1_ERR_INVALID_CONFIG    RP1_CONFIG_* selector / offending value
+7     RP1_ERR_INVALID_NODE      RP1_NODE_BAD_* selector / offending value
 ```
-
-### Halt Condition
-
-The graph completes when **no further progress is possible**:
-- No `made_progress` in the last scan pass (no PENDING node had its barriers met, no inflight kernel finished/timed out, no parked WAIT resolved)
-- No nodes in DISPATCHED state (no kernels still running that could unblock others)
-- No nodes in WAITING state (no WAIT still gated on a signal a peer/host may yet raise)
-
-INFINITE kernels are in DONE state from the moment they're dispatched, so they never block halt. Their entries in the inflight list are for error monitoring only.
 
-The scanner polls all outstanding work. `wfi()` is disabled everywhere until
-the submission, kernel-completion, and signal paths have real IRQ wakeups; a
-host BAR write alone does not wake the R5.
+### Terminal quiescence
 
-All remaining PENDING nodes have permanently unsatisfied barriers (e.g., the unchosen branch of a COND). This is correct -- those nodes were never meant to run.
+After an error or HALT, RP1 never activates another packet. It inspects only
+already tracked kernels:
 
-HALT opcode is supplemental. It provides an explicit early exit for graphs that want to terminate before natural completion.
-
-### Kernel Dispatch Sequence
-
-When the scanner executes KERNEL_DISPATCH:
-
-```
-1. AXI_READ(kernel_base_addr + 0x00)        // clear stale, sticky ap_done from a prior run
-2. DSB()
-3. args = (rp1_kernel_arg_t *) &arg_buffer[arg_buffer_offset]
-4. For i in 0..arg_count-1:
-     AXI_WRITE(kernel_base_addr + args[i].reg_offset, args[i].value)
-5. DSB()                                    // Ensure all args written
-6. AXI_WRITE(kernel_base_addr + 0x00, 0x01) // ap_start
-7. Add to inflight table, continue scanning
-```
+- a finite kernel that asserts `ap_done` is counted as finite-done;
+- a finite kernel that reaches its original deadline is counted as
+  finite-timeout and requires recovery; and
+- an infinite kernel is counted as infinite and requires recovery.
 
-Steps 3-6 are AXI-Lite writes from R5 to PL, each taking ~10ns. A kernel with 8 arguments launches in **~100ns instead of ~10us (100x faster than PCIe)**.
+Quiescence does not release dependency barriers because graph execution has
+already ended. It exists to classify whether buffers and the fabric can be
+trusted for reuse, not to continue useful graph work.
 
-### Node Layout
+`ERROR` and `HALTED` are reset-only states. The outer loop continues updating
+heartbeat but rejects later `graph_seq` values. Current host recovery is a card
+reset/hotplug sequence; there is no protocol soft-reset path in VRT.
 
-Each scope's nodes must be contiguous in the node array: top-level nodes in one block, each loop body in its own block, each conditional branch in its own block. The flat scanner scans all `node_count` nodes every pass, but nodes outside the active scope have unsatisfied barriers and are skipped cheaply (one BTCM read + one AND+CMP).
+## Submission and publication ordering
 
-At any point during execution, multiple disjoint blocks of the node array can be active simultaneously. For example, two independent LOOPs in a diamond pattern both have their body nodes in PENDING state -- the scanner dispatches from both bodies in the same pass. This is how concurrent loops work without nested scheduler calls.
+Both host and firmware currently poll shared DDR. There is no wired interrupt
+handoff.
 
-### Arbitrary Graph Support
+### Firmware boot publication
 
-| Constraint | Limit | Notes |
-|------------|-------|-------|
-| Total nodes per graph | 4096 | 256KB node array |
-| Barrier signals | 1024 (32 buckets x 32) | 128 bytes in BTCM |
-| Barriers per node dependency | 32 (one bucket) | Cross-bucket via NOP bridges |
-| In-flight kernels | 32 | Error if exceeded; internal implementation limit |
-| Signal array slots | 256 | For value-carrying control flow |
-| Fan-in per node | 32 direct | Wider fan-in via NOP reduction nodes |
-| Fan-out per node | Unlimited | Multiple nodes can await the same barrier bit |
+Firmware publishes its fixed contract in this order:
 
-**OR logic:** Multiple nodes set the same barrier bit. First to complete unblocks the waiter.
+1. Clear control magic and enter `INIT`.
+2. Reset both `graph_seq` and `graph_done_seq` to the same zero idle baseline,
+   then write version, required capabilities, platform id, zero result, and
+   `READY`.
+3. Execute a full barrier.
+4. Write `RP1_CTRL_MAGIC`.
+5. Execute another full barrier.
 
-**AND logic:** One node awaits multiple bits. All must be set before it proceeds.
+Visible `SQR1` magic therefore commits the boot contract. Firmware may write
+the host-owned doorbell only while magic is invalid; clearing it before
+publication prevents a graph left in DDR by an earlier firmware instance from
+replaying after reload. Hosts must wait for visible magic before incrementing
+the new baseline.
 
-**Cross-bucket:** NOP node with `await_bucket=A, set_bucket=B` bridges regions. Executes instantly.
+### Host submission
 
-**Fan-in > 32:** Host inserts NOP reduction nodes. 64-wide fan-in = 2 NOPs (each gathering 32), feeding a final node that awaits both NOP outputs.
+`Rp1Submitter`:
 
----
+1. Requires compatible magic/version/capabilities/platform and `READY`.
+2. Writes argument records.
+3. Clears graph-owned signal slots.
+4. Writes all node packets.
+5. Writes node count and trace configuration.
+6. Executes a host fence.
+7. Writes `graph_seq = previous + 1`.
+8. Executes another host fence.
 
-## E. Examples
+Only the sequence store transfers ownership. Submission equality, not numeric
+ordering, handles `uint32_t` wrap.
 
-### Diamond DAG
+### Firmware result commit
 
-```
-      A
-     / \
-    B   C
-    |   |
-    D   E
-     \ /
-      F
-```
+After observing a new sequence, firmware snapshots the sequence and node count,
+then:
 
-All nodes in bucket 0:
+1. Clears `result.magic`, barriers, resets per-graph BTCM/error state, and
+   enters `RUNNING`.
+2. Validates every shared range, executes a barrier, and copies the active DDR
+   node words once into BTCM.
+3. Validates the BTCM packets and executes or classifies the graph.
+4. Emits `GRAPH_DONE` and captures `graph_elapsed_ticks`.
+5. Flushes the final partial trace page.
+6. Fills every result payload word, ending with
+   `publish_elapsed_ticks`.
+7. Barriers, writes `RP1_GRAPH_RESULT_MAGIC`, and barriers.
+8. Writes terminal `READY`, `ERROR`, or `HALTED`, and barriers.
+9. Writes the exact accepted sequence to `graph_done_seq`, and barriers.
 
-```
-Node 0: KERNEL_DISPATCH A  await=0/0x00  set=0/0x01   (sets bit 0)
-Node 1: KERNEL_DISPATCH B  await=0/0x01  set=0/0x02   (needs bit 0, sets bit 1)
-Node 2: KERNEL_DISPATCH C  await=0/0x01  set=0/0x04   (needs bit 0, sets bit 2)
-Node 3: KERNEL_DISPATCH D  await=0/0x02  set=0/0x08   (needs bit 1, sets bit 3)
-Node 4: KERNEL_DISPATCH E  await=0/0x04  set=0/0x10   (needs bit 2, sets bit 4)
-Node 5: KERNEL_DISPATCH F  await=0/0x18  set=0/0x20   (needs bits 3+4, sets bit 5)
-```
+The host must not use visible result magic or terminal state as an early
+completion signal. It polls until `graph_done_seq == wanted`, fences, then
+copies and validates result magic, result sequence, outcome/state agreement,
+image-state consistency, and all discriminants.
 
-E dispatches as soon as C finishes, regardless of B.
+## Optional trace ring
 
-### OR Pattern (Race)
+`rp1_trace_entry_t` is 16 bytes:
 
+```text
+Offset  Field       Meaning
+------  ----------  --------------------------------------------
+0x00    timestamp   PMU ticks since graph start
+0x04    event       rp1_trace_event_t
+0x06    node_index  Packet index, or 0xffff for graph events
+0x08    aux0        Event-specific detail
+0x0c    aux1        Event-specific detail
 ```
-algo_A -.
-         >- use_winner
-algo_B -'
-```
 
-```
-Node 0: KERNEL_DISPATCH algo_A  await=0/0x00  set=1/0x01   (sets bucket 1 bit 0)
-Node 1: KERNEL_DISPATCH algo_B  await=0/0x00  set=1/0x01   (sets bucket 1 bit 0 -- same!)
-Node 2: KERNEL_DISPATCH winner  await=1/0x01  set=1/0x02   (fires when EITHER A or B done)
-```
+Events cover graph start/done, activation, kernel launch/done/timeout, loops,
+conditions, wait park/wake, PDI response, image mismatch, and trace flush
+boundaries.
 
-### Cross-Bucket Bridge
+Normal events are staged in one 4 KiB BTCM page (256 entries). When a normal
+event leaves one slot:
 
-```
-Region A (bucket 0): nodes 0-15, produce bits 0-15
-Region B (bucket 1): nodes 20-35, need all of region A done
-```
+1. `TRACE_FLUSH_START` occupies the final slot.
+2. Firmware synchronously copies the full page into the DDR ring.
+3. The producer cursor is published only after all entries are visible.
+4. `TRACE_FLUSH_END` becomes the first entry in the new BTCM page.
 
-```
-Node 16: NOP  await=0/0xFFFF  set=1/0x01   (gather all 16 from bucket 0, bridge to bucket 1)
-Node 20: ...  await=1/0x01    ...           (depends on the bridge)
-```
+The marker interval measures blocking DDR flush cost. The final partial page is
+copied after `GRAPH_DONE` without another marker pair, avoiding recursive
+flushes. `trace_write_idx` starts at zero for each graph and is monotonic within
+that graph. Ring addressing wraps and overwrites old entries; the result flag
+reports overflow.
 
-### Iterative Convergence
+The latency benchmark preserves both physical handoff time and a
+flush-adjusted handoff:
 
-```
-        init
-         |
-    +- LOOP ----------------------+
-    |      A                      |
-    |     / \                     |
-    |    B   C   (parallel)       |
-    |     \ /                     |
-    |      D                      |
-    |      |                      |
-    |   read_err -> signal[10]    |
-    |   RERUN -> loop node        |
-    +-----------------------------+
-         |
-      finalize
-```
+- `KERNEL_DONE(i)` to `KERNEL_LAUNCH(i+1)`;
+- the same interval minus any fully bracketed flush; and
+- each `TRACE_FLUSH_START` to `TRACE_FLUSH_END` duration.
 
-Outer graph: bucket 0. Loop body: buckets 4-5.
+## Host integration
 
-```
--- outer graph (bucket 0) --
-Node 0: KERNEL_DISPATCH init     await=0/0x00  set=0/0x01
-Node 1: LOOP            await=0/0x01  set=0/0x02
-        body_start=3, body_end=8, max_iterations=1000
-        condition_signal=10, condition_op=LT, condition_value=threshold
-        bucket_clear_start=4, bucket_clear_end=5, loop_id=0
-Node 2: KERNEL_DISPATCH finalize await=0/0x02  set=0/0x04
-
--- loop body (nodes 3-8, uses buckets 4-5) --
-Node 3: KERNEL_DISPATCH A        await=4/0x00  set=4/0x01
-Node 4: KERNEL_DISPATCH B        await=4/0x01  set=4/0x02
-Node 5: KERNEL_DISPATCH C        await=4/0x01  set=4/0x04
-Node 6: KERNEL_DISPATCH D        await=4/0x06  set=4/0x08   (needs B+C)
-Node 7: SCALAR_READ err -> [10]  await=4/0x08  set=4/0x10   (needs D)
-Node 8: RERUN target=1           await=4/0x10  set=4/0x20   (needs read, reruns loop node)
-```
+### Rp1Submitter
 
-Flow: init completes -> LOOP fires, clears buckets 4-5, resets nodes 3-8 to PENDING -> body runs with full parallelism (B,C concurrent) -> SCALAR_READ captures error -> RERUN resets loop node to PENDING -> loop node fires again, checks condition -> continues or exits -> finalize runs after exit.
+`vrt::graph::fpga::Rp1Submitter` is the mechanical v6 adapter. It stages an
+`Rp1GraphImage`, writes the sequence doorbell, waits by exact equality, and
+returns a host-owned `Rp1GraphResult`.
 
-### Conditional Execution (If/Else)
+The typed result exposes:
 
-```
-    compute -> flag
-       |
-    COND (flag == 1?)
-    /          \
-  fast_path   slow_path
-    \          /
-      merge
-```
+- `Rp1GraphOutcome`;
+- optional `Rp1TerminalError`;
+- `Rp1ImageState` and active image id;
+- flags and completed operation count;
+- graph/publication ticks and trace cursor; and
+- decoded `Rp1Quiescence`.
 
-Two CONDs with complementary conditions, each gating its own branch body:
+`FAILED` and `HALTED` return normally from `submitAndWait()` so callers can
+reconcile state. Invalid host images, corrupt publication, transport errors,
+and host timeouts throw. A post-doorbell timeout permanently poisons the
+submitter because staged storage may still be firmware-owned.
 
-```
--- outer graph (bucket 0) --
-Node 0: KERNEL_DISPATCH compute  await=0/0x00  set=0/0x01
-Node 1: SCALAR_READ flag->[20]   await=0/0x01  set=0/0x02
-Node 2: COND (flag!=1 -> continue=run fast)  await=0/0x02  set=0/0x04
-        condition_signal=20, condition_op=EQ, condition_value=1
-        body_start=5, body_end=5, bucket_clear_start=4, bucket_clear_end=4
-        done_bucket=0, done_mask=0x00
-Node 3: COND (flag==1 -> continue=run slow)  await=0/0x02  set=0/0x08
-        condition_signal=20, condition_op=NE, condition_value=1
-        body_start=6, body_end=6, bucket_clear_start=5, bucket_clear_end=5
-        done_bucket=0, done_mask=0x00
-Node 4: KERNEL_DISPATCH merge    await=0/0x40  set=0/0x80
-
--- then branch (bucket 4) --
-Node 5: KERNEL_DISPATCH fast     await=4/0x00  set=0/0x40   (sets merge dep via OR)
-
--- else branch (bucket 5) --
-Node 6: KERNEL_DISPATCH slow     await=5/0x00  set=0/0x40   (same output bit -- OR logic)
-```
+### FpgaDevicePlan
 
-Both CONDs evaluate. One's condition is "not met" (continue) so it resets its body to PENDING. The other's is "met" (done) so it does nothing. Only one branch runs. Both branches set the same merge barrier (0/0x40), so merge unblocks regardless of which ran.
+The FPGA graph backend adds a trailing `SIGNAL` sentinel that depends on all
+intended leaves. After a result:
 
-### Concurrent Loops (Diamond)
+1. Reconcile active image state, even for failure.
+2. Optionally print the result when `VRT_RP1_RESULT` is set.
+3. Drain/print trace when `VRT_RP1_TRACE` is set.
+4. Surface non-success with the complete terminal record.
+5. On success, require the lifecycle sentinel value.
 
-```
-      init
-     /    \
-   LOOP_A  LOOP_B    (independent, concurrent)
-     \    /
-      join
-```
+The one-line diagnostic is suitable for acceptance automation:
 
+```text
+[rp1-result] seq=N outcome=SUCCESS(1) flags=0x... image=KNOWN(1):I completed=C graph_ticks=G publish_ticks=P trace_write_idx=T quiescence=D/T/I
 ```
-Node 0:  KERNEL_DISPATCH init    await=0/0x00  set=0/0x01
-Node 1:  LOOP A         await=0/0x01  set=0/0x02  (body=3-5, buckets 4-5, loop_id=0)
-Node 2:  LOOP B         await=0/0x01  set=0/0x04  (body=6-8, buckets 6-7, loop_id=1)
-Node 9:  KERNEL_DISPATCH join    await=0/0x06  set=0/0x08  (needs both loops done)
-
--- loop A body (nodes 3-5, buckets 4-5) --
-Node 3:  KERNEL_DISPATCH ...     await=4/0x00  set=4/0x01
-Node 4:  SCALAR_READ -> [10]     await=4/0x01  set=4/0x02
-Node 5:  RERUN target=1          await=4/0x02  set=4/0x04
-
--- loop B body (nodes 6-8, buckets 6-7) --
-Node 6:  KERNEL_DISPATCH ...     await=6/0x00  set=6/0x01
-Node 7:  SCALAR_READ -> [11]     await=6/0x01  set=6/0x02
-Node 8:  RERUN target=2          await=6/0x02  set=6/0x04
-```
-
-Both loop bodies are active simultaneously. The flat scanner dispatches nodes from both bodies in the same pass. Kernels from loop A and loop B can be in-flight concurrently on the FPGA. Each loop has its own bucket range and loop ID -- no interference.
 
----
+### Image-aware lowering
 
-## F. Patterns
+`FpgaVbinSpec` assigns stable 1-based numeric ids in image-name order.
+`PDI_LOAD` carries the installed id; every guarded kernel packet carries its
+expected id. `FpgaDevice` reconciles the result back to the named image.
 
-Compound node sequences that implement higher-level primitives from the base opcodes. These are analogous to pseudo-instructions in assembly -- the graph builder emits them as a fixed template, and the scanner executes them with no special case.
-
-### AWAIT_SEMAPHORE
-
-Wait until a signal slot satisfies a condition before allowing downstream nodes to proceed. The signal can be written by a SIGNAL node, a SCALAR_READ from a kernel register, or directly by the host into DDR.
-
-**Nodes:** 1 (native `WAIT`, opcode `0x0001`)
-
-```
-Node K: WAIT  await=<upstream>/mask  set=<downstream>/mask
-              condition_signal=S, condition_op=<op>, condition_value=V
-```
+High-level `Graph::addFpga()` handles vbin parsing, QDMA PDI staging, the vrtd
+session, BAR mapping, readiness checks, and device construction. Lower-level
+mock/test construction may use a kernel-address lookup and image id zero.
 
-**Mechanism:**
+### SMI and acceptance
 
-1. WAIT fires when upstream barriers are met. Reads `signal_array[S].value`.
-2. If the condition holds immediately: marks itself DONE, sets downstream barriers. Downstream proceeds in the same scan pass.
-3. If not: transitions to `RP1_NODE_WAITING` (not `PENDING` -- it will not be re-evaluated as a fresh dispatch candidate). `check_waits()` re-polls every `WAITING` node each scan pass, independent of barrier state, until the condition holds.
+`v80-smi debug rp1-dump` prints the v6 control contract and all graph-result
+fields without mutating the device. `rp1-ping` validates one untraced SIGNAL
+result; `rp1-trace-ping` validates the same result with tracing and prints the
+trace ring.
 
-**Signal reads are atomic** -- aligned 32-bit loads on the R5 are single AXI transactions. No special synchronization is needed beyond the `volatile` qualifier on signal slots.
+The graph hardware acceptance script enables `VRT_RP1_RESULT` and
+`VRT_RP1_TRACE`, validates each result's outcome/flags/image/timing/quiescence,
+retains PDI trace-count checks, and compares the last diagnostic sequence with
+the following read-only SMI dump.
 
-**Cost:** One scan pass per poll (~200-300ns). For signals written by other nodes within the same graph, the semaphore resolves within 1-2 scan passes. For host-written signals, latency depends on when the host performs the DDR write. While any node is `WAITING` the scanner busy-polls instead of `wfi()`-ing (see Section D), so this latency does not grow with core idling.
+## Limits and deferred work
 
-**Example -- wait for host flag:**
+Current protocol limits:
 
-```
-Node 10: SIGNAL slot=5, value=0, op=SET   await=0/0x01  set=0/0x02   (init slot)
-Node 11: WAIT  await=0/0x02  set=0/0x04                              (AWAIT_SEMAPHORE)
-               condition_signal=5, condition_op=NE, condition_value=0
-Node 12: KERNEL_DISPATCH  await=0/0x04  set=0/0x08                   (runs after host sets signal[5] != 0)
+```text
+Resource                         Limit
+-------------------------------  -------------------------------------
+Packets per graph                1024
+Barrier bits                     1024 (32 buckets x 32)
+Direct fan-in per packet         32 bits from one bucket
+In-flight kernels                32
+Signal slots                     256
+Loop counters                    64
+Trace ring                       4096 entries
+Argument staging                 Default 1 MiB shared range
+Concurrent submitters            1 exclusive owner
 ```
-
-**Legacy pattern (pre-WAIT):** before opcode `0x0001` was added, the same
-effect was built from `LOOP` + `RERUN`: a `LOOP` node whose body is a single
-`RERUN` that immediately re-triggers it, spinning until its condition holds
-without ever clearing real work. This still works (LOOP/RERUN semantics are
-unchanged) but the single-node `WAIT` form above is preferred for new graphs
--- it's cheaper (no body-clear/RERUN bookkeeping) and self-documenting.
-
-### PUSH_SEMAPHORE
-
-Signal a remote device that a local operation has completed. The remote device may be another SLASH board, a ROCm GPU, or any PCIe peer with a memory-mapped doorbell or signal slot. The graph creator resolves the target address at graph build time based on the device topology and P2P mappings.
 
-**Nodes:** 1 (SCALAR_WRITE)
+Not yet implemented:
 
-```
-Node K: SCALAR_WRITE  await=<upstream>/mask  set=<downstream>/mask
-                      target_addr=A, value=V
-```
+- firmware graph deadline for permanently parked waits;
+- interrupt-driven host/RP1 completion;
+- safe multi-client graph serialization;
+- protocol soft reset/recovery;
+- hardware DMA or direct HBM/host access;
+- linker-emitted R5 address tables; and
+- automatic proof that a PDI reconfiguration boundary drained the region.
 
-`A` is a P2P-mapped address in the R5's address space that routes through the NoC and PCIe outbound window to the remote device's memory. The graph creator computes it from the remote device's BAR address and the target offset (e.g., a signal array slot, a doorbell register, or a GPU completion flag).
+If multiple outstanding graphs are added later, completion needs a
+graph-granularity transport. Protocol v6 deliberately avoids reintroducing
+per-node publication into the dispatch hot path.
 
-**Requires:** RPU → PCIe outbound AXI path in the block design (not yet wired).
+## Verification
 
-**Examples of remote targets:**
+The migration is covered at several layers:
 
-| Remote device | Target address `A` | Value `V` |
-|---------------|-------------------|-----------|
-| SLASH board | P2P window + signal array offset + slot × 16 | Semaphore value |
-| ROCm GPU | P2P window + device doorbell offset | Completion token |
-| Host memory | P2P window + host-pinned buffer offset | Status word |
+- static ABI size/offset assertions in the shared header;
+- RP1 unit and QEMU graph tests for the exact 1024-node maximum, immutable BTCM
+  snapshots, success, fatal errors, HALT, sequence wrap, PDI image state,
+  partial effects, quiescence, trace finalization, and result publication;
+- VRT mock-BAR tests for result validation, state/outcome agreement, image
+  reconciliation, sentinel checks, timeout poisoning, and diagnostics;
+- SMI compilation plus the read-only/result-aware probes;
+- the local fake graph-hardware acceptance harness; and
+- RP1 latency host tests for result validation and BTCM flush accounting.
 
-**Interrupt-driven targets (host, GPU):** Use a second write pair for the doorbell so the target wakes without polling. SCALAR_WRITE supports up to `RP1_SCALAR_WRITE_MAX` (6) `(addr, value)` pairs per node, stopping at the first `addr == 0`:
+Typical local checks from the repository root are:
 
-```
-Node K: SCALAR_WRITE  await=<upstream>/mask  set=<downstream>/mask
-                      writes[0] = (addr=<signal slot>,      value=V)
-                      writes[1] = (addr=<doorbell register>, value=<token>)
-```
+```bash
+./scripts/build-and-test-rp1-qemu.sh
 
-| Target | Signal address | Doorbell address | Effect |
-|--------|---------------|-----------------|--------|
-| Host (GCQ) | DDR signal slot (BAR-mapped) | `0x80010000` (GCQ S01_AXI CQ tail) | `irq_cq` fires, host driver wakes |
-| Host (MSI-X) | Host-pinned memory via P2P | MSI-X table entry address | MSI-X vector fires |
-| ROCm GPU | GPU VRAM via P2P | GPU doorbell BAR | GPU signal/interrupt |
-| Remote SLASH | Remote DDR signal slot via P2P | not needed — remote RP1 polls | |
+cmake -S vrt -B vrt/build -G Ninja \
+  -DVRT_INCLUDE_VRTD=1 -DVRTD_INCLUDE_LIBSLASH=1 -DVRT_BUILD_TESTS=1
+cmake --build vrt/build --target unit_tests
+ctest --test-dir vrt/build/tests --output-on-failure
 
-**Combined with AWAIT_SEMAPHORE for cross-device synchronization:**
+cmake -S examples/extra/rp1_latency -B examples/extra/rp1_latency/build \
+  -G Ninja -DVRT_USE_REPO=ON -DBUILD_VBIN=OFF
+cmake --build examples/extra/rp1_latency/build
+ctest --test-dir examples/extra/rp1_latency/build --output-on-failure
 
-```
-Board A graph:                          Board B graph:
-  KERNEL_DISPATCH (compute)               AWAIT_SEMAPHORE signal[5] != 0
-  PUSH_SEMAPHORE → Board B signal[5]=1   KERNEL_DISPATCH (consume)
+./scripts/test-graph-hardware-local.sh
 ```
 
-Board A computes, then pushes a semaphore to Board B's signal array. Board B spins until the signal arrives, then proceeds. Both graphs are submitted independently. No host involvement on the critical path.
-
----
-
-## G. Error Handling
-
-### Error codes (`rp1_ctrl_t.rp1_error_code`)
-
-| Value | Symbol             | Meaning                                          |
-|-------|--------------------|--------------------------------------------------|
-| 0     | (none)             | No error since the last graph reset.             |
-| 1     | `ERR_INFLIGHT_FULL`| Scanner tried to dispatch a 33rd in-flight kernel. |
-| 2     | `ERR_KERNEL_TIMEOUT` | A kernel did not assert `ap_done` within `timeout_cycles`. |
-| 3     | `ERR_PDI_TIMEOUT`  | PLM did not complete a `PDI_LOAD` IPI within `timeout_cycles`. |
-| 4     | `ERR_IMAGE_MISMATCH` | A `KERNEL_DISPATCH`'s non-zero `expected_image_id` did not match the image last installed by `PDI_LOAD` (see Section A). |
-| 5     | `ERR_PDI_FAILED`   | PLM completed a `PDI_LOAD` command with an error response. |
-| 6     | `ERR_INVALID_CONFIG` | Shared bases, counts, sizes, or cursors are invalid. |
-| 7     | `ERR_INVALID_NODE` | A packet has invalid barriers, ranges, operation, arguments, or signal slots. |
-| 8     | `ERR_CQ_CORRUPT` | Unsigned CQ occupancy exceeds configured capacity. |
-
-Bit 31 (`RP1_ERR_RECOVERY_REQUIRED`) is orthogonal to the base code. It means
-launched work could not be proven quiescent and the terminal RP1/card must be
-reset before reuse.
-
-### Fatal publication
-
-The first error wins: firmware latches its node, detail, and aux and never
-overwrites them with a secondary quiesce failure. A fatal path stops all new
-activation (including the lifecycle sentinel), emits its CQ evidence, and
-polls tracked finite kernels until they complete or their PMU deadline expires.
-Infinite or expired work adds `RECOVERY_REQUIRED`. Only after CQ/trace/error
-publication does firmware expose `ERROR`, barrier, and publish
-`graph_done_seq`. `ERROR`/`HALTED` never accept another graph sequence.
-
-### Kernel Timeout
-If a kernel doesn't assert `ap_done` within `timeout_cycles`, RP1:
-1. Marks the node ERROR
-2. Writes a CQ entry with status=TIMEOUT
-3. Sets `rp1_error_code = 2` in the control block
-4. If HALT_ON_ERROR: stops graph processing. Otherwise: applies `barrier_set_mask` and continues.
-
-### PDI Load Timeout
-If the PMC does not clear the IPI observation register within
-`timeout_cycles` of a `PDI_LOAD` node firing, RP1 follows the same
-recipe with `rp1_error_code = 3` and a `RP1_CQ_TIMEOUT` CQ entry.  See
-the `PDI_LOAD` payload description in Section A for the full sequence.
-
-### Image Mismatch
-If a `KERNEL_DISPATCH`'s `expected_image_id` is non-zero and does not match
-`g_active_image_id` (the image last installed by `PDI_LOAD`; 0 = none),
-RP1:
-1. Marks the node ERROR
-2. Writes a `RP1_CQ_ERROR` CQ entry with `error_detail` set to the active
-   image id
-3. Sets `rp1_error_code = 4` in the control block
-4. If HALT_ON_ERROR: stops graph processing. Otherwise: applies `barrier_set_mask` and continues.
-
-### Inflight Limit
-If the scanner would dispatch a 33rd kernel, it reports ERR_INFLIGHT_FULL, sets `rp1_state = ERROR`, and aborts the graph unconditionally (this one is not gated behind `HALT_ON_ERROR` -- there is no slot to track the kernel in, so there is nothing safe to continue with).
-
-### Unrecognized Opcode
-RP1 does **not** treat an opcode outside the table in Section A as a graph
-error. The scanner's `default` case (which also handles `NOP`) executes it
-as a no-op immediate completion: the node is marked `DONE`, its
-`barrier_set_mask` is applied, and an `RP1_CQ_OK` entry is written. There is
-currently no distinct "malformed packet" detection -- a bad opcode silently
-becomes a no-op rather than an error. Graph correctness for opcode values
-is the host compiler's responsibility.
-
-### Watchdog
-RP1 increments `heartbeat` every scan-loop iteration (including idle polling
-of `graph_seq`), so it is a liveness counter, not a fixed-period timer.
-**Not yet implemented on the host side:** `Rp1Submitter` does not currently
-poll `heartbeat` independently of `graph_done_seq`; a stalled RP1 during a
-submission is only detected via the `submitAndWait()` timeout
-(`Rp1TimeoutError`), not a dedicated heartbeat check.
-
-### Recovery
-Design intent: host resets by asserting soft reset on GCQ
-(`RESET_INTERRUPT_CTRL[31]`) and waiting for `rp1_state = READY`. **Not yet
-implemented:** there is no reset path wired in the current host stack
-(`Rp1Submitter`/`FpgaDevice`); today the only recourse after `Rp1TimeoutError`
-or `rp1_state = ERROR` is a full SBR/hotplug reset of the card via
-`v80-smi reset` or the driver's hotplug ioctls.
-
----
-
-## H. Integration Points
-
-### VRT Runtime
-
-The VRT side of the integration is built as layered components in
-`vrt/{include,src}/graph/device/` (under namespace
-`vrt::graph` for the public surface and `vrt::graph::fpga` for the
-internal plumbing):
-
-| Layer | Header | Role |
-|-------|--------|------|
-| `Rp1BarWindow` | `device/fpga/rp1_bar_window.hpp` | Owns the `vrtd::BarFile` for BAR4. Each method brackets exactly one BAR access through `BarFile::getPtr<T>(Direction, offset)` so the dma-buf `SYNC_START` / `SYNC_END` contract is honoured. |
-| `Rp1Submitter` | `device/fpga/rp1_submitter.hpp` | Programs the control block on first use (checks v4, required capabilities, and non-zero platform id), validates every packet, stages an `Rp1GraphImage`, bumps `graph_seq`, and incrementally drains CQ while waiting by exact sequence equality. Retained entries are returned for final side-effect/status validation; terminal errors surface immediately with the full record. |
-| `FpgaVbinSpec` | `device/fpga/vbin_spec.hpp` | Resolves an image's `system_map` (register offsets, m_axi memory regions, R5 base addresses) and assigns each named image a stable 1-based numeric id for the `expected_image_id` guard. Constructing `FpgaDevice` with a `FpgaVbinSpec` (instead of a raw `FpgaKernelLocationLookup`) is what lets `Graph::addFpga()` resolve everything below without the caller hardcoding addresses. |
-| `control_lowering` helpers | `device/fpga/control_lowering.hpp` | `isRp1EvaluableCondition` / `mapRp1Condition` decide whether a host `Condition` can become a native RP1 `compare(signal, op, value)`; `SignalSlotAllocator` / `LoopIdAllocator` hand out signal slots / loop ids; `lowerBarrierEvents()` allocates barrier bits per **reset domain** (not just a single flat bucket 0). |
-| `FpgaDevice : IDevice` | `device/fpga_device.hpp` | Lowers a `vrt::graph::DGraph` into an `Rp1GraphImage` (see below). |
-
-Authoring stays in `vrt::graph::Graph` — there is no separate
-`GraphBuilder` type. The high-level entry point is
-`Graph::addFpga(const FpgaSpec&)` (`vrt/include/vrt/graph/authoring/fpga.hpp`),
-which takes a BDF, a vrtd socket, and a list of named `FpgaImageSource`s
-(vbin paths), and folds QDMA PDI staging, the vrtd session + BAR4 window,
-the RP1 readiness preflight, and `FpgaDevice` construction into one call. It
-returns an `FpgaHandle`; `FpgaHandle::image(name)` yields a named
-`FpgaImageHandle` used both for kernel handles and, via its `ImageRef`
-conversion, for reprogram nodes. The user region starts with no active
-image, so every FPGA dispatch must be gated (via `.after`/reprogram
-ordering) behind loading its image first. The lower-level constructor,
-`FpgaDevice(id, window, FpgaKernelLocationLookup lookup, ...)`, is still
-available for tests and mock/no-vbin setups: it resolves kernel names to R5
-AXI-Lite base addresses via a user-supplied lookup function instead of a
-vbin's `system_map`. The canonical demonstration is
-`examples/graph/00_multi_image_pipeline` (`multi_image_pipeline.cpp`), which
-uses the high-level `addFpga()` path with two named images (no hardcoded R5
-addresses in the example itself); it exercises a CPU+FPGA loop with an
-in-loop `PDI_LOAD` reprogram between the two images and a post-loop
-CPU-driven conditional.
-
-`FpgaDevice::compilePlan()` now lowers, beyond plain kernel dispatch:
-
-- **`CompiledKernelNode` -> `RP1_OP_KERNEL_DISPATCH`.** Arguments come from
-  `IOMap` scalar bindings packed in `IOTypeMap::inputScalars` order;
-  constants are baked in at compile time, global-variable bindings are
-  resolved at `launch()` time via the per-graph scalar map (this deferred
-  path is exercised directly, not just as an unused fallback -- see
-  `fpga_device_test.cpp`'s `GlobalScalarOnFpgaKernelUsesDeferredLaunchValue`
-  and `DeferredScalarsResolvedAtLaunch`).
-- **`CompiledReprogramNode` -> `RP1_OP_PDI_LOAD`.** The PDI is staged into
-  DDR via QDMA (`setPdiStagingDevice()` / `stagePdiFile()`/`stagePdiBytes()`)
-  and the resulting physical address + the image's numeric id
-  (`imageNumericId()`) go into the packet; downstream `KERNEL_DISPATCH`
-  nodes in that image get `expected_image_id` set so a stale dispatch fails
-  fast instead of hanging (Section A).
-- **`CompiledLoopNode` / `CompiledConditionalNode` -> `RP1_OP_LOOP` /
-  `RP1_OP_COND` + `RP1_OP_RERUN`**, when the whole loop body / branch lowers
-  to the FPGA and its predicate is RP1-evaluable
-  (`isRp1EvaluableCondition`) — otherwise a split Authority/Follower
-  rendezvous is generated so a peer device (e.g. CPU) can drive the control
-  decision and the FPGA side follows via `WAIT`/`SIGNAL`.
-- **`CompiledSignalNode` / `CompiledWaitNode` -> `RP1_OP_SIGNAL` /
-  `RP1_OP_WAIT`**, for cross-queue rendezvous over host-visible signal
-  slots.
-- **`CompiledBridgeOpNode` -> data movement** via the registered bridge
-  (see `CpuFpgaBridge` below).
-- Barrier bits are allocated **per reset domain** via `lowerBarrierEvents()`
-  (not simply "bucket 0"); each domain gets its own bucket range, and bit 31
-  of the top-level lifecycle bucket is still reserved for the trailing
-  sentinel `RP1_OP_SIGNAL` (`kDefaultSentinelSlot` / `kDefaultSentinelValue`)
-  that fires once every leaf node in that domain completes.
-- Sentinel value zero is forbidden (zero means "not completed"). Its slot
-  reservation cannot collide with explicit rendezvous/scalar slots, and slot
-  or value changes are locked once lowering creates an executable. Both host
-  and firmware independently range-check every SIGNAL, WAIT, SCALAR_READ,
-  SCALAR_COPY, LOOP, and COND slot before submission/activation.
-
-Buffer arguments are no longer purely "the user's problem": `FpgaDevice`
-packs 64-bit DDR addresses for `IOTypeMap::inputs`/`outputs`/RW buffer pairs
-following the scalars, and `ensureBufferByKey()` allocates each buffer
-either in real device memory (HBM/DDR, when the kernel's `m_axi` region is
-known via the vbin spec and a staging device is configured) or, as a
-mock/test fallback, in the BAR-window arena past the signal array
-(`kBufferArenaStart`). `CpuFpgaBridge`
-(`vrt/src/graph/crossdevice/cpu_fpga_bridge.cpp`) implements both buffer and
-scalar transfer between CPU and FPGA queues via a semaphore pool; it has no
-outstanding FPGA-side TODOs.
-
-Current limitations (each throws a descriptive diagnostic from
-`compilePlan()` rather than silently misbehaving):
-
-- Top-level `CompiledBoundaryNode`s are not yet supported (boundaries are
-  only handled inside loop/conditional child DGraphs).
-- A loop body that mixes CPU and FPGA kernels, or an FPGA loop with no FPGA
-  body nodes, is not yet supported.
-- Control-flow outputs published to a device other than the one that
-  produced them are not yet executable.
-- Up to 31 "leaf" barrier bits per reset-domain bucket (bit 31 reserved);
-  large graphs span multiple buckets via the reset-domain lowering rather
-  than being capped at a single flat 31-kernel graph.
-- Wider-than-32-bit FPGA output scalars are rejected during plan compilation
-  until the protocol grows a multi-slot read.
-
-### Driver Changes
-
-The current implementation reuses the existing daemon path unchanged: vrtd
-hands out a BAR fd via `VRTD_REQ_GET_BAR_FD`, the libvrtdpp `vrtd::BarFile`
-wraps it, and `Rp1BarWindow` builds typed accessors on top. No new wire
-opcodes.
-
-Multi-tenant serialisation of `graph_seq` and an `irq_cq`-backed eventfd for
-completion (replacing the current poll loop -- see Section B, "Not Yet
-Implemented") remain future phases; `Rp1Submitter` documents itself as
-unsafe for concurrent submitters against the same `Rp1BarWindow`.
-
-### Linker Changes
-- The RPU -> user-region AXI-Lite hardware path (`rpu_sc` M02_AXI, NoC
-  `REMAPS` to `0x8800_0000`) is already wired in the base block design --
-  see "Hardware Prerequisites" above. What's still missing:
-- `tcl_gen.py` / `system_map.xml` do not yet emit an R5-visible address
-  table alongside the PCIe-visible one; `FpgaVbinSpec` currently derives R5
-  addresses from the PCIe `system_map` via the
-  `r5_addr = xml_addr - 0x0202'0000'0000 + 0x8800'0000` formula at runtime
-  rather than reading a precomputed table.
-
----
-
-## I. Performance Analysis
-
-### Dispatch Latency
-
-| Operation | Host-Driven (PCIe) | RP1 Graph Processor |
-|-----------|--------------------|-----------------------|
-| 1 register write | ~1us | ~10ns |
-| Kernel launch (8 args) | ~10us | ~100ns |
-| 10 kernels back-to-back | ~120us | ~1us |
-| 100-iter convergence loop | ~12ms + 100 host RTTs | ~12ms + 0 host RTTs |
-
-### Throughput
-
-- Node array: 4096 nodes x 64B = 256KB (fits in a single QDMA transfer)
-- Dispatch overhead per node: ~200-300ns (DDR read + AXI-Lite writes)
-- Throughput limited by kernel execution time, not dispatch
-
-### BTCM Budget
-
-| Item | Size |
-|------|------|
-| `completed_barriers[32]` | 128B |
-| `node_status[4096]` | 4KB |
-| `loop_iterations[64]` | 256B |
-| `inflight[32]` | 768B |
-| Stack | 4KB |
-| Code variables | ~1KB |
-| **Total** | **~10.1KB of 64KB** |
-
----
-
-## J. Verification Plan
-
-1. **QEMU test:** Write test nodes to emulated DDR. Verify barrier propagation, node execution order, CQ generation.
-2. **Hardware bringup:** Verify GCQ interrupt delivery. Verify R5 DDR access.
-3. **Diamond DAG:** A->{B,C}->{D,E}->F. Verify B/C dispatch concurrently.
-4. **OR pattern:** Two nodes set same barrier bit. Verify consumer unblocks on first completion.
-5. **Cross-bucket bridge:** NOP gathers from bucket 0, sets into bucket 1. Verify downstream unblock.
-6. **LOOP + RERUN:** Loop with SCALAR_READ exit condition. Verify iteration count, bucket clearing, intra-iteration parallelism, RERUN re-triggering loop node.
-7. **COND:** Conditional with both branches. Verify only one executes, merge unblocks via OR.
-8. **Concurrent loops:** Diamond with two independent LOOPs. Verify both bodies active simultaneously, kernels interleaved.
-9. **INFINITE kernel:** Stream producer with INFINITE flag. Verify graph completes while kernel runs, kernel silently dropped from inflight on ap_done.
-10. **Fan-in reduction:** 64-wide fan-in via 2 NOP reduction nodes. Verify correct join.
-11. **Error/timeout:** Invalid kernel address. Verify timeout, HALT_ON_ERROR, inflight limit error.
-12. **WAIT (cross-queue rendezvous):** WAIT node parked on a signal slot the host/a peer writes after a delay. Verify status transitions to `WAITING`, `check_waits()` resolves it without a `wfi()` stall, downstream unblocks.
-13. **PDI_LOAD + expected_image_id:** Reprogram between two images; verify `KERNEL_DISPATCH` nodes with a matching `expected_image_id` succeed and a stale/mismatched one fails fast with `RP1_ERR_IMAGE_MISMATCH` instead of hanging. Covered end-to-end today by `examples/graph/00_multi_image_pipeline` and `fpga_device_test.cpp`.
-
-This plan predates the current implementation; items 1, 3-11 are exercised
-today by `rp1_graph_test.c` (QEMU) and `vrt/tests/fpga_device_test.cpp` /
-`graph_authoring_test.cpp` (host-side compilation + mock RP1). Item 2
-(hardware bringup) is exercised by `v80-smi debug rp1-ping` and the
-`smi/src/debug/rp1_probe.{hpp,cpp}` probe.
+Matched firmware, VRT, SMI, graph examples, and vbins are required for V80
+hardware acceptance. Protocol-v4 firmware is intentionally incompatible.

--- a/linker/slashkit/resources/aved/rp1/CMakeLists.txt
+++ b/linker/slashkit/resources/aved/rp1/CMakeLists.txt
@@ -73,6 +73,7 @@ set(RP1_SOURCES
     src/rp1_boot.S
     src/rp1_hal.c
     src/rp1_store.c
+    src/rp1_scheduler.c
     src/rp1_loop.c
     src/rp1_run.c
     src/rp1_pdi.c

--- a/linker/slashkit/resources/aved/rp1/include/slash/uapi/rp1_protocol.h
+++ b/linker/slashkit/resources/aved/rp1/include/slash/uapi/rp1_protocol.h
@@ -17,9 +17,9 @@
  * stack (libslash, SMI, VRT FpgaDevice).  It describes:
  *
  *   - Opcodes, flags, status codes, and condition operators
- *   - The 64-byte node packet and its 48-byte payload union
+ *   - The 32-byte node packet and its 20-byte payload union
  *   - The 4 KB control block at the base of the host-visible BAR window
- *   - The 16-byte signal slot and 16-byte completion-queue entry
+ *   - The 16-byte signal slot, 64-byte graph result, and trace entry
  *   - The in-flight kernel tracking table
  *   - Recommended default layout offsets within the BAR window
  *
@@ -61,8 +61,8 @@ extern "C" {
 #define RP1_CTRL_BAR_OFFSET             0x00000000UL  /* host BAR-relative */
 #define RP1_CTRL_WINDOW_SIZE            0x04000000UL  /* 64 MB aperture */
 
-#define RP1_DEFAULT_NODE_ARRAY_OFFSET   0x00001000UL  /* 256 KB */
-#define RP1_DEFAULT_CQ_OFFSET           0x00041000UL  /*  64 KB */
+#define RP1_DEFAULT_NODE_ARRAY_OFFSET   0x00001000UL  /* 256 KB reserved */
+#define RP1_RESERVED_CQ_OFFSET          0x00041000UL  /* legacy v4 CQ gap */
 #define RP1_DEFAULT_ARG_BUF_OFFSET      0x00051000UL  /*   1 MB */
 #define RP1_DEFAULT_SIG_ARRAY_OFFSET    0x00151000UL  /*   4 KB */
 #define RP1_DEFAULT_TRACE_OFFSET        0x00152000UL  /* trace ring */
@@ -72,40 +72,47 @@ extern "C" {
  * ====================================================================== */
 
 typedef enum {
-    RP1_OP_NOP             = 0x0000,
-    RP1_OP_WAIT            = 0x0001,
-    RP1_OP_SIGNAL          = 0x0002,
-    RP1_OP_KERNEL_DISPATCH = 0x0010,
-    RP1_OP_SCALAR_WRITE    = 0x0011,
-    RP1_OP_SCALAR_READ     = 0x0012,
-    RP1_OP_SCALAR_COPY     = 0x0013,
-    RP1_OP_DMA_COPY        = 0x0020,
-    RP1_OP_DMA_FILL        = 0x0021,
-    RP1_OP_PDI_LOAD        = 0x0030,
-    RP1_OP_LOOP            = 0x0040,
-    RP1_OP_COND            = 0x0041,
-    RP1_OP_RERUN           = 0x0042,
-    RP1_OP_HALT            = 0x00FF,
+    RP1_OP_NOP             = 0,
+    RP1_OP_WAIT            = 1,
+    RP1_OP_SIGNAL          = 2,
+    RP1_OP_KERNEL_DISPATCH = 3,
+    RP1_OP_SCALAR_WRITE    = 4,
+    RP1_OP_SCALAR_READ     = 5,
+    RP1_OP_SCALAR_COPY     = 6,
+    RP1_OP_DMA_COPY        = 7,
+    RP1_OP_DMA_FILL        = 8,
+    RP1_OP_PDI_LOAD        = 9,
+    RP1_OP_LOOP            = 10,
+    RP1_OP_COND            = 11,
+    RP1_OP_RERUN           = 12,
+    RP1_OP_HALT            = 13,
 } rp1_opcode_t;
 
 /* =========================================================================
- * Universal node flags (rp1_node_t.flags)
+ * Compact node control word
  * ====================================================================== */
 
-#define RP1_FLAG_HALT_ON_ERROR  (1u << 0)
-#define RP1_FLAG_SILENT         (1u << 1)
-#define RP1_FLAG_INFINITE       (1u << 2)   /* KERNEL_DISPATCH: node DONE immediately */
+#define RP1_NODE_OPCODE_SHIFT    0u
+#define RP1_NODE_OPCODE_MASK     0x000Fu
+#define RP1_NODE_FLAGS_SHIFT     4u
+#define RP1_NODE_FLAGS_MASK      0x00F0u
+#define RP1_NODE_STATUS_SHIFT    8u
+#define RP1_NODE_STATUS_MASK     0x0F00u
+#define RP1_NODE_RESERVED_MASK   0xF000u
+
+/* Bit 0 marks an infinite dispatch; flags bits 1-3 are reserved and zero. */
+#define RP1_FLAG_INFINITE        (1u << 0)
 
 /* =========================================================================
- * Node status (written by RP1 into rp1_node_t.status)
+ * Node status (written by RP1 into the node control word)
  * ====================================================================== */
 
 typedef enum {
-    RP1_NODE_PENDING    = 0x0000,
-    RP1_NODE_DISPATCHED = 0x0001,
-    RP1_NODE_DONE       = 0x0002,
-    RP1_NODE_WAITING    = 0x0003,  /* RP1_OP_WAIT: gated on a signal slot      */
-    RP1_NODE_ERROR      = 0x00FF,
+    RP1_NODE_PENDING    = 0,
+    RP1_NODE_DISPATCHED = 1,
+    RP1_NODE_DONE       = 2,
+    RP1_NODE_WAITING    = 3,  /* RP1_OP_WAIT: gated on a signal slot */
+    RP1_NODE_ERROR      = 4,
 } rp1_node_status_t;
 
 /* =========================================================================
@@ -120,19 +127,10 @@ typedef enum {
 #define RP1_ERR_PDI_FAILED      5u  /* PLM rejected a partial-PDI load command   */
 #define RP1_ERR_INVALID_CONFIG  6u  /* invalid shared control-block configuration */
 #define RP1_ERR_INVALID_NODE    7u  /* malformed node packet                      */
-#define RP1_ERR_CQ_CORRUPT      8u  /* CQ producer/consumer cursors are invalid   */
-
-/* ORed into rp1_error_code when terminal recovery requires an RP1/card reset
- * because one or more launched kernels could not be proven quiescent. */
-#define RP1_ERR_RECOVERY_REQUIRED  (1u << 31)
-#define RP1_ERR_CODE_MASK           (~RP1_ERR_RECOVERY_REQUIRED)
-
 /* terminal_error_detail values for RP1_ERR_INVALID_CONFIG. */
 #define RP1_CONFIG_NODE_COUNT       1u
 #define RP1_CONFIG_NODE_BASE        2u
-#define RP1_CONFIG_CQ_SIZE          3u
-#define RP1_CONFIG_CQ_BASE          4u
-#define RP1_CONFIG_CQ_CURSORS       5u
+#define RP1_CONFIG_RESERVED_CQ      3u
 #define RP1_CONFIG_ARG_BASE         6u
 #define RP1_CONFIG_SIGNAL_BASE      7u
 #define RP1_CONFIG_TRACE            8u
@@ -144,7 +142,6 @@ typedef enum {
 #define RP1_NODE_BAD_TARGET         4u
 #define RP1_NODE_BAD_OPERATION      5u
 #define RP1_NODE_BAD_ARGUMENTS      6u
-#define RP1_NODE_PDI_WITHOUT_CQ     7u
 
 /* =========================================================================
  * Condition operators (used by LOOP and COND)
@@ -189,6 +186,64 @@ typedef enum {
 } rp1_state_t;
 
 /* =========================================================================
+ * Terminal graph result (protocol v6)
+ * ====================================================================== */
+
+#define RP1_GRAPH_RESULT_MAGIC  0x52534C54UL  /* "RSLT" */
+#define RP1_TERMINAL_OPCODE_NONE 0xFFFFFFFFu
+
+typedef enum {
+    RP1_GRAPH_RESULT_NONE    = 0,
+    RP1_GRAPH_RESULT_SUCCESS = 1,
+    RP1_GRAPH_RESULT_FAILED  = 2,
+    RP1_GRAPH_RESULT_HALTED  = 3,
+} rp1_graph_outcome_t;
+
+typedef enum {
+    RP1_IMAGE_STATE_NONE    = 0,
+    RP1_IMAGE_STATE_KNOWN   = 1,
+    RP1_IMAGE_STATE_UNKNOWN = 2,
+} rp1_image_state_t;
+
+#define RP1_RESULT_RECOVERY_REQUIRED    (1u << 0)
+#define RP1_RESULT_EFFECTS_MAY_BE_PARTIAL (1u << 1)
+#define RP1_RESULT_INFINITE_WORK_REMAINS  (1u << 2)
+#define RP1_RESULT_TRACE_ENABLED          (1u << 3)
+#define RP1_RESULT_TRACE_OVERFLOW         (1u << 4)
+#define RP1_RESULT_UNREACHED_NODES        (1u << 5)
+
+#define RP1_QUIESCE_FINITE_DONE_SHIFT      0u
+#define RP1_QUIESCE_FINITE_TIMEOUT_SHIFT   8u
+#define RP1_QUIESCE_INFINITE_SHIFT        16u
+#define RP1_QUIESCE_COUNT_MASK             0xFFu
+#define RP1_QUIESCE_PACK(done, timeout, infinite)                       \
+    ((((uint32_t)(done) & RP1_QUIESCE_COUNT_MASK)                       \
+      << RP1_QUIESCE_FINITE_DONE_SHIFT) |                               \
+     (((uint32_t)(timeout) & RP1_QUIESCE_COUNT_MASK)                    \
+      << RP1_QUIESCE_FINITE_TIMEOUT_SHIFT) |                            \
+     (((uint32_t)(infinite) & RP1_QUIESCE_COUNT_MASK)                   \
+      << RP1_QUIESCE_INFINITE_SHIFT))
+
+typedef struct {
+    volatile uint32_t magic;               /* Written last: RP1_GRAPH_RESULT_MAGIC */
+    volatile uint32_t graph_seq;           /* Accepted graph sequence               */
+    volatile uint32_t outcome;             /* rp1_graph_outcome_t                    */
+    volatile uint32_t flags;               /* RP1_RESULT_*                           */
+    volatile uint32_t error_code;          /* First terminal RP1_ERR_* code          */
+    volatile uint32_t terminal_node;        /* Failing or HALT node                   */
+    volatile uint32_t terminal_opcode;      /* Opcode at terminal_node                */
+    volatile uint32_t error_detail;         /* Error-specific primary detail          */
+    volatile uint32_t error_aux;            /* Error-specific auxiliary detail        */
+    volatile uint32_t active_image_id;      /* Final known image id, or 0             */
+    volatile uint32_t image_state;          /* rp1_image_state_t                      */
+    volatile uint32_t completed_operations; /* Successful node executions             */
+    volatile uint32_t graph_elapsed_ticks;  /* Graph work through GRAPH_DONE          */
+    volatile uint32_t publish_elapsed_ticks;/* Includes final trace/result preparation */
+    volatile uint32_t trace_write_idx;      /* Final monotonic trace producer cursor  */
+    volatile uint32_t quiescence;           /* RP1_QUIESCE_PACK counts                */
+} rp1_graph_result_t;
+
+/* =========================================================================
  * Trace events (optional trace ring)
  * ====================================================================== */
 
@@ -205,10 +260,12 @@ typedef enum {
     RP1_TRACE_PDI_LOAD       = 9,
     RP1_TRACE_IMAGE_MISMATCH = 10,
     RP1_TRACE_GRAPH_DONE     = 11,
+    RP1_TRACE_FLUSH_START    = 12,
+    RP1_TRACE_FLUSH_END      = 13,
 } rp1_trace_event_t;
 
 /* =========================================================================
- * Payload structures (each 48 bytes, embedded in rp1_node_t)
+ * Payload structures (embedded in the 20-byte rp1_node_t payload)
  * ====================================================================== */
 
 /* Single kernel argument register write -- protocol v2.
@@ -224,7 +281,7 @@ typedef struct {
     uint32_t value;        /* 32-bit value to write                           */
 } rp1_kernel_arg_t;
 
-/* KERNEL_DISPATCH (0x0010)
+/* KERNEL_DISPATCH
  *
  * arg_buffer_offset is the byte offset into the shared argument buffer where
  * this kernel's rp1_kernel_arg_t[] begins; arg_count is the number of
@@ -235,55 +292,55 @@ typedef struct {
     uint32_t kernel_base_addr;   /* AXI-Lite base in R5 address space        */
     uint32_t arg_buffer_offset;  /* Byte offset into argument buffer          */
     uint16_t arg_count;          /* Number of (reg_offset, value) arg pairs   */
-    uint16_t ctrl_flags;         /* Bit 0: auto-restart                       */
+    uint8_t  ctrl_flags;         /* Reserved in phase 1; must be zero          */
+    uint8_t  _reserved;
     uint32_t timeout_cycles;     /* PMU ticks; 0 = firmware default           */
     uint32_t expected_image_id;  /* Image this kernel needs; 0 = no guard.
                                   * If non-zero and != the image last loaded
                                   * by PDI_LOAD, RP1 fails the node fast       */
-    uint8_t  _reserved[28];
 } rp1_payload_kernel_dispatch_t;
 
-/* SCALAR_WRITE (0x0011) -- up to 6 register writes, stop at first addr == 0. */
+/* SCALAR_WRITE -- up to two register writes, stop at first addr == 0. */
 typedef struct {
     uint32_t addr;
     uint32_t value;
 } rp1_write_pair_t;
 
-#define RP1_SCALAR_WRITE_MAX  6
+#define RP1_SCALAR_WRITE_MAX  2
 
 typedef struct {
     rp1_write_pair_t writes[RP1_SCALAR_WRITE_MAX];
+    uint8_t _reserved[4];
 } rp1_payload_scalar_write_t;
 
-/* SCALAR_READ (0x0012) */
+/* SCALAR_READ */
 typedef struct {
     uint32_t source_addr;    /* AXI-Lite address to read            */
-    uint32_t target_slot;    /* Signal array slot index (0-255)     */
-    uint8_t  _reserved[40];
+    uint8_t  target_slot;    /* Signal array slot index (0-255)     */
+    uint8_t  _reserved[3];
 } rp1_payload_scalar_read_t;
 
-/* SCALAR_COPY (0x0013) -- copy a signal slot's value into an AXI-Lite register.
+/* SCALAR_COPY -- copy a signal slot's value into an AXI-Lite register.
  *
  * The slot<->register inverse of SCALAR_READ: writes g_signals[source_slot] to
  * dest_addr.  Used to feed a loop-carried scalar held in a host-visible signal
  * slot into a body kernel's s_axilite input register each iteration, so the
  * carried value can flow through a kernel argument rather than a DDR buffer. */
 typedef struct {
-    uint32_t source_slot;    /* Signal array slot index to read     */
     uint32_t dest_addr;      /* AXI-Lite address to write           */
-    uint8_t  _reserved[40];
+    uint8_t  source_slot;    /* Signal array slot index to read     */
+    uint8_t  _reserved[3];
 } rp1_payload_scalar_copy_t;
 
-/* SIGNAL (0x0002) */
+/* SIGNAL */
 typedef struct {
-    uint32_t target_slot;    /* Signal array slot index (0-255)     */
     uint32_t value;
-    uint16_t operation;      /* rp1_sigop_t                         */
-    uint16_t _reserved0;
-    uint8_t  _reserved1[36];
+    uint8_t  target_slot;    /* Signal array slot index (0-255)     */
+    uint8_t  operation;      /* rp1_sigop_t                         */
+    uint8_t  _reserved[2];
 } rp1_payload_signal_t;
 
-/* WAIT (0x0001) -- block the node until a signal slot satisfies a condition.
+/* WAIT -- block the node until a signal slot satisfies a condition.
  *
  * The cross-queue rendezvous primitive: another command queue (a peer device's
  * RP1 graph, or the host writing over the BAR) raises @c condition_signal via
@@ -295,37 +352,95 @@ typedef struct {
  * outstanding the scanner keeps polling (it does not wfi), so host-written
  * signal updates are observed promptly. */
 typedef struct {
-    uint32_t condition_signal;  /* Signal array slot to poll           */
     uint32_t condition_value;   /* Comparison value                    */
-    uint16_t condition_op;      /* rp1_condop_t                        */
-    uint16_t _reserved0;
-    uint8_t  _reserved1[36];
+    uint8_t  condition_signal;  /* Signal array slot to poll           */
+    uint8_t  condition_op;      /* rp1_condop_t                        */
+    uint8_t  _reserved[2];
 } rp1_payload_wait_t;
 
-/* DMA_COPY (0x0020) */
+/* DMA_COPY */
 typedef struct {
     uint32_t src_addr_lo;
     uint32_t src_addr_hi;
     uint32_t dst_addr_lo;
     uint32_t dst_addr_hi;
-    uint32_t length;
-    uint16_t src_type;   /* 0=DDR, 1=HBM, 2=HOST */
-    uint16_t dst_type;
-    uint8_t  _reserved[24];
+    uint32_t length_types;
 } rp1_payload_dma_copy_t;
 
-/* DMA_FILL (0x0021) */
+#define RP1_DMA_LENGTH_MASK     0x0FFFFFFFu
+#define RP1_DMA_SRC_TYPE_SHIFT  28u
+#define RP1_DMA_DST_TYPE_SHIFT  30u
+#define RP1_DMA_TYPE_MASK       0x3u
+
+/**
+ * Return a packed DMA copy length and endpoint-type word.
+ *
+ * Values outside the 28-bit length and 2-bit type ranges are truncated.
+ */
+static inline uint32_t rp1_dma_pack(uint32_t length, uint8_t src_type,
+                                    uint8_t dst_type)
+{
+    return (length & RP1_DMA_LENGTH_MASK) |
+           (((uint32_t)src_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_SRC_TYPE_SHIFT) |
+           (((uint32_t)dst_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_DST_TYPE_SHIFT);
+}
+
+/** Return the byte length encoded in a packed DMA copy word. */
+static inline uint32_t rp1_dma_get_length(uint32_t packed)
+{
+    return packed & RP1_DMA_LENGTH_MASK;
+}
+
+/** Return the source memory type encoded in a packed DMA copy word. */
+static inline uint8_t rp1_dma_get_src_type(uint32_t packed)
+{
+    return (uint8_t)((packed >> RP1_DMA_SRC_TYPE_SHIFT) &
+                     RP1_DMA_TYPE_MASK);
+}
+
+/** Return the destination memory type encoded in a packed DMA copy word. */
+static inline uint8_t rp1_dma_get_dst_type(uint32_t packed)
+{
+    return (uint8_t)((packed >> RP1_DMA_DST_TYPE_SHIFT) &
+                     RP1_DMA_TYPE_MASK);
+}
+
+/** Replace the byte length in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_length(uint32_t packed, uint32_t length)
+{
+    return (packed & ~RP1_DMA_LENGTH_MASK) |
+           (length & RP1_DMA_LENGTH_MASK);
+}
+
+/** Replace the source memory type in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_src_type(uint32_t packed, uint8_t src_type)
+{
+    return (packed & ~(RP1_DMA_TYPE_MASK << RP1_DMA_SRC_TYPE_SHIFT)) |
+           (((uint32_t)src_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_SRC_TYPE_SHIFT);
+}
+
+/** Replace the destination memory type in a packed DMA copy word. */
+static inline uint32_t rp1_dma_set_dst_type(uint32_t packed, uint8_t dst_type)
+{
+    return (packed & ~(RP1_DMA_TYPE_MASK << RP1_DMA_DST_TYPE_SHIFT)) |
+           (((uint32_t)dst_type & RP1_DMA_TYPE_MASK)
+            << RP1_DMA_DST_TYPE_SHIFT);
+}
+
+/* DMA_FILL */
 typedef struct {
     uint32_t dst_addr_lo;
     uint32_t dst_addr_hi;
     uint32_t length;
     uint32_t pattern;
-    uint16_t dst_type;
-    uint16_t _reserved0;
-    uint8_t  _reserved1[28];
+    uint8_t  dst_type;
+    uint8_t  _reserved[3];
 } rp1_payload_dma_fill_t;
 
-/* PDI_LOAD (0x0030) -- partial PDI reconfiguration via PMC IPI.
+/* PDI_LOAD -- partial PDI reconfiguration via PMC IPI.
  *
  * The host pre-stages a partial PDI in DDR at (pdi_addr_hi << 32 | pdi_addr_lo)
  * and submits this node.  When the node fires, RP1 issues the canonical
@@ -341,62 +456,57 @@ typedef struct {
     uint32_t image_id;        /* Image id this PDI installs; recorded as
                                * the active image so KERNEL_DISPATCH can
                                * guard against stale dispatches. 0 = none */
-    uint8_t  _reserved1[32];
+    uint8_t  _reserved[4];
 } rp1_payload_pdi_load_t;
 
-/* LOOP (0x0040) */
+/* LOOP */
 typedef struct {
-    uint32_t body_start;          /* First node index of loop body     */
-    uint32_t body_end;            /* Last node index (inclusive)        */
+    uint16_t body_start;          /* First node index of loop body     */
+    uint16_t body_end;            /* Last node index (inclusive)        */
     uint32_t max_iterations;      /* Hard cap (0 = condition-only)     */
-    uint32_t condition_signal;    /* Signal array slot to check        */
     uint32_t condition_value;     /* Exit when signal matches          */
-    uint16_t condition_op;        /* rp1_condop_t                      */
+    uint8_t  condition_signal;    /* Signal array slot to check        */
+    uint8_t  condition_op;        /* rp1_condop_t                      */
     uint8_t  bucket_clear_start;  /* First bucket to clear per iter    */
     uint8_t  bucket_clear_end;    /* Last bucket to clear (inclusive)  */
     uint8_t  loop_id;             /* Index into loop_iterations[]      */
-    uint8_t  _reserved[23];
+    uint8_t  _reserved[3];
 } rp1_payload_loop_t;
 
-/* COND (0x0041) */
+/* COND */
 typedef struct {
-    uint32_t condition_signal;    /* Signal slot to evaluate           */
     uint32_t condition_value;
-    uint16_t condition_op;        /* rp1_condop_t                      */
+    uint32_t done_mask;
+    uint16_t body_start;          /* First node index (inclusive)      */
+    uint16_t body_end;            /* Last node index (inclusive)       */
+    uint8_t  condition_signal;    /* Signal slot to evaluate           */
+    uint8_t  condition_op;        /* rp1_condop_t                      */
     uint8_t  bucket_clear_start;  /* First bucket to clear (inclusive) */
     uint8_t  bucket_clear_end;    /* Last bucket to clear (inclusive)  */
-    uint32_t body_start;          /* First node index (inclusive)      */
-    uint32_t body_end;            /* Last node index (inclusive)       */
     uint8_t  done_bucket;
-    uint8_t  _reserved0[3];
-    uint32_t done_mask;
-    uint8_t  _reserved1[20];
+    uint8_t  _reserved[3];
 } rp1_payload_cond_t;
 
-/* RERUN (0x0042) */
+/* RERUN */
 typedef struct {
-    uint32_t target_node;    /* Node index to reset DONE -> PENDING  */
-    uint16_t rerun_flags;    /* RP1_RERUN_CLEAR_STATE                */
+    uint16_t target_node;    /* Node index to reset DONE -> PENDING  */
+    uint8_t  rerun_flags;    /* RP1_RERUN_CLEAR_STATE                */
     uint8_t  loop_id;        /* Loop ID to clear (if CLEAR_STATE)    */
-    uint8_t  _reserved0[1];
-    uint8_t  _reserved1[40];
+    uint8_t  _reserved[16];
 } rp1_payload_rerun_t;
 
 /* =========================================================================
- * Node packet -- 64 bytes, 16-byte header + 48-byte payload
+ * Node packet -- 32 bytes, 12-byte header + 20-byte payload
  * ====================================================================== */
 
 typedef struct {
-    /* Header (16 bytes) */
-    uint16_t opcode;               /* rp1_opcode_t                          */
-    uint16_t flags;                /* RP1_FLAG_*                            */
-    uint32_t barrier_await_mask;   /* Which bits in await_bucket must be set */
-    uint32_t barrier_set_mask;     /* Which bits in set_bucket to raise      */
+    uint16_t control;              /* Packed opcode, flags, and status      */
     uint8_t  barrier_await_bucket; /* Which of 32 buckets to check (0-31)   */
     uint8_t  barrier_set_bucket;   /* Which of 32 buckets to write (0-31)   */
-    uint16_t status;               /* rp1_node_status_t, written by RP1     */
+    uint32_t barrier_await_mask;   /* Which bits in await_bucket must be set */
+    uint32_t barrier_set_mask;     /* Which bits in set_bucket to raise      */
 
-    /* Payload (48 bytes) */
+    /* Payload (20 bytes) */
     union {
         rp1_payload_kernel_dispatch_t kernel_dispatch;
         rp1_payload_scalar_write_t    scalar_write;
@@ -410,9 +520,85 @@ typedef struct {
         rp1_payload_loop_t            loop;
         rp1_payload_cond_t            cond;
         rp1_payload_rerun_t           rerun;
-        uint8_t raw[48];
+        uint8_t raw[20];
     } payload;
 } rp1_node_t;
+
+/**
+ * Build a control word from unshifted opcode, flag, and status values.
+ *
+ * Values are truncated to their four-bit fields and reserved bits are zero.
+ */
+static inline uint16_t rp1_node_make_control(uint16_t opcode, uint16_t flags,
+                                             uint16_t status)
+{
+    return (uint16_t)(((opcode << RP1_NODE_OPCODE_SHIFT) &
+                       RP1_NODE_OPCODE_MASK) |
+                      ((flags << RP1_NODE_FLAGS_SHIFT) &
+                       RP1_NODE_FLAGS_MASK) |
+                      ((status << RP1_NODE_STATUS_SHIFT) &
+                       RP1_NODE_STATUS_MASK));
+}
+
+/** Return the complete packed node control word. */
+static inline uint16_t rp1_node_get_control(const rp1_node_t *node)
+{
+    return node->control;
+}
+
+/** Replace the complete packed node control word. */
+static inline void rp1_node_set_control(rp1_node_t *node, uint16_t control)
+{
+    node->control = control;
+}
+
+/** Return the unshifted opcode nibble from a node. */
+static inline uint8_t rp1_node_get_opcode(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_OPCODE_MASK) >>
+                     RP1_NODE_OPCODE_SHIFT);
+}
+
+/** Replace the opcode nibble without changing flags, status, or reserved bits. */
+static inline void rp1_node_set_opcode(rp1_node_t *node, uint16_t opcode)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_OPCODE_MASK) |
+                   ((opcode << RP1_NODE_OPCODE_SHIFT) &
+                    RP1_NODE_OPCODE_MASK));
+}
+
+/** Return the unshifted flags nibble from a node. */
+static inline uint8_t rp1_node_get_flags(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_FLAGS_MASK) >>
+                     RP1_NODE_FLAGS_SHIFT);
+}
+
+/** Replace the flags nibble without changing opcode, status, or reserved bits. */
+static inline void rp1_node_set_flags(rp1_node_t *node, uint16_t flags)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_FLAGS_MASK) |
+                   ((flags << RP1_NODE_FLAGS_SHIFT) &
+                    RP1_NODE_FLAGS_MASK));
+}
+
+/** Return the unshifted status nibble from a node. */
+static inline uint8_t rp1_node_get_status(const rp1_node_t *node)
+{
+    return (uint8_t)((node->control & RP1_NODE_STATUS_MASK) >>
+                     RP1_NODE_STATUS_SHIFT);
+}
+
+/** Replace the status nibble without changing opcode, flags, or reserved bits. */
+static inline void rp1_node_set_status(rp1_node_t *node, uint16_t status)
+{
+    node->control =
+        (uint16_t)((node->control & (uint16_t)~RP1_NODE_STATUS_MASK) |
+                   ((status << RP1_NODE_STATUS_SHIFT) &
+                    RP1_NODE_STATUS_MASK));
+}
 
 /* =========================================================================
  * Control block -- 4 KB DDR region at RP1_CTRL_PHYS_ADDR
@@ -420,19 +606,21 @@ typedef struct {
 
 #define RP1_CTRL_MAGIC  0x53515231UL  /* "SQR1" */
 
-/* Protocol-v4 firmware capabilities.  These bits describe support for the
- * reserved v4 contracts; host code must reject firmware missing any bit in
+/* Protocol-v6 firmware capabilities.  These bits describe support for the
+ * reserved v6 contracts; host code must reject firmware missing any bit in
  * RP1_REQUIRED_CAPABILITIES. */
 #define RP1_CAP_PLATFORM_PDI_IPI_CONFIG   (1u << 0)
 #define RP1_CAP_PMU_CYCLE_TIMEOUTS        (1u << 1)
-#define RP1_CAP_CQ_FLOW_CONTROL           (1u << 2)
 #define RP1_CAP_STRUCTURED_PDI_RESPONSE   (1u << 3)
 #define RP1_CAP_LATCHED_TERMINAL_ERRORS   (1u << 4)
+#define RP1_CAP_BTCM_TRACE_STAGING        (1u << 5)
+#define RP1_CAP_GRAPH_RESULT              (1u << 6)
 
 #define RP1_REQUIRED_CAPABILITIES                                      \
     (RP1_CAP_PLATFORM_PDI_IPI_CONFIG | RP1_CAP_PMU_CYCLE_TIMEOUTS |   \
-     RP1_CAP_CQ_FLOW_CONTROL | RP1_CAP_STRUCTURED_PDI_RESPONSE |      \
-     RP1_CAP_LATCHED_TERMINAL_ERRORS)
+     RP1_CAP_STRUCTURED_PDI_RESPONSE |                                \
+     RP1_CAP_LATCHED_TERMINAL_ERRORS | RP1_CAP_BTCM_TRACE_STAGING |   \
+     RP1_CAP_GRAPH_RESULT)
 
 #define RP1_PDI_IPI_PLATFORM_UNKNOWN  0u
 #define RP1_TERMINAL_ERROR_NODE_NONE  0xFFFFFFFFu
@@ -443,17 +631,16 @@ typedef struct {
     volatile uint32_t version;          /* 0x04: protocol version                */
     /* Host writes, RP1 reads */
     volatile uint32_t node_count;       /* 0x08: nodes in this graph             */
-    volatile uint32_t cq_size;          /* 0x0C: power of 2, <= MAX_CQ_ENTRIES   */
+    volatile uint32_t _reserved_cq_size;/* 0x0C: must be zero in protocol v6     */
     volatile uint32_t node_base_lo;     /* 0x10: node array base (low 32 bits)   */
     volatile uint32_t node_base_hi;     /* 0x14: node array base (high 32 bits)  */
-    volatile uint32_t cq_base_lo;       /* 0x18: CQ base (low 32 bits)           */
-    volatile uint32_t cq_base_hi;       /* 0x1C: CQ base (high 32 bits)          */
+    volatile uint32_t _reserved_cq_base_lo; /* 0x18: must be zero in v6           */
+    volatile uint32_t _reserved_cq_base_hi; /* 0x1C: must be zero in v6           */
     volatile uint32_t graph_seq;        /* 0x20: host increments per graph        */
     /* RP1 writes */
     volatile uint32_t graph_done_seq;   /* 0x24: last completed graph             */
-    volatile uint32_t cq_write_idx;     /* 0x28: next CQ write position          */
-    /* Host writes */
-    volatile uint32_t cq_read_idx;      /* 0x2C: next unread CQ position         */
+    volatile uint32_t _reserved_cq_write_idx; /* 0x28: zero in protocol v6         */
+    volatile uint32_t _reserved_cq_read_idx;  /* 0x2C: zero in protocol v6         */
     /* RP1 writes */
     volatile uint32_t rp1_state;        /* 0x30: rp1_state_t                     */
     volatile uint32_t rp1_error_code;   /* 0x34: last error code                 */
@@ -469,13 +656,15 @@ typedef struct {
     volatile uint32_t trace_base_hi;    /* 0x58: trace ring base (high 32 bits)  */
     volatile uint32_t trace_size;       /* 0x5C: trace entries (power of 2)      */
     volatile uint32_t trace_write_idx;  /* 0x60: next trace write position       */
-    /* RP1 writes: protocol-v4 contract publication and diagnostics */
+    /* RP1 writes: protocol-v6 contract publication and diagnostics */
     volatile uint32_t capabilities;          /* 0x64: RP1_CAP_*                    */
     volatile uint32_t pdi_ipi_platform_id;   /* 0x68: selected IPI/platform config */
     volatile uint32_t terminal_error_node;   /* 0x6C: latched failing node         */
     volatile uint32_t terminal_error_detail; /* 0x70: structured error detail      */
     volatile uint32_t terminal_error_aux;    /* 0x74: structured auxiliary detail  */
-    uint8_t _reserved[0x1000 - 0x78];
+    uint32_t _reserved_result_align[2];      /* 0x78-0x7F                       */
+    rp1_graph_result_t result;               /* 0x80-0xBF: committed graph result */
+    uint8_t _reserved[0x1000 - 0xC0];
 } rp1_ctrl_t;
 
 /* =========================================================================
@@ -490,23 +679,6 @@ typedef struct {
     volatile uint32_t last_writer_node; /* Node that last wrote               */
     volatile uint32_t flags;            /* RP1_SIG_FLAG_*                     */
 } rp1_signal_slot_t;
-
-/* =========================================================================
- * Completion queue entry -- 16 bytes
- * ====================================================================== */
-
-typedef enum {
-    RP1_CQ_OK      = 0,
-    RP1_CQ_ERROR   = 1,
-    RP1_CQ_TIMEOUT = 2,
-} rp1_cq_status_t;
-
-typedef struct {
-    volatile uint32_t node_index;    /* Which node completed               */
-    volatile uint32_t status;        /* rp1_cq_status_t                    */
-    volatile uint32_t error_detail;  /* Opcode-specific error code         */
-    volatile uint32_t timestamp;     /* PMU ticks since graph start        */
-} rp1_cq_entry_t;
 
 /* =========================================================================
  * Trace queue entry -- 16 bytes
@@ -540,18 +712,17 @@ typedef struct {
  * Compile-time size constants
  * ====================================================================== */
 
-#define RP1_MAX_NODES          4096
-#define RP1_MAX_CQ_ENTRIES     4096
+#define RP1_MAX_NODES          1024
 #define RP1_MAX_TRACE_ENTRIES  4096
 #define RP1_MAX_LOOPS            64
 #define RP1_MAX_INFLIGHT         32
 #define RP1_MAX_SIGNALS         256
 #define RP1_MAX_BUCKETS          32
 
-#define RP1_PROTOCOL_VERSION  4u
+#define RP1_PROTOCOL_VERSION  6u
 
 /* Cortex-R5 PMCCNTR is configured with PMCR.D, so one protocol PMU tick is
- * exactly 64 R5 core cycles. timeout_cycles and trace/CQ timestamps use this
+ * exactly 64 R5 core cycles. timeout_cycles and trace/result timestamps use this
  * unit. Hardware defaults are derived from the generated R5 clock frequency. */
 #define RP1_PMU_CYCLE_DIVISOR             64u
 #define RP1_DEFAULT_KERNEL_TIMEOUT_MS    1000u
@@ -569,41 +740,109 @@ typedef struct {
 #  define RP1_STATIC_ASSERT(cond, msg) _Static_assert((cond), msg)
 #endif
 
-/* Node packet must be exactly 64 bytes with payload at offset 16. */
-RP1_STATIC_ASSERT(sizeof(rp1_node_t) == 64,
-                  "rp1_node_t must be exactly 64 bytes");
-RP1_STATIC_ASSERT(offsetof(rp1_node_t, payload) == 16,
-                  "rp1_node_t payload must start at byte 16");
+/* Node packet must be exactly 32 bytes with payload at offset 12. */
+RP1_STATIC_ASSERT(sizeof(rp1_node_t) == 32,
+                  "rp1_node_t must be exactly 32 bytes");
+#if defined(__cplusplus)
+RP1_STATIC_ASSERT(alignof(rp1_node_t) == 4,
+                  "rp1_node_t must be naturally four-byte aligned");
+#else
+RP1_STATIC_ASSERT(_Alignof(rp1_node_t) == 4,
+                  "rp1_node_t must be naturally four-byte aligned");
+#endif
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, control) == 0,
+                  "rp1_node_t control must start at byte 0");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_await_bucket) == 2,
+                  "rp1_node_t await bucket must start at byte 2");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_set_bucket) == 3,
+                  "rp1_node_t set bucket must start at byte 3");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_await_mask) == 4,
+                  "rp1_node_t await mask must start at byte 4");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, barrier_set_mask) == 8,
+                  "rp1_node_t set mask must start at byte 8");
+RP1_STATIC_ASSERT(offsetof(rp1_node_t, payload) == 12,
+                  "rp1_node_t payload must start at byte 12");
 
 /* Kernel argument pair (protocol v2) must be exactly 8 bytes. */
 RP1_STATIC_ASSERT(sizeof(rp1_kernel_arg_t) == 8,
                   "rp1_kernel_arg_t must be exactly 8 bytes");
 
-/* Each payload variant must fit in the 48-byte payload union. */
-RP1_STATIC_ASSERT(sizeof(rp1_payload_kernel_dispatch_t) == 48,
-                  "kernel_dispatch payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_write_t)    == 48,
-                  "scalar_write payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_read_t)     == 48,
-                  "scalar_read payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_copy_t)     == 48,
-                  "scalar_copy payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_signal_t)          == 48,
-                  "signal payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_wait_t)            == 48,
-                  "wait payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_copy_t)        == 48,
-                  "dma_copy payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_fill_t)        == 48,
-                  "dma_fill payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_pdi_load_t)        == 48,
-                  "pdi_load payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_loop_t)            == 48,
-                  "loop payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_cond_t)            == 48,
-                  "cond payload must be 48 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_payload_rerun_t)           == 48,
-                  "rerun payload must be 48 bytes");
+/* Every payload has its exact protocol-v6 natural size. */
+RP1_STATIC_ASSERT(sizeof(rp1_payload_kernel_dispatch_t) == 20,
+                  "kernel_dispatch payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_write_t)    == 20,
+                  "scalar_write payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_read_t)     == 8,
+                  "scalar_read payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_scalar_copy_t)     == 8,
+                  "scalar_copy payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_signal_t)          == 8,
+                  "signal payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_wait_t)            == 8,
+                  "wait payload must be 8 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_copy_t)        == 20,
+                  "dma_copy payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_dma_fill_t)        == 20,
+                  "dma_fill payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_pdi_load_t)        == 20,
+                  "pdi_load payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_loop_t)            == 20,
+                  "loop payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_cond_t)            == 20,
+                  "cond payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(rp1_payload_rerun_t)           == 20,
+                  "rerun payload must be 20 bytes");
+RP1_STATIC_ASSERT(sizeof(((rp1_node_t *)0)->payload.raw) == 20,
+                  "raw payload must be 20 bytes");
+
+/* Compact payload field offsets are part of the wire ABI. */
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, arg_count) == 8,
+                  "dispatch arg_count offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, ctrl_flags) == 10,
+                  "dispatch ctrl_flags offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t, timeout_cycles) == 12,
+                  "dispatch timeout offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_kernel_dispatch_t,
+                           expected_image_id) == 16,
+                  "dispatch image offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_scalar_read_t, target_slot) == 4,
+                  "scalar_read target offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_scalar_copy_t, source_slot) == 4,
+                  "scalar_copy source offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_signal_t, target_slot) == 4,
+                  "signal target offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_signal_t, operation) == 5,
+                  "signal operation offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_wait_t, condition_signal) == 4,
+                  "wait signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_wait_t, condition_op) == 5,
+                  "wait operation offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_dma_copy_t, length_types) == 16,
+                  "dma_copy packed offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_dma_fill_t, dst_type) == 16,
+                  "dma_fill type offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_pdi_load_t, image_id) == 12,
+                  "pdi_load image offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, max_iterations) == 4,
+                  "loop maximum offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, condition_value) == 8,
+                  "loop value offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, condition_signal) == 12,
+                  "loop signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_loop_t, loop_id) == 16,
+                  "loop id offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, done_mask) == 4,
+                  "cond done mask offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, body_start) == 8,
+                  "cond body offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, condition_signal) == 12,
+                  "cond signal offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_cond_t, done_bucket) == 16,
+                  "cond done bucket offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_rerun_t, rerun_flags) == 2,
+                  "rerun flags offset");
+RP1_STATIC_ASSERT(offsetof(rp1_payload_rerun_t, loop_id) == 3,
+                  "rerun loop offset");
 
 /* Control block must be exactly 4 KB. */
 RP1_STATIC_ASSERT(sizeof(rp1_ctrl_t) == 0x1000,
@@ -613,13 +852,13 @@ RP1_STATIC_ASSERT(sizeof(rp1_ctrl_t) == 0x1000,
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, magic)              == 0x00, "ctrl.magic offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, version)            == 0x04, "ctrl.version offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, node_count)         == 0x08, "ctrl.node_count offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_size)            == 0x0C, "ctrl.cq_size offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_size)  == 0x0C, "ctrl.reserved_cq_size offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, node_base_lo)       == 0x10, "ctrl.node_base_lo offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_base_lo)         == 0x18, "ctrl.cq_base_lo offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_base_lo) == 0x18, "ctrl.reserved_cq_base offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, graph_seq)          == 0x20, "ctrl.graph_seq offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, graph_done_seq)     == 0x24, "ctrl.graph_done_seq offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_write_idx)       == 0x28, "ctrl.cq_write_idx offset");
-RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, cq_read_idx)        == 0x2C, "ctrl.cq_read_idx offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_write_idx) == 0x28, "ctrl.reserved_cq_write offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, _reserved_cq_read_idx) == 0x2C, "ctrl.reserved_cq_read offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, rp1_state)          == 0x30, "ctrl.rp1_state offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, heartbeat)          == 0x3C, "ctrl.heartbeat offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, arg_buf_base_lo)    == 0x40, "ctrl.arg_buf_base_lo offset");
@@ -634,12 +873,13 @@ RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, pdi_ipi_platform_id)== 0x68, "ctrl.pdi_ip
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_node)== 0x6C, "ctrl.terminal_error_node offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_detail) == 0x70, "ctrl.terminal_error_detail offset");
 RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, terminal_error_aux) == 0x74, "ctrl.terminal_error_aux offset");
+RP1_STATIC_ASSERT(offsetof(rp1_ctrl_t, result)             == 0x80, "ctrl.result offset");
 
-/* Signal slot, CQ entry, inflight tracker sizes. */
+/* Result, signal slot, trace entry, and inflight tracker sizes. */
+RP1_STATIC_ASSERT(sizeof(rp1_graph_result_t) == 64,
+                  "rp1_graph_result_t must be 64 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_signal_slot_t) == 16,
                   "rp1_signal_slot_t must be 16 bytes");
-RP1_STATIC_ASSERT(sizeof(rp1_cq_entry_t) == 16,
-                  "rp1_cq_entry_t must be 16 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_trace_entry_t) == 16,
                   "rp1_trace_entry_t must be 16 bytes");
 RP1_STATIC_ASSERT(sizeof(rp1_inflight_t) == 24,
@@ -648,14 +888,6 @@ RP1_STATIC_ASSERT(offsetof(rp1_inflight_t, timeout_start) == 0x0C,
                   "inflight timeout_start offset");
 RP1_STATIC_ASSERT(offsetof(rp1_inflight_t, timeout_cycles) == 0x10,
                   "inflight timeout_cycles offset");
-RP1_STATIC_ASSERT(RP1_DEFAULT_CQ_OFFSET +
-                      RP1_MAX_CQ_ENTRIES * sizeof(rp1_cq_entry_t) <=
-                  RP1_DEFAULT_ARG_BUF_OFFSET,
-                  "maximum default CQ must not overlap argument buffer");
-RP1_STATIC_ASSERT(RP1_MAX_CQ_ENTRIES != 0 &&
-                      (RP1_MAX_CQ_ENTRIES &
-                       (RP1_MAX_CQ_ENTRIES - 1)) == 0,
-                  "maximum CQ entries must be a power of two");
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/linker/slashkit/resources/aved/rp1/src/rp1_graph_test.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_graph_test.c
@@ -5,8 +5,8 @@
  * End-to-end graph tests for the RP1 flat scanner, running under Xilinx
  * QEMU with ARM semihosting.  Each test builds a tiny graph in shared
  * DDR, hands it to rp1_run() via the on_scan_pass / on_graph_done hooks
- * defined in rp1_loop.h, and asserts on the resulting node statuses,
- * barriers, signal slots, CQ entries, and dispatch order.
+ * defined in rp1_loop.h, and asserts on node state, barriers, signal slots,
+ * terminal graph results, and dispatch order.
  *
  * The hook completes fake "kernels" by OR-ing 0x2 (ap_done) into the
  * ctrl-reg word of each in-flight kernel after activate_nodes() has
@@ -33,15 +33,13 @@
  *
  * Mirrors the protocol defaults so the test environment matches what the
  * host stack will eventually program into the control block.  The
- * control block sits at RP1_CTRL_PHYS_ADDR; nodes / CQ / args / signals
- * follow at the documented offsets.
+ * control block sits at RP1_CTRL_PHYS_ADDR; nodes, args, signals, and trace
+ * storage follow at the documented offsets.
  * ---------------------------------------------------------------------- */
 
 #define G_CTRL  ((volatile rp1_ctrl_t *)(uintptr_t)(RP1_CTRL_PHYS_ADDR))
 #define G_NODES ((rp1_node_t *)(uintptr_t) \
                  (RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_NODE_ARRAY_OFFSET))
-#define G_CQ    ((volatile rp1_cq_entry_t *)(uintptr_t) \
-                 (RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_CQ_OFFSET))
 #define G_ARGS  ((uint32_t *)(uintptr_t) \
                  (RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_ARG_BUF_OFFSET))
 #define G_SIGS  ((volatile rp1_signal_slot_t *)(uintptr_t) \
@@ -49,7 +47,6 @@
 #define G_TRACE ((volatile rp1_trace_entry_t *)(uintptr_t) \
                  (RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_TRACE_OFFSET))
 
-#define TEST_CQ_SIZE  64u
 #define TEST_TRACE_SIZE 128u
 
 /* Fake AXI-Lite kernel: 256-byte page per kernel, word 0 is the
@@ -90,9 +87,7 @@ static uint32_t s_node_count;
 static int      s_graph_done_returns;
 static uint32_t s_pass_count;
 static uint32_t s_skip_completion_node;
-static uint32_t s_drain_cq;
-static rp1_cq_entry_t s_cq_capture[128];
-static uint32_t s_cq_capture_count;
+static uint32_t s_pending_graph_seq;
 
 /* WAIT-arming: after s_wait_after scan passes, write s_wait_value into signal
  * slot s_wait_slot.  s_wait_seen_slot captures the witness slot's value at the
@@ -112,38 +107,20 @@ static void hook_reset(uint32_t node_count)
     s_graph_done_returns = 1;   /* default: exit rp1_run after one graph */
     s_pass_count = 0;
     s_skip_completion_node = RP1_TERMINAL_ERROR_NODE_NONE;
-    s_drain_cq = 0;
-    s_cq_capture_count = 0;
     s_wait_armed = 0;
     s_wait_after = 0;
     s_wait_slot = 0;
     s_wait_value = 0;
     s_wait_witness_slot = 0;
     s_wait_witness_at_fire = 0xFFFFFFFFu;
+    s_pending_graph_seq = 1u;
     for (uint32_t i = 0; i < TRACE_MAX / 32u; i++) s_seen[i] = 0;
     for (uint32_t i = 0; i < TRACE_MAX; i++) s_trace[i] = 0;
-    for (uint32_t i = 0; i < 128u; i++) {
-        s_cq_capture[i].node_index = 0;
-        s_cq_capture[i].status = 0;
-        s_cq_capture[i].error_detail = 0;
-        s_cq_capture[i].timestamp = 0;
-    }
 }
 
 static void hook_on_scan_pass(void)
 {
     s_pass_count++;
-
-    if (s_drain_cq) {
-        uint32_t cursor = G_CTRL->cq_read_idx;
-        uint32_t end = G_CTRL->cq_write_idx;
-        while (cursor != end && s_cq_capture_count < 128u) {
-            s_cq_capture[s_cq_capture_count++] =
-                G_CQ[cursor & (G_CTRL->cq_size - 1u)];
-            cursor++;
-        }
-        G_CTRL->cq_read_idx = end;
-    }
 
     /* Cross-queue producer simulation: raise the awaited signal after a few
      * passes, recording the witness slot first to prove the WAIT held off its
@@ -158,7 +135,7 @@ static void hook_on_scan_pass(void)
 
     for (uint32_t i = 0; i < s_node_count && i < TRACE_MAX; i++) {
         if (s_seen[i >> 5] & (1u << (i & 31u))) continue;
-        uint8_t st = g_node_status[i];
+        uint8_t st = rp1_node_get_status(&g_nodes[i]);
         if (st == RP1_NODE_DISPATCHED || st == RP1_NODE_DONE) {
             s_seen[i >> 5] |= (1u << (i & 31u));
             s_trace[s_trace_count++] = i;
@@ -181,10 +158,45 @@ static int hook_on_graph_done(int result)
     return s_graph_done_returns;
 }
 
+/*
+ * Model a host that waits for firmware readiness before ringing the doorbell.
+ * setup_graph() records the sequence because startup deliberately clears DDR.
+ */
+static int submit_on_idle(void)
+{
+    if (s_pending_graph_seq != 0u) {
+        G_CTRL->graph_seq = s_pending_graph_seq;
+        s_pending_graph_seq = 0u;
+    }
+    return 0;
+}
+
 static const rp1_hooks_t s_hooks = {
     .on_scan_pass  = hook_on_scan_pass,
     .on_graph_done = hook_on_graph_done,
-    .on_idle       = 0,
+    .on_idle       = submit_on_idle,
+};
+
+/*
+ * Model a later submission in one still-running firmware instance. QEMU tests
+ * call rp1_run() as a bounded harness, so seed the previously installed image
+ * after startup initialization but before ringing this graph's doorbell.
+ */
+static int submit_known_image_on_idle(void)
+{
+    if (s_pending_graph_seq != 0u) {
+        g_active_image_id = 7u;
+        g_active_image_state = RP1_IMAGE_STATE_KNOWN;
+        G_CTRL->graph_seq = s_pending_graph_seq;
+        s_pending_graph_seq = 0u;
+    }
+    return 0;
+}
+
+static const rp1_hooks_t s_known_image_hooks = {
+    .on_scan_pass  = hook_on_scan_pass,
+    .on_graph_done = hook_on_graph_done,
+    .on_idle       = submit_known_image_on_idle,
 };
 
 static void make_signal(rp1_node_t *n,
@@ -203,7 +215,6 @@ static int wrap_on_graph_done(int result)
         make_signal(&G_NODES[0], 1u, 0x2222u, RP1_SIGOP_SET,
                     0, 0u, 0, 1u);
         G_CTRL->node_count = 1u;
-        G_CTRL->cq_read_idx = G_CTRL->cq_write_idx;
         G_CTRL->graph_seq = 0u;
         return 0;
     }
@@ -213,7 +224,7 @@ static int wrap_on_graph_done(int result)
 static const rp1_hooks_t s_wrap_hooks = {
     .on_scan_pass = hook_on_scan_pass,
     .on_graph_done = wrap_on_graph_done,
-    .on_idle = 0,
+    .on_idle = submit_on_idle,
 };
 
 static uint32_t s_terminal_idle_calls;
@@ -231,6 +242,8 @@ static int terminal_resubmit_on_done(int result)
 
 static int terminal_exit_on_idle(void)
 {
+    if (s_pending_graph_seq != 0u)
+        return submit_on_idle();
     s_terminal_idle_calls++;
     return s_terminal_idle_calls >= 2u;
 }
@@ -241,18 +254,39 @@ static const rp1_hooks_t s_terminal_hooks = {
     .on_idle = terminal_exit_on_idle,
 };
 
+static uint32_t s_boot_graphs;
+
+/* Record an unexpected stale graph execution and stop the firmware loop. */
+static int boot_graph_done(int result)
+{
+    (void)result;
+    s_boot_graphs++;
+    return 1;
+}
+
+/* Stop after startup reaches its first idle observation. */
+static int boot_exit_on_idle(void)
+{
+    return 1;
+}
+
+static const rp1_hooks_t s_boot_hooks = {
+    .on_scan_pass = hook_on_scan_pass,
+    .on_graph_done = boot_graph_done,
+    .on_idle = boot_exit_on_idle,
+};
+
 /* -------------------------------------------------------------------------
  * Graph setup
  * ---------------------------------------------------------------------- */
 
 static void setup_graph(uint32_t node_count, uint32_t fake_kernel_count)
 {
-    /* Wipe only the regions we touch.  rp1_run() resets the BTCM state
-     * (barriers, node_status, loop_iters, inflight) on each new graph
-     * submission via rp1_store_init(). */
+    /* Wipe only the regions we touch. rp1_run() replaces the BTCM node
+     * snapshot and resets barriers, loop counters, and inflight state through
+     * rp1_store_init() for each new graph. */
     tmemzero((volatile void *)G_CTRL,  sizeof(rp1_ctrl_t));
     tmemzero((volatile void *)G_NODES, node_count * sizeof(rp1_node_t));
-    tmemzero((volatile void *)G_CQ,    TEST_CQ_SIZE * sizeof(rp1_cq_entry_t));
     tmemzero((volatile void *)G_ARGS,  64u * sizeof(uint32_t));
     tmemzero((volatile void *)G_SIGS,  64u * sizeof(rp1_signal_slot_t));
     tmemzero((volatile void *)G_TRACE, TEST_TRACE_SIZE * sizeof(rp1_trace_entry_t));
@@ -261,10 +295,8 @@ static void setup_graph(uint32_t node_count, uint32_t fake_kernel_count)
                  fake_kernel_count * FAKE_KERNEL_STRIDE);
     }
 
-    G_CTRL->cq_size           = TEST_CQ_SIZE;
     G_CTRL->node_count        = node_count;
     G_CTRL->node_base_lo      = (uint32_t)(uintptr_t)G_NODES;
-    G_CTRL->cq_base_lo        = (uint32_t)(uintptr_t)G_CQ;
     G_CTRL->arg_buf_base_lo   = (uint32_t)(uintptr_t)G_ARGS;
     G_CTRL->sig_array_base_lo = (uint32_t)(uintptr_t)G_SIGS;
     G_CTRL->trace_base_lo     = (uint32_t)(uintptr_t)G_TRACE;
@@ -283,18 +315,26 @@ static void setup_graph(uint32_t node_count, uint32_t fake_kernel_count)
  * which can lower to a memset call under -ffreestanding -nostdlib.
  * ---------------------------------------------------------------------- */
 
+/* Initialize one compact header with firmware-owned status set to PENDING. */
+static void make_header(rp1_node_t *n, uint8_t opcode, uint8_t flags,
+                        uint8_t aw_b, uint32_t aw_m,
+                        uint8_t st_b, uint32_t st_m)
+{
+    rp1_node_set_control(
+        n, rp1_node_make_control(opcode, flags, RP1_NODE_PENDING));
+    n->barrier_await_mask = aw_m;
+    n->barrier_set_mask = st_m;
+    n->barrier_await_bucket = aw_b;
+    n->barrier_set_bucket = st_b;
+}
+
 static void make_kernel(rp1_node_t *n, uint32_t kernel_idx,
                         uint8_t aw_b, uint32_t aw_m,
                         uint8_t st_b, uint32_t st_m,
                         uint32_t arg_buf_offset, uint16_t arg_count)
 {
-    n->opcode               = RP1_OP_KERNEL_DISPATCH;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_KERNEL_DISPATCH, 0u,
+                aw_b, aw_m, st_b, st_m);
 
     n->payload.kernel_dispatch.kernel_base_addr  = (uint32_t)FAKE_KERNEL(kernel_idx);
     n->payload.kernel_dispatch.arg_buffer_offset = arg_buf_offset;
@@ -308,30 +348,19 @@ static void make_signal(rp1_node_t *n,
                         uint8_t aw_b, uint32_t aw_m,
                         uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_SIGNAL;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_SIGNAL, 0u, aw_b, aw_m, st_b, st_m);
 
-    n->payload.signal.target_slot = slot;
     n->payload.signal.value       = value;
-    n->payload.signal.operation   = op;
+    n->payload.signal.target_slot = (uint8_t)slot;
+    n->payload.signal.operation   = (uint8_t)op;
 }
 
 static void make_scalar_write(rp1_node_t *n, uint32_t addr, uint32_t value,
                               uint8_t aw_b, uint32_t aw_m,
                               uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_SCALAR_WRITE;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_SCALAR_WRITE, 0u,
+                aw_b, aw_m, st_b, st_m);
 
     n->payload.scalar_write.writes[0].addr  = addr;
     n->payload.scalar_write.writes[0].value = value;
@@ -341,16 +370,11 @@ static void make_scalar_read(rp1_node_t *n, uint32_t source_addr, uint32_t targe
                              uint8_t aw_b, uint32_t aw_m,
                              uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_SCALAR_READ;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_SCALAR_READ, 0u,
+                aw_b, aw_m, st_b, st_m);
 
     n->payload.scalar_read.source_addr = source_addr;
-    n->payload.scalar_read.target_slot = target_slot;
+    n->payload.scalar_read.target_slot = (uint8_t)target_slot;
 }
 
 static void make_wait(rp1_node_t *n,
@@ -358,17 +382,11 @@ static void make_wait(rp1_node_t *n,
                       uint8_t aw_b, uint32_t aw_m,
                       uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_WAIT;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_WAIT, 0u, aw_b, aw_m, st_b, st_m);
 
-    n->payload.wait.condition_signal = cond_signal;
     n->payload.wait.condition_value  = cond_val;
-    n->payload.wait.condition_op     = cond_op;
+    n->payload.wait.condition_signal = (uint8_t)cond_signal;
+    n->payload.wait.condition_op     = (uint8_t)cond_op;
 }
 
 static void make_loop(rp1_node_t *n,
@@ -379,20 +397,14 @@ static void make_loop(rp1_node_t *n,
                       uint8_t aw_b, uint32_t aw_m,
                       uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_LOOP;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_LOOP, 0u, aw_b, aw_m, st_b, st_m);
 
-    n->payload.loop.body_start         = body_start;
-    n->payload.loop.body_end           = body_end;
+    n->payload.loop.body_start         = (uint16_t)body_start;
+    n->payload.loop.body_end           = (uint16_t)body_end;
     n->payload.loop.max_iterations     = max_iter;
-    n->payload.loop.condition_signal   = cond_signal;
     n->payload.loop.condition_value    = cond_val;
-    n->payload.loop.condition_op       = cond_op;
+    n->payload.loop.condition_signal   = (uint8_t)cond_signal;
+    n->payload.loop.condition_op       = (uint8_t)cond_op;
     n->payload.loop.bucket_clear_start = bucket_clear_start;
     n->payload.loop.bucket_clear_end   = bucket_clear_end;
     n->payload.loop.loop_id            = loop_id;
@@ -402,15 +414,9 @@ static void make_rerun(rp1_node_t *n, uint32_t target_node,
                        uint8_t aw_b, uint32_t aw_m,
                        uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_RERUN;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_RERUN, 0u, aw_b, aw_m, st_b, st_m);
 
-    n->payload.rerun.target_node = target_node;
+    n->payload.rerun.target_node = (uint16_t)target_node;
     n->payload.rerun.rerun_flags = 0;
     n->payload.rerun.loop_id     = 0;
 }
@@ -423,38 +429,26 @@ static void make_cond(rp1_node_t *n,
                       uint8_t aw_b, uint32_t aw_m,
                       uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_COND;
-    n->flags                = 0;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_COND, 0u, aw_b, aw_m, st_b, st_m);
 
-    n->payload.cond.condition_signal   = cond_signal;
     n->payload.cond.condition_value    = cond_val;
-    n->payload.cond.condition_op       = cond_op;
+    n->payload.cond.condition_signal   = (uint8_t)cond_signal;
+    n->payload.cond.condition_op       = (uint8_t)cond_op;
     n->payload.cond.bucket_clear_start = bucket_clear_start;
     n->payload.cond.bucket_clear_end   = bucket_clear_end;
-    n->payload.cond.body_start         = body_start;
-    n->payload.cond.body_end           = body_end;
+    n->payload.cond.body_start         = (uint16_t)body_start;
+    n->payload.cond.body_end           = (uint16_t)body_end;
     n->payload.cond.done_bucket        = done_bucket;
     n->payload.cond.done_mask          = done_mask;
 }
 
 static void make_pdi_load(rp1_node_t *n,
                           uint32_t addr_lo, uint32_t addr_hi,
-                          uint32_t timeout_cycles, uint16_t flags,
+                          uint32_t timeout_cycles, uint8_t flags,
                           uint8_t aw_b, uint32_t aw_m,
                           uint8_t st_b, uint32_t st_m)
 {
-    n->opcode               = RP1_OP_PDI_LOAD;
-    n->flags                = flags;
-    n->barrier_await_mask   = aw_m;
-    n->barrier_set_mask     = st_m;
-    n->barrier_await_bucket = aw_b;
-    n->barrier_set_bucket   = st_b;
-    n->status               = RP1_NODE_PENDING;
+    make_header(n, RP1_OP_PDI_LOAD, flags, aw_b, aw_m, st_b, st_m);
 
     n->payload.pdi_load.pdi_addr_lo    = addr_lo;
     n->payload.pdi_load.pdi_addr_hi    = addr_hi;
@@ -487,6 +481,14 @@ static uint32_t s_fake_cycles;
 static uint32_t s_cycle_step;
 static pdi_access_t s_pdi_access[PDI_ACCESS_MAX];
 static uint32_t s_pdi_access_count;
+static uint32_t s_publication_watch;
+static uint32_t s_publication_started;
+static uint32_t s_publication_phase;
+static uint32_t s_publication_violation;
+/* Optional fake control port whose reads emulate HLS ap_done clear-on-read. */
+static uintptr_t s_watched_kernel_ctrl;
+/* Number of MMIO reads observed at s_watched_kernel_ctrl. */
+static uint32_t s_watched_kernel_ctrl_reads;
 
 static void record_pdi_access(uint32_t kind, uintptr_t address, uint32_t value)
 {
@@ -515,6 +517,14 @@ static uint32_t test_mmio_read32(uintptr_t address, void *context)
         record_pdi_access(PDI_ACCESS_READ, address, s_pdi_detail);
         return s_pdi_detail;
     }
+    if (address == s_watched_kernel_ctrl) {
+        volatile uint32_t *control = (volatile uint32_t *)address;
+        uint32_t value = *control;
+
+        s_watched_kernel_ctrl_reads++;
+        *control = value & ~0x2u;
+        return value;
+    }
     return *(volatile uint32_t *)address;
 }
 
@@ -538,10 +548,32 @@ static void test_mmio_write32(uintptr_t address, uint32_t value, void *context)
     *(volatile uint32_t *)address = value;
 }
 
-static void test_barrier(void *context)
+static void test_barrier(rp1_barrier_kind_t barrier, void *context)
 {
     (void)context;
-    record_pdi_access(PDI_ACCESS_BARRIER, 0u, 0u);
+    record_pdi_access(PDI_ACCESS_BARRIER, 0u, (uint32_t)barrier);
+
+    if (!s_publication_watch)
+        return;
+    if (G_CTRL->rp1_state == RP1_STATE_RUNNING)
+        s_publication_started = 1u;
+    if (!s_publication_started)
+        return;
+
+    if (G_CTRL->graph_done_seq == G_CTRL->graph_seq) {
+        if (G_CTRL->result.magic != RP1_GRAPH_RESULT_MAGIC ||
+            G_CTRL->rp1_state == RP1_STATE_RUNNING ||
+            s_publication_phase < 2u)
+            s_publication_violation = 1u;
+        s_publication_phase = 3u;
+    } else if (G_CTRL->rp1_state != RP1_STATE_RUNNING) {
+        if (G_CTRL->result.magic != RP1_GRAPH_RESULT_MAGIC ||
+            s_publication_phase < 1u)
+            s_publication_violation = 1u;
+        s_publication_phase = 2u;
+    } else if (G_CTRL->result.magic == RP1_GRAPH_RESULT_MAGIC) {
+        s_publication_phase = 1u;
+    }
 }
 
 static uint32_t test_cycles(void *context)
@@ -572,7 +604,216 @@ static void pdi_override_reset(void)
     s_fake_cycles = 0;
     s_cycle_step = 1u;
     s_pdi_access_count = 0;
+    s_publication_watch = 0u;
+    s_publication_started = 0u;
+    s_publication_phase = 0u;
+    s_publication_violation = 0u;
+    s_watched_kernel_ctrl = 0u;
+    s_watched_kernel_ctrl_reads = 0u;
     rp1_hal_set_hooks(&s_hal_hooks);
+}
+
+/*
+ * Count control reads for one fake CU and model the clear-on-read ap_done bit.
+ * The normal scan hook still decides when the fake invocation completes.
+ */
+static void watch_kernel_ctrl(uintptr_t address)
+{
+    s_watched_kernel_ctrl = address;
+    s_watched_kernel_ctrl_reads = 0u;
+}
+
+/* Verify each public barrier primitive preserves its distinct HAL identity. */
+static int test_barrier_variants(void)
+{
+    pdi_override_reset();
+
+    rp1_dsb_st();
+    rp1_dsb_sy();
+    rp1_dmb_st();
+    rp1_dmb_sy();
+    rp1_hal_reset_hooks();
+
+    CHECK_EQ32(s_pdi_access_count, 4u, "barriers: all variants observed");
+    CHECK_EQ32(s_pdi_access[0].value, RP1_BARRIER_DSB_ST,
+               "barriers: dsb st");
+    CHECK_EQ32(s_pdi_access[1].value, RP1_BARRIER_DSB_SY,
+               "barriers: dsb sy");
+    CHECK_EQ32(s_pdi_access[2].value, RP1_BARRIER_DMB_ST,
+               "barriers: dmb st");
+    CHECK_EQ32(s_pdi_access[3].value, RP1_BARRIER_DMB_SY,
+               "barriers: dmb sy");
+    return 0;
+}
+
+/*
+ * Observe each firmware barrier and require the release sequence to progress
+ * from committed result, to terminal state, to graph_done_seq.
+ */
+static int test_result_publication_order(void)
+{
+    setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
+    pdi_override_reset();
+    make_signal(&G_NODES[0], 0u, 0xABCDu, RP1_SIGOP_SET,
+                0, 0u, 0, 1u);
+    s_publication_watch = 1u;
+
+    int rc = rp1_run(&s_hooks);
+    s_publication_watch = 0u;
+    rp1_hal_reset_hooks();
+
+    CHECK_EQ32(rc, 0u, "publish_order: rp1_run rc");
+    CHECK_EQ32(s_publication_violation, 0u,
+               "publish_order: no release-order violation");
+    CHECK_EQ32(s_publication_phase, 3u,
+               "publish_order: completion sequence observed");
+    return 0;
+}
+
+/*
+ * A firmware reload must discard both sequence words before publishing magic.
+ * Otherwise the stale host doorbell can execute the previous graph immediately.
+ */
+static int test_boot_sequence_baseline(void)
+{
+    setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
+    make_signal(&G_NODES[0], 0u, 0xABCDu, RP1_SIGOP_SET,
+                0, 0u, 0, 1u);
+    G_CTRL->graph_seq = 41u;
+    G_CTRL->graph_done_seq = 40u;
+    s_boot_graphs = 0u;
+
+    int rc = rp1_run(&s_boot_hooks);
+
+    CHECK_EQ32(rc, 0u, "boot_baseline: idle return");
+    CHECK_EQ32(G_CTRL->graph_seq, 0u, "boot_baseline: graph_seq reset");
+    CHECK_EQ32(G_CTRL->graph_done_seq, 0u,
+               "boot_baseline: graph_done_seq reset");
+    CHECK_EQ32(s_boot_graphs, 0u, "boot_baseline: stale graph not executed");
+    CHECK_EQ32(G_SIGS[0].value, 0u, "boot_baseline: stale graph had no effect");
+    CHECK_EQ32(G_CTRL->rp1_state, RP1_STATE_READY,
+               "boot_baseline: firmware ready");
+    return 0;
+}
+
+/*
+ * Protocol-v6 hosts must zero every former CQ control word. Rejecting stale
+ * v4 configuration prevents an old host from submitting under the new ABI.
+ */
+static int test_reserved_cq_config_rejected(void)
+{
+    setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
+    make_signal(&G_NODES[0], 0u, 0xABCDu, RP1_SIGOP_SET,
+                0, 0u, 0, 1u);
+    G_CTRL->_reserved_cq_size = 64u;
+
+    int rc = rp1_run(&s_hooks);
+
+    CHECK(rc == -1, "reserved_cq: graph failed");
+    CHECK_EQ32(G_CTRL->result.magic, RP1_GRAPH_RESULT_MAGIC,
+               "reserved_cq: result committed");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_FAILED,
+               "reserved_cq: failed outcome");
+    CHECK_EQ32(G_CTRL->result.error_code, RP1_ERR_INVALID_CONFIG,
+               "reserved_cq: invalid config");
+    CHECK_EQ32(G_CTRL->result.error_detail, RP1_CONFIG_RESERVED_CQ,
+               "reserved_cq: detail");
+    CHECK_EQ32(G_CTRL->result.error_aux, 1u,
+               "reserved_cq: size bit reported");
+    CHECK_EQ32(G_SIGS[0].value, 0u,
+               "reserved_cq: graph had no side effect");
+    return 0;
+}
+
+/*
+ * Firmware must execute only the BTCM snapshot. Mutating every meaningful DDR
+ * field after rp1_store_init() must not redirect execution or receive status
+ * writeback from the scanner.
+ */
+static int test_btcm_node_snapshot(void)
+{
+    setup_graph(/* node_count */ 1u, /* fake_kernels */ 0u);
+    make_signal(&G_NODES[0], 4u, 0x11112222u, RP1_SIGOP_SET,
+                0u, 0u, 0u, 1u);
+    for (uint32_t i = 8u; i < sizeof(G_NODES[0].payload.raw); i++)
+        G_NODES[0].payload.raw[i] = (uint8_t)(0x80u + i);
+    rp1_node_set_status(&G_NODES[0], RP1_NODE_ERROR);
+    uint8_t expected_payload[sizeof(G_NODES[0].payload.raw)];
+    for (uint32_t i = 0u; i < sizeof(expected_payload); i++)
+        expected_payload[i] = G_NODES[0].payload.raw[i];
+
+    uint32_t detail = 0u;
+    uint32_t aux = 0u;
+    CHECK_EQ32(rp1_store_init(&detail, &aux), 0u,
+               "snapshot: store accepted");
+    CHECK_EQ32(g_node_count, 1u, "snapshot: local count cached");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_PENDING,
+               "snapshot: stale DDR status discarded");
+    CHECK_EQ32(rp1_node_get_status(&G_NODES[0]), RP1_NODE_ERROR,
+               "snapshot: DDR status not initialized");
+    for (uint32_t i = 0u; i < sizeof(expected_payload); i++)
+        CHECK_EQ32(g_nodes[0].payload.raw[i], expected_payload[i],
+                   "snapshot: every payload byte copied");
+
+    /* Replace the source packet after the snapshot and execute directly. */
+    make_signal(&G_NODES[0], 5u, 0x33334444u, RP1_SIGOP_SET,
+                0u, 0u, 0u, 2u);
+    rp1_node_set_status(&G_NODES[0], RP1_NODE_ERROR);
+    uint16_t ddr_control = G_NODES[0].control;
+    int rc = rp1_loop(&s_hooks);
+
+    CHECK_EQ32(rc, 0u, "snapshot: scanner result");
+    CHECK_EQ32(G_SIGS[4].value, 0x11112222u,
+               "snapshot: BTCM payload executed");
+    CHECK_EQ32(G_SIGS[5].value, 0u,
+               "snapshot: changed DDR payload ignored");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "snapshot: BTCM status mutated");
+    CHECK_EQ32(G_NODES[0].control, ddr_control,
+               "snapshot: DDR control never written");
+    CHECK_EQ32(G_NODES[0].payload.signal.value, 0x33334444u,
+               "snapshot: DDR payload never written");
+    return 0;
+}
+
+/* Accept exactly 1024 packets, execute their BTCM copies, and reject 1025. */
+static int test_exact_node_limit(void)
+{
+    setup_graph(RP1_MAX_NODES, 0u);
+    for (uint32_t i = 0u; i < RP1_MAX_NODES; i++)
+        make_header(&G_NODES[i], RP1_OP_NOP, 0u, 0u, 0u, 0u, 0u);
+    G_NODES[0].payload.raw[0] = 0x11u;
+    G_NODES[RP1_MAX_NODES - 1u].payload.raw[19] = 0xEEu;
+
+    uint32_t detail = 0u;
+    uint32_t aux = 0u;
+    CHECK_EQ32(rp1_store_init(&detail, &aux), 0u,
+               "node_limit: exact maximum accepted");
+    CHECK_EQ32(g_node_count, RP1_MAX_NODES,
+               "node_limit: exact maximum cached");
+    CHECK_EQ32(g_nodes[0].payload.raw[0], 0x11u,
+               "node_limit: first packet copied");
+    CHECK_EQ32(g_nodes[RP1_MAX_NODES - 1u].payload.raw[19], 0xEEu,
+               "node_limit: last packet copied");
+    CHECK_EQ32(rp1_loop(&s_hooks), 0u,
+               "node_limit: exact maximum executed");
+    CHECK_EQ32(g_completed_operations, RP1_MAX_NODES,
+               "node_limit: every packet completed");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[RP1_MAX_NODES - 1u]),
+               RP1_NODE_DONE, "node_limit: last packet done");
+
+    setup_graph(RP1_MAX_NODES + 1u, 0u);
+    detail = 0u;
+    aux = 0u;
+    CHECK(rp1_store_init(&detail, &aux) != 0,
+          "node_limit: maximum plus one rejected");
+    CHECK_EQ32(detail, RP1_CONFIG_NODE_COUNT,
+               "node_limit: count rejection detail");
+    CHECK_EQ32(aux, RP1_MAX_NODES + 1u,
+               "node_limit: rejected count preserved");
+    CHECK_EQ32(g_node_count, 0u,
+               "node_limit: rejected graph has no active snapshot");
+    return 0;
 }
 
 static void prepare_diamond_graph(void)
@@ -606,7 +847,7 @@ static void prepare_diamond_graph(void)
  *   - KERNEL_DISPATCH writes args to FAKE_K + 0x10 and ap_start to + 0x00.
  *   - barrier AND ({B,C} done) gates D.
  *   - parallel dispatch: B and C are both in flight at some point.
- *   - the CQ is populated in the natural dispatch order.
+ *   - one sequence-tagged successful graph result is committed.
  * ---------------------------------------------------------------------- */
 
 static int test_diamond_dag(void)
@@ -623,39 +864,76 @@ static int test_diamond_dag(void)
     CHECK_EQ32(s_trace[3],    3u, "diamond: D last");
     CHECK(s_max_inflight >= 2u, "diamond: B and C in flight together");
 
-    CHECK_EQ32(G_CTRL->cq_write_idx,   4u,                 "diamond: cq entries");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,                 "diamond: graph_done_seq");
     CHECK_EQ32(G_CTRL->rp1_state,      RP1_STATE_READY,    "diamond: rp1_state");
+    CHECK_EQ32(G_CTRL->result.magic, RP1_GRAPH_RESULT_MAGIC,
+               "diamond: result committed");
+    CHECK_EQ32(G_CTRL->result.graph_seq, 1u,
+               "diamond: result sequence");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_SUCCESS,
+               "diamond: successful outcome");
+    CHECK_EQ32(G_CTRL->result.flags, 0u,
+               "diamond: no exceptional flags");
+    CHECK_EQ32(G_CTRL->result.error_code, 0u,
+               "diamond: no terminal error");
+    CHECK_EQ32(G_CTRL->result.terminal_node,
+               RP1_TERMINAL_ERROR_NODE_NONE,
+               "diamond: no terminal node");
+    CHECK_EQ32(G_CTRL->result.terminal_opcode,
+               RP1_TERMINAL_OPCODE_NONE,
+               "diamond: no terminal opcode");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_NONE,
+               "diamond: no active image");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 4u,
+               "diamond: four successful operations");
+    CHECK_EQ32(G_CTRL->result.quiescence, 0u,
+               "diamond: no quiescence work");
+    CHECK(G_CTRL->result.publish_elapsed_ticks >=
+          G_CTRL->result.graph_elapsed_ticks,
+          "diamond: publication follows graph completion");
 
     for (uint32_t i = 0; i < 4; i++) {
         volatile uint32_t *ctrl = (volatile uint32_t *)(uintptr_t)FAKE_KERNEL(i);
         CHECK_EQ32(ctrl[0],        0x3u, "diamond: ctrl reg ap_start|ap_done");
         CHECK_EQ32(ctrl[0x10 / 4], i,    "diamond: kernel arg[0]");
+        CHECK_EQ32(rp1_node_get_status(&g_nodes[i]), RP1_NODE_DONE,
+                   "diamond: BTCM status is authoritative");
+        CHECK_EQ32(rp1_node_get_status(&G_NODES[i]), RP1_NODE_PENDING,
+                   "diamond: DDR packet remains unchanged");
     }
     return 0;
 }
 
-static int test_cq_timestamps(void)
+/*
+ * Independent dispatches to one CU must serialize. The second invocation
+ * reuses the completion read as its ap_done clear, while a subsequent PDI
+ * transition invalidates that knowledge and restores the first-use clear.
+ */
+static int test_cu_clean_tracking(void)
 {
-    prepare_diamond_graph();
+    setup_graph(/* node_count */ 4u, /* fake_kernels */ 1u);
+    pdi_override_reset();
+    watch_kernel_ctrl(FAKE_KERNEL(0));
+
+    make_kernel(&G_NODES[0], 0u, 0u, 0u, 0u, 1u, 0u, 0u);
+    make_kernel(&G_NODES[1], 0u, 0u, 0u, 0u, 2u, 0u, 0u);
+    make_pdi_load(&G_NODES[2], 0x10000000u, 0u, 20u,
+                  0u, 0u, 3u, 0u, 4u);
+    make_kernel(&G_NODES[3], 0u, 0u, 4u, 0u, 8u, 0u, 0u);
 
     int rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "cq_ts: first rp1_run rc");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 4u, "cq_ts: first cq entries");
+    uint32_t control_reads = s_watched_kernel_ctrl_reads;
+    rp1_hal_reset_hooks();
 
-    for (uint32_t i = 1; i < G_CTRL->cq_write_idx; i++)
-        CHECK(G_CQ[i].timestamp >= G_CQ[i - 1u].timestamp,
-              "cq_ts: timestamps non-decreasing");
-    CHECK(G_CQ[3].timestamp > G_CQ[0].timestamp,
-          "cq_ts: timestamps advanced");
-
-    uint32_t first_last = G_CQ[3].timestamp;
-
-    prepare_diamond_graph();
-    rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "cq_ts: second rp1_run rc");
-    CHECK(G_CQ[0].timestamp < first_last,
-          "cq_ts: second graph timestamp baseline reset");
+    CHECK_EQ32(rc, 0u, "cu_clean: rp1_run rc");
+    CHECK_EQ32(s_max_inflight, 1u,
+               "cu_clean: same-CU dispatches serialized");
+    CHECK_EQ32(s_pdi_call_count, 1u, "cu_clean: PDI issued once");
+    CHECK_EQ32(control_reads, 8u,
+               "cu_clean: reused clear skipped and PDI invalidated cache");
+    for (uint32_t i = 0u; i < 4u; i++)
+        CHECK_EQ32(rp1_node_get_status(&g_nodes[i]), RP1_NODE_DONE,
+                   "cu_clean: every node completed");
     return 0;
 }
 
@@ -666,6 +944,10 @@ static int test_trace_disabled_by_default(void)
     int rc = rp1_run(&s_hooks);
     CHECK_EQ32(rc, 0u, "trace_default: rp1_run rc");
     CHECK_EQ32(G_CTRL->trace_write_idx, 0u, "trace_default: trace disabled");
+    CHECK_EQ32(G_CTRL->result.trace_write_idx, 0u,
+               "trace_default: result cursor zero");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_TRACE_ENABLED) == 0u,
+          "trace_default: result trace flag clear");
     return 0;
 }
 
@@ -685,6 +967,10 @@ static int test_trace_queue(void)
                "trace_queue: graph start node");
     CHECK_EQ32(G_TRACE[writes - 1u].event, RP1_TRACE_GRAPH_DONE,
                "trace_queue: last event graph done");
+    CHECK_EQ32(G_CTRL->result.trace_write_idx, writes,
+               "trace_queue: result cursor is final");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_TRACE_ENABLED) != 0u,
+          "trace_queue: result reports tracing");
 
     uint32_t launch_count = 0;
     uint32_t done_count = 0;
@@ -702,6 +988,53 @@ static int test_trace_queue(void)
 
     CHECK_EQ32(launch_count, 4u, "trace_queue: launch entries");
     CHECK_EQ32(done_count, 4u, "trace_queue: done entries");
+    return 0;
+}
+
+/*
+ * Fill one BTCM trace page and prove the synchronous DDR copy is bracketed by
+ * adjacent FLUSH_START/END events.
+ */
+static int test_trace_btcm_flush(void)
+{
+    const uint32_t node_count = 260u;
+    const uint32_t trace_size = 512u;
+    setup_graph(node_count, 0);
+    tmemzero((volatile void *)G_TRACE,
+             trace_size * sizeof(rp1_trace_entry_t));
+    G_CTRL->trace_enable = 1u;
+    G_CTRL->trace_size = trace_size;
+
+    for (uint32_t i = 0; i < node_count; i++) {
+        make_header(&G_NODES[i], RP1_OP_NOP, 0u, 0, 0u, 0, 0u);
+    }
+
+    int rc = rp1_run(&s_hooks);
+    CHECK_EQ32(rc, 0u, "trace_flush: rp1_run rc");
+    CHECK_EQ32(G_CTRL->trace_write_idx, 264u,
+               "trace_flush: events plus flush markers");
+    CHECK_EQ32(G_TRACE[0].event, RP1_TRACE_GRAPH_START,
+               "trace_flush: graph start first");
+    CHECK_EQ32(G_TRACE[255].event, RP1_TRACE_FLUSH_START,
+               "trace_flush: full page ends with flush start");
+    CHECK_EQ32(G_TRACE[256].event, RP1_TRACE_FLUSH_END,
+               "trace_flush: fresh page begins with flush end");
+    CHECK_EQ32(G_TRACE[263].event, RP1_TRACE_GRAPH_DONE,
+               "trace_flush: final partial page ends with graph done");
+    CHECK_EQ32(G_CTRL->result.trace_write_idx, 264u,
+               "trace_flush: result captures final cursor");
+    CHECK_EQ32(G_CTRL->result.completed_operations, node_count,
+               "trace_flush: all NOP operations counted");
+    CHECK_EQ32(G_TRACE[255].aux0, RP1_TRACE_STAGING_ENTRIES,
+               "trace_flush: start reports page entries");
+    CHECK_EQ32(G_TRACE[255].aux1, 0u,
+               "trace_flush: start reports old DDR cursor");
+    CHECK_EQ32(G_TRACE[256].aux0, RP1_TRACE_STAGING_ENTRIES,
+               "trace_flush: end reports page entries");
+    CHECK_EQ32(G_TRACE[256].aux1, RP1_TRACE_STAGING_ENTRIES,
+               "trace_flush: end reports new DDR cursor");
+    CHECK(G_TRACE[256].timestamp >= G_TRACE[255].timestamp,
+          "trace_flush: end follows start");
     return 0;
 }
 
@@ -735,9 +1068,12 @@ static int test_kernel_unblocks_signal(void)
 
     CHECK_EQ32(G_SIGS[0].value, 0xBEEFBEEFu, "kernel_chain: pre signal");
     CHECK_EQ32(G_SIGS[1].value, 0xCAFEBABEu, "kernel_chain: post signal");
-    CHECK_EQ32(g_node_status[0], RP1_NODE_DONE, "kernel_chain: node 0 DONE");
-    CHECK_EQ32(g_node_status[1], RP1_NODE_DONE, "kernel_chain: node 1 DONE");
-    CHECK_EQ32(g_node_status[2], RP1_NODE_DONE, "kernel_chain: node 2 DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "kernel_chain: node 0 DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_DONE,
+               "kernel_chain: node 1 DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[2]), RP1_NODE_DONE,
+               "kernel_chain: node 2 DONE");
     CHECK_EQ32(g_barriers[0] & 0x7u, 0x7u, "kernel_chain: barriers raised");
 
     CHECK_EQ32(s_trace_count, 3u, "kernel_chain: nodes traced");
@@ -745,10 +1081,8 @@ static int test_kernel_unblocks_signal(void)
     CHECK_EQ32(s_trace[1],    1u, "kernel_chain: kernel second");
     CHECK_EQ32(s_trace[2],    2u, "kernel_chain: post third");
 
-    CHECK_EQ32(G_CTRL->cq_write_idx, 3u, "kernel_chain: cq entries");
-    CHECK_EQ32(G_CQ[0].node_index,   0u, "kernel_chain: CQ[0] pre");
-    CHECK_EQ32(G_CQ[1].node_index,   1u, "kernel_chain: CQ[1] kernel");
-    CHECK_EQ32(G_CQ[2].node_index,   2u, "kernel_chain: CQ[2] post");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 3u,
+               "kernel_chain: operations counted");
 
     volatile uint32_t *ctrl = (volatile uint32_t *)(uintptr_t)FAKE_KERNEL(0);
     CHECK_EQ32(ctrl[0],        0x3u,        "kernel_chain: ctrl ap_start|ap_done");
@@ -763,7 +1097,7 @@ static int test_kernel_unblocks_signal(void)
  *
  * Pure-scanner sanity check: no kernels, only immediate-completion
  * SIGNAL ops chained via single-bit barrier dependencies in bucket 0.
- * Exercises the DDR-resolved pointers (g_nodes, g_signals, g_cq).
+ * Exercises the DDR-resolved node and signal pointers.
  * ---------------------------------------------------------------------- */
 
 static int test_signal_chain(void)
@@ -784,103 +1118,9 @@ static int test_signal_chain(void)
     CHECK_EQ32(G_SIGS[3].value, 0xD003u, "chain: slot 3");
 
     CHECK_EQ32(s_trace_count,        4u, "chain: nodes traced");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 4u, "chain: cq entries");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 4u,
+               "chain: operations counted");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u, "chain: graph_done_seq");
-    return 0;
-}
-
-static int test_cq_flow_control(void)
-{
-    setup_graph(/* node_count */ 12, /* fake_kernels */ 0);
-    G_CTRL->cq_size = 4u;
-    G_CQ[4].node_index = 0xA1A2A3A4u;
-    G_CQ[4].status = 0xB1B2B3B4u;
-    G_CQ[4].error_detail = 0xC1C2C3C4u;
-    G_CQ[4].timestamp = 0xD1D2D3D4u;
-    for (uint32_t i = 0; i < 12u; i++) {
-        make_signal(&G_NODES[i], i, 0x100u + i, RP1_SIGOP_SET,
-                    0, 0u, 0, 1u << (i & 31u));
-    }
-    s_drain_cq = 1u;
-
-    int rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "cq_flow: rp1_run rc");
-    CHECK_EQ32(s_cq_capture_count, 12u,
-               "cq_flow: all entries incrementally drained");
-    for (uint32_t i = 0; i < 12u; i++)
-        CHECK_EQ32(s_cq_capture[i].node_index, i,
-                   "cq_flow: lossless node order");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 12u, "cq_flow: producer cursor");
-    CHECK_EQ32(G_CTRL->cq_read_idx, 12u, "cq_flow: consumer cursor");
-    CHECK_EQ32(G_CQ[4].node_index, 0xA1A2A3A4u,
-               "cq_flow: canary node");
-    CHECK_EQ32(G_CQ[4].status, 0xB1B2B3B4u,
-               "cq_flow: canary status");
-    CHECK_EQ32(G_CQ[4].error_detail, 0xC1C2C3C4u,
-               "cq_flow: canary detail");
-    CHECK_EQ32(G_CQ[4].timestamp, 0xD1D2D3D4u,
-               "cq_flow: canary timestamp");
-    return 0;
-}
-
-static int test_cq_config_validation(void)
-{
-    setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
-    make_signal(&G_NODES[0], 0, 1u, RP1_SIGOP_SET,
-                0, 0u, 0, 1u);
-    G_CTRL->cq_size = 3u;
-    int rc = rp1_run(&s_hooks);
-    CHECK_EQ32((uint32_t)(rc + 1), 0u,
-               "cq_config: non-power-of-two rejected");
-    CHECK_EQ32(G_CTRL->terminal_error_detail, RP1_CONFIG_CQ_SIZE,
-               "cq_config: size detail");
-    CHECK_EQ32(G_CTRL->terminal_error_aux, 3u,
-               "cq_config: invalid size value");
-
-    setup_graph(1, 0);
-    make_signal(&G_NODES[0], 0, 1u, RP1_SIGOP_SET,
-                0, 0u, 0, 1u);
-    G_CTRL->cq_size = RP1_MAX_CQ_ENTRIES * 2u;
-    rc = rp1_run(&s_hooks);
-    CHECK_EQ32((uint32_t)(rc + 1), 0u,
-               "cq_config: oversize rejected");
-    CHECK_EQ32(G_CTRL->terminal_error_detail, RP1_CONFIG_CQ_SIZE,
-               "cq_config: oversize detail");
-
-    setup_graph(1, 0);
-    make_signal(&G_NODES[0], 0, 1u, RP1_SIGOP_SET,
-                0, 0u, 0, 1u);
-    G_CTRL->cq_size = RP1_MAX_CQ_ENTRIES;
-    rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "cq_config: maximum accepted");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 1u,
-               "cq_config: maximum ring wrote entry");
-    return 0;
-}
-
-static int test_cq_cursor_wrap(void)
-{
-    setup_graph(/* node_count */ 3, /* fake_kernels */ 0);
-    G_CTRL->cq_size = 4u;
-    G_CTRL->cq_write_idx = 0xFFFFFFFEu;
-    G_CTRL->cq_read_idx = 0xFFFFFFFEu;
-    for (uint32_t i = 0; i < 3u; i++) {
-        make_signal(&G_NODES[i], i, i + 1u, RP1_SIGOP_SET,
-                    0, 0u, 0, 1u << i);
-    }
-
-    uint32_t detail = 0u;
-    uint32_t aux = 0u;
-    CHECK_EQ32(rp1_store_init(&detail, &aux), 0u,
-               "cq_wrap: store init");
-    g_graph_start_cycles = rp1_cycles();
-    int rc = rp1_loop(&s_hooks);
-    CHECK_EQ32(rc, 0u, "cq_wrap: scanner result");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 1u,
-               "cq_wrap: producer wrapped");
-    CHECK_EQ32(G_CQ[2].node_index, 0u, "cq_wrap: slot 2");
-    CHECK_EQ32(G_CQ[3].node_index, 1u, "cq_wrap: slot 3");
-    CHECK_EQ32(G_CQ[0].node_index, 2u, "cq_wrap: slot 0");
     return 0;
 }
 
@@ -889,7 +1129,7 @@ static int test_graph_sequence_wrap(void)
     setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
     make_signal(&G_NODES[0], 0u, 0x1111u, RP1_SIGOP_SET,
                 0, 0u, 0, 1u);
-    G_CTRL->graph_seq = 0xFFFFFFFFu;
+    s_pending_graph_seq = 0xFFFFFFFFu;
     s_wrap_graphs = 0u;
 
     int rc = rp1_run(&s_wrap_hooks);
@@ -897,6 +1137,12 @@ static int test_graph_sequence_wrap(void)
     CHECK_EQ32(s_wrap_graphs, 2u, "seq_wrap: both graphs ran");
     CHECK_EQ32(G_CTRL->graph_done_seq, 0u,
                "seq_wrap: equality completion wrapped");
+    CHECK_EQ32(G_CTRL->result.magic, RP1_GRAPH_RESULT_MAGIC,
+               "seq_wrap: wrapped result committed");
+    CHECK_EQ32(G_CTRL->result.graph_seq, 0u,
+               "seq_wrap: result sequence wrapped");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_SUCCESS,
+               "seq_wrap: wrapped graph succeeded");
     CHECK_EQ32(G_SIGS[0].value, 0x1111u,
                "seq_wrap: pre-wrap graph ran");
     CHECK_EQ32(G_SIGS[1].value, 0x2222u,
@@ -904,51 +1150,60 @@ static int test_graph_sequence_wrap(void)
     return 0;
 }
 
-static int test_signal_slot_validation(void)
+/*
+ * Every uint8_t signal value names one of the 256 slots, so protocol-v6 slot
+ * encoding has no invalid value. Retain all-or-nothing validation coverage
+ * with the remaining compact discriminants.
+ */
+static int test_compact_operation_validation(void)
 {
-    static const uint16_t opcodes[] = {
+    static const uint8_t opcodes[] = {
         RP1_OP_SIGNAL,
         RP1_OP_WAIT,
-        RP1_OP_SCALAR_READ,
-        RP1_OP_SCALAR_COPY,
-        RP1_OP_LOOP,
-        RP1_OP_COND,
+        14u,
+        RP1_OP_NOP,
+        RP1_OP_NOP,
+        RP1_OP_NOP,
+    };
+    static const uint8_t flags[] = {
+        0u,
+        0u,
+        0u,
+        0x2u,
+        0u,
+        RP1_FLAG_INFINITE,
+    };
+    static const uint16_t reserved[] = {
+        0u,
+        0u,
+        0u,
+        0u,
+        0x1000u,
+        0u,
+    };
+    static const uint16_t bad_values[] = {
+        RP1_SIGOP_AND + 1u,
+        RP1_COP_AND_Z + 1u,
+        14u,
+        0x20u,
+        0x1000u,
+        0x10u,
     };
 
     for (uint32_t test = 0; test < sizeof(opcodes) / sizeof(opcodes[0]);
          test++) {
         setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
         rp1_node_t *node = &G_NODES[0];
-        node->opcode = opcodes[test];
-        node->status = RP1_NODE_PENDING;
-        switch (node->opcode) {
+        make_header(node, opcodes[test], flags[test],
+                    0u, 0u, 0u, 0u);
+        rp1_node_set_control(
+            node, (uint16_t)(rp1_node_get_control(node) | reserved[test]));
+        switch (opcodes[test]) {
         case RP1_OP_SIGNAL:
-            node->payload.signal.target_slot = RP1_MAX_SIGNALS;
-            node->payload.signal.operation = RP1_SIGOP_SET;
+            node->payload.signal.operation = (uint8_t)bad_values[test];
             break;
         case RP1_OP_WAIT:
-            node->payload.wait.condition_signal = RP1_MAX_SIGNALS;
-            node->payload.wait.condition_op = RP1_COP_EQ;
-            break;
-        case RP1_OP_SCALAR_READ:
-            node->payload.scalar_read.target_slot = RP1_MAX_SIGNALS;
-            break;
-        case RP1_OP_SCALAR_COPY:
-            node->payload.scalar_copy.source_slot = RP1_MAX_SIGNALS;
-            break;
-        case RP1_OP_LOOP:
-            node->payload.loop.condition_signal = RP1_MAX_SIGNALS;
-            node->payload.loop.condition_op = RP1_COP_EQ;
-            node->payload.loop.body_start = 0u;
-            node->payload.loop.body_end = 0u;
-            break;
-        case RP1_OP_COND:
-            node->payload.cond.condition_signal = RP1_MAX_SIGNALS;
-            node->payload.cond.condition_op = RP1_COP_EQ;
-            node->payload.cond.body_start = 1u;
-            node->payload.cond.body_end = 0u;
-            node->payload.cond.bucket_clear_start = 1u;
-            node->payload.cond.bucket_clear_end = 0u;
+            node->payload.wait.condition_op = (uint8_t)bad_values[test];
             break;
         default:
             break;
@@ -956,16 +1211,104 @@ static int test_signal_slot_validation(void)
 
         int rc = rp1_run(&s_hooks);
         CHECK_EQ32((uint32_t)(rc + 1), 0u,
-                   "slot_validation: graph rejected");
+                   "operation_validation: graph rejected");
         CHECK_EQ32(G_CTRL->terminal_error_node, 0u,
-                   "slot_validation: node latched");
+                   "operation_validation: node latched");
         CHECK_EQ32(G_CTRL->terminal_error_detail,
-                   RP1_NODE_BAD_SIGNAL_SLOT,
-                   "slot_validation: detail");
-        CHECK_EQ32(G_CTRL->terminal_error_aux, RP1_MAX_SIGNALS,
-                   "slot_validation: bad slot preserved");
-        CHECK_EQ32(G_CQ[0].status, RP1_CQ_ERROR,
-                   "slot_validation: CQ evidence");
+                   RP1_NODE_BAD_OPERATION,
+                   "operation_validation: detail");
+        CHECK_EQ32(G_CTRL->terminal_error_aux, bad_values[test],
+                   "operation_validation: bad value preserved");
+        CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_FAILED,
+                   "operation_validation: failed result");
+        CHECK_EQ32(G_CTRL->result.terminal_opcode, opcodes[test],
+                   "operation_validation: opcode preserved");
+        CHECK_EQ32(G_CTRL->result.completed_operations, 0u,
+                   "operation_validation: no operation started");
+        CHECK((G_CTRL->result.flags &
+               RP1_RESULT_EFFECTS_MAY_BE_PARTIAL) == 0u,
+              "operation_validation: no partial effects");
+    }
+    return 0;
+}
+
+/*
+ * Phase-1 DMA and compact control validation must reject every field the
+ * executor would otherwise ignore. A trailing SIGNAL proves validation
+ * completes before any graph side effect.
+ */
+static int test_phase1_payload_validation(void)
+{
+    enum {
+        BAD_DMA_COPY_HIGH,
+        BAD_DMA_COPY_TYPE,
+        BAD_DMA_COPY_RANGE,
+        BAD_DMA_FILL_HIGH,
+        BAD_DMA_FILL_TYPE,
+        BAD_DMA_FILL_RANGE,
+        BAD_DISPATCH_FLAGS,
+        BAD_RERUN_FLAGS,
+        BAD_CASE_COUNT,
+    };
+    static const uint32_t expected_detail[BAD_CASE_COUNT] = {
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_ARGUMENTS,
+        RP1_NODE_BAD_TARGET,
+    };
+
+    for (uint32_t test = 0u; test < BAD_CASE_COUNT; test++) {
+        setup_graph(/* node_count */ 2u, /* fake_kernels */ 1u);
+        rp1_node_t *node = &G_NODES[0];
+
+        if (test <= BAD_DMA_COPY_RANGE) {
+            make_header(node, RP1_OP_DMA_COPY, 0u, 0u, 0u, 0u, 0u);
+            node->payload.dma_copy.src_addr_lo = 0x1000u;
+            node->payload.dma_copy.dst_addr_lo = 0x2000u;
+            node->payload.dma_copy.length_types =
+                rp1_dma_pack(8u, 0u, 0u);
+            if (test == BAD_DMA_COPY_HIGH)
+                node->payload.dma_copy.src_addr_hi = 1u;
+            else if (test == BAD_DMA_COPY_TYPE)
+                node->payload.dma_copy.length_types =
+                    rp1_dma_pack(8u, 1u, 0u);
+            else
+                node->payload.dma_copy.src_addr_lo = 0xFFFFFFFCu;
+        } else if (test <= BAD_DMA_FILL_RANGE) {
+            make_header(node, RP1_OP_DMA_FILL, 0u, 0u, 0u, 0u, 0u);
+            node->payload.dma_fill.dst_addr_lo = 0x2000u;
+            node->payload.dma_fill.length = 8u;
+            if (test == BAD_DMA_FILL_HIGH)
+                node->payload.dma_fill.dst_addr_hi = 1u;
+            else if (test == BAD_DMA_FILL_TYPE)
+                node->payload.dma_fill.dst_type = 1u;
+            else
+                node->payload.dma_fill.dst_addr_lo = 0xFFFFFFFCu;
+        } else if (test == BAD_DISPATCH_FLAGS) {
+            make_kernel(node, 0u, 0u, 0u, 0u, 0u, 0u, 0u);
+            node->payload.kernel_dispatch.ctrl_flags = 1u;
+        } else {
+            make_rerun(node, 0u, 0u, 0u, 0u, 0u);
+            node->payload.rerun.rerun_flags = 0x2u;
+        }
+        make_signal(&G_NODES[1], 63u, 0xBAD0u, RP1_SIGOP_SET,
+                    0u, 0u, 0u, 1u);
+
+        int rc = rp1_run(&s_hooks);
+        CHECK_EQ32((uint32_t)(rc + 1), 0u,
+                   "phase1_validation: graph rejected");
+        CHECK_EQ32(G_CTRL->terminal_error_node, 0u,
+                   "phase1_validation: bad node latched");
+        CHECK_EQ32(G_CTRL->terminal_error_detail, expected_detail[test],
+                   "phase1_validation: detail");
+        CHECK_EQ32(G_CTRL->result.completed_operations, 0u,
+                   "phase1_validation: no operation started");
+        CHECK_EQ32(G_SIGS[63].value, 0u,
+                   "phase1_validation: sentinel did not run");
     }
     return 0;
 }
@@ -990,8 +1333,7 @@ static int test_signal_slot_validation(void)
  *     the exit condition (loop_iters[0] is incremented before the check,
  *     so it lands at 4 on exit).
  *   - finalize fires after the LOOP node sets its own barrier on exit.
- *   - CQ entries: init + 3*(body SIGNAL + body RERUN) + LOOP_exit + final = 9.
- *     (LOOP does NOT write CQ on the continue path, only on exit.)
+ *   - successful operation count includes all four LOOP evaluations: 12.
  * ---------------------------------------------------------------------- */
 
 static int test_loop_decrement(void)
@@ -1016,7 +1358,8 @@ static int test_loop_decrement(void)
     CHECK_EQ32(G_SIGS[0].value,        0u,          "loop: slot[0] reached 0");
     CHECK_EQ32(G_SIGS[10].value,       0xCAFEBABEu, "loop: finalize ran");
     CHECK_EQ32(g_loop_iters[0],        4u,          "loop: iteration counter");
-    CHECK_EQ32(G_CTRL->cq_write_idx,   9u,          "loop: cq entries");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 12u,
+               "loop: successful operation count");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,          "loop: graph_done_seq");
     return 0;
 }
@@ -1032,7 +1375,7 @@ static int test_loop_decrement(void)
  *  Node 3: SIGNAL  slot=21 SET 0xBBBB  await=0/0x20  (only on met)
  *
  * Avoids the if/else-via-body pattern from ARCHITECTURE.md § E (which
- * relies on body_clear + node_status reset to gate body execution and
+ * relies on body_clear + packed BTCM status reset to gate body execution and
  * isn't airtight when body-await masks are zero) and instead exercises
  * COND as a pure boolean: condition evaluation, the always-set
  * barrier_set_mask, and the conditional done_mask in done_bucket.
@@ -1061,7 +1404,8 @@ static int test_cond_boolean(void)
     CHECK_EQ32(rc, 0u, "cond[met]: rp1_run rc");
     CHECK_EQ32(G_SIGS[20].value,     0xAAAAu, "cond[met]: 'always' branch ran");
     CHECK_EQ32(G_SIGS[21].value,     0xBBBBu, "cond[met]: 'met-only' branch ran");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 4u,      "cond[met]: cq entries");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 4u,
+               "cond[met]: successful operation count");
 
     /* ---- Run 2: condition NOT met (slot[5] == 99) ---- */
     setup_graph(4, 0);
@@ -1080,8 +1424,11 @@ static int test_cond_boolean(void)
     CHECK_EQ32(rc, 0u, "cond[nomet]: rp1_run rc");
     CHECK_EQ32(G_SIGS[20].value,     0xAAAAu, "cond[nomet]: 'always' branch ran");
     CHECK_EQ32(G_SIGS[21].value,     0u,      "cond[nomet]: 'met-only' silent");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 3u,      "cond[nomet]: cq entries");
-    CHECK_EQ32(g_node_status[3],     RP1_NODE_PENDING,
+    CHECK_EQ32(G_CTRL->result.completed_operations, 3u,
+               "cond[nomet]: successful operation count");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_UNREACHED_NODES) != 0u,
+          "cond[nomet]: skipped node reported");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[3]), RP1_NODE_PENDING,
                "cond[nomet]: node 3 stayed PENDING");
     return 0;
 }
@@ -1102,7 +1449,7 @@ static int test_cond_boolean(void)
  * the condition-exit + signal-body path; this covers max_iterations + a kernel.
  *
  * Expected: body runs 3 times (loop_iters lands at 4 on exit), finalize fires.
- * CQ = 3*(kernel + rerun) + loop_exit + finalize = 8.
+ * Successful operations include all four LOOP evaluations: 11.
  * ---------------------------------------------------------------------- */
 
 static int test_loop_fixed_count(void)
@@ -1127,8 +1474,10 @@ static int test_loop_fixed_count(void)
 
     CHECK_EQ32(g_loop_iters[0],        4u,       "loop_fixed: 3 body runs (iters=4)");
     CHECK_EQ32(G_SIGS[10].value,       0xD05Eu,  "loop_fixed: finalize ran on exit");
-    CHECK_EQ32(G_CTRL->cq_write_idx,   8u,       "loop_fixed: cq entries");
-    CHECK_EQ32(g_node_status[3],       RP1_NODE_DONE, "loop_fixed: finalize DONE");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 11u,
+               "loop_fixed: successful operation count");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[3]), RP1_NODE_DONE,
+               "loop_fixed: finalize DONE");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,       "loop_fixed: graph_done_seq");
     return 0;
 }
@@ -1158,7 +1507,8 @@ static int test_scalar_read(void)
     CHECK_EQ32(rc, 0u, "scalar_read: rp1_run rc");
 
     CHECK_EQ32(G_SIGS[6].value,        0x1234ABCDu, "scalar_read: slot captured reg");
-    CHECK_EQ32(g_node_status[1],       RP1_NODE_DONE, "scalar_read: node DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_DONE,
+               "scalar_read: node DONE");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,          "scalar_read: graph_done_seq");
     return 0;
 }
@@ -1196,10 +1546,13 @@ static int test_wait_blocks(void)
     CHECK_EQ32(s_wait_witness_at_fire, 0u,
                "wait: downstream stayed blocked until the signal arrived");
     CHECK_EQ32(G_SIGS[20].value,     0xF00Du,        "wait: downstream ran after release");
-    CHECK_EQ32(g_node_status[0],     RP1_NODE_DONE,  "wait: WAIT node DONE");
-    CHECK_EQ32(g_node_status[1],     RP1_NODE_DONE,  "wait: downstream DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "wait: WAIT node DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_DONE,
+               "wait: downstream DONE");
     CHECK_EQ32(g_barriers[0] & 0x3u, 0x3u,           "wait: both barriers raised");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 2u,             "wait: cq entries");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 2u,
+               "wait: operations counted after wake");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,           "wait: graph_done_seq");
     CHECK(s_pass_count > s_wait_after, "wait: scanner kept polling while parked");
     return 0;
@@ -1230,12 +1583,18 @@ static int test_pdi_mmio_contract(void)
                "pdi_mmio: request command address");
     CHECK_EQ32(s_pdi_access[4].kind, PDI_ACCESS_BARRIER,
                "pdi_mmio: request barrier");
+    CHECK_EQ32(s_pdi_access[4].value, RP1_BARRIER_DMB_ST,
+               "pdi_mmio: request stores ordered before trigger");
     CHECK_EQ32(s_pdi_access[5].address, RP1_PDI_IPI_TRIGGER_REG,
                "pdi_mmio: generated trigger address");
     CHECK_EQ32(s_pdi_access[5].value, RP1_PDI_IPI_TARGET_MASK,
                "pdi_mmio: generated target mask");
+    CHECK_EQ32(s_pdi_access[6].value, RP1_BARRIER_DSB_ST,
+               "pdi_mmio: trigger completed before deadline starts");
     CHECK_EQ32(s_pdi_access[7].address, RP1_PDI_IPI_OBSERVATION_REG,
                "pdi_mmio: generated observation address");
+    CHECK_EQ32(s_pdi_access[8].value, RP1_BARRIER_DMB_SY,
+               "pdi_mmio: acknowledgement ordered before response");
     CHECK_EQ32(s_pdi_access[9].address, RP1_PDI_IPI_RESPONSE_BASE,
                "pdi_mmio: response status address");
     CHECK_EQ32(s_pdi_access[10].address, RP1_PDI_IPI_RESPONSE_BASE + 4u,
@@ -1276,7 +1635,6 @@ static int test_kernel_timeout_invariant(void)
     pdi_override_reset();
     s_cycle_step = 1u;
     make_kernel(&G_NODES[0], 0, 0, 0u, 0, 1u, 0u, 0u);
-    G_NODES[0].flags = RP1_FLAG_HALT_ON_ERROR;
     G_NODES[0].payload.kernel_dispatch.timeout_cycles = 12u;
     s_skip_completion_node = 0u;
     int slow = rp1_run(&s_hooks);
@@ -1286,7 +1644,6 @@ static int test_kernel_timeout_invariant(void)
     pdi_override_reset();
     s_cycle_step = 4u;
     make_kernel(&G_NODES[0], 0, 0, 0u, 0, 1u, 0u, 0u);
-    G_NODES[0].flags = RP1_FLAG_HALT_ON_ERROR;
     G_NODES[0].payload.kernel_dispatch.timeout_cycles = 12u;
     s_skip_completion_node = 0u;
     int fast = rp1_run(&s_hooks);
@@ -1300,26 +1657,15 @@ static int test_kernel_timeout_invariant(void)
           "kernel_deadline: scanner poll count does not define timeout");
     CHECK_EQ32(G_CTRL->terminal_error_aux, 12u,
                "kernel_deadline: requested PMU deadline retained");
-    return 0;
-}
-
-static int test_silent_pdi_rejected(void)
-{
-    setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
-    pdi_override_reset();
-    make_pdi_load(&G_NODES[0], 0x10000000u, 0u, 10u,
-                  RP1_FLAG_SILENT, 0, 0u, 0, 1u);
-
-    int rc = rp1_run(&s_hooks);
-    CHECK_EQ32((uint32_t)(rc + 1), 0u,
-               "pdi_silent: graph rejected");
-    CHECK_EQ32(s_pdi_call_count, 0u,
-               "pdi_silent: IPI was not triggered");
-    CHECK_EQ32(G_CTRL->terminal_error_detail,
-               RP1_NODE_PDI_WITHOUT_CQ,
-               "pdi_silent: validation detail");
-    CHECK_EQ32(G_CQ[0].status, RP1_CQ_ERROR,
-               "pdi_silent: forced CQ evidence");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_FAILED,
+               "kernel_deadline: failed result");
+    CHECK_EQ32(G_CTRL->result.terminal_opcode, RP1_OP_KERNEL_DISPATCH,
+               "kernel_deadline: terminal opcode");
+    CHECK_EQ32(G_CTRL->result.quiescence,
+               RP1_QUIESCE_PACK(0u, 1u, 0u),
+               "kernel_deadline: finite timeout classified");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_RECOVERY_REQUIRED) != 0u,
+          "kernel_deadline: timeout requires recovery");
     return 0;
 }
 
@@ -1328,7 +1674,7 @@ static int test_silent_pdi_rejected(void)
  *
  *   Single PDI_LOAD node, override returns success.
  *   Verifies the scanner forwards the payload to rp1_pdi_load() verbatim
- *   and marks the node DONE / writes an OK CQ entry on return.
+ *   with a zero flags nibble.
  * ---------------------------------------------------------------------- */
 
 static int test_pdi_load_basic(void)
@@ -1340,7 +1686,7 @@ static int test_pdi_load_basic(void)
                   /* addr_lo */ 0x10000000u,
                   /* addr_hi */ 0x00000001u,
                   /* timeout */ 12345u,
-                  /* flags   */ 0,
+                  /* flags   */ 0u,
                   /* await   */ 0, 0x00,
                   /* set     */ 0, 0x01);
 
@@ -1350,28 +1696,28 @@ static int test_pdi_load_basic(void)
     CHECK_EQ32(s_pdi_call_count,       1u,          "pdi_basic: invoked once");
     CHECK_EQ32(s_pdi_last_addr_lo,     0x10000000u, "pdi_basic: addr_lo forwarded");
     CHECK_EQ32(s_pdi_last_addr_hi,     0x00000001u, "pdi_basic: addr_hi forwarded");
-    CHECK_EQ32(g_node_status[0],       RP1_NODE_DONE, "pdi_basic: node DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "pdi_basic: node DONE");
     CHECK_EQ32(g_barriers[0] & 0x1u,   0x1u,          "pdi_basic: barrier set");
-    CHECK_EQ32(G_CTRL->cq_write_idx,   1u,            "pdi_basic: one CQ entry");
-    CHECK_EQ32(G_CQ[0].status,         RP1_CQ_OK,     "pdi_basic: CQ status OK");
-    CHECK_EQ32(G_CQ[0].node_index,     0u,            "pdi_basic: CQ node_index");
     CHECK_EQ32(G_CTRL->rp1_state,      RP1_STATE_READY, "pdi_basic: rp1_state");
     CHECK_EQ32(G_CTRL->rp1_error_code, 0u,            "pdi_basic: no error");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_SUCCESS,
+               "pdi_basic: success result");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 1u,
+               "pdi_basic: operation counted");
     return 0;
 }
 
 /* -------------------------------------------------------------------------
  * test_pdi_load_timeout
  *
- *   Two passes: first with HALT_ON_ERROR cleared (graph continues, barrier
- *   still raised so downstream can run), second with HALT_ON_ERROR set
- *   (scanner aborts via rp1_state = ERROR).  In both cases rp1_pdi_load()
- *   returns -1, which the scanner must surface as ERR_PDI_TIMEOUT (3).
+ *   Every PDI transport timeout or PLM rejection is fatal. The active image
+ *   becomes UNKNOWN, no dependent is activated, and the structured response
+ *   remains intact in both the legacy latch and committed result.
  * ---------------------------------------------------------------------- */
 
 static int test_pdi_load_timeout(void)
 {
-    /* ---- Run 1: non-fatal timeout (no HALT_ON_ERROR) ---- */
     setup_graph(/* node_count */ 2, /* fake_kernels */ 0);
     pdi_override_reset();
     s_pdi_force_timeout = 1u;
@@ -1379,43 +1725,35 @@ static int test_pdi_load_timeout(void)
     make_pdi_load(&G_NODES[0],
                   0xDEAD0000u, 0u, 3u, /* flags */ 0,
                   0, 0x00, 0, 0x01);
-    /* Downstream SIGNAL gated on the PDI's set bit — verifies the
-     * scanner still raises barriers on non-fatal timeout. */
     make_signal(&G_NODES[1], 30, 0xFEEDBEEFu, RP1_SIGOP_SET,
                 0, 0x01, 0, 0x02);
 
     int rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "pdi_timeout[non-fatal]: rp1_run rc");
+    CHECK_EQ32((uint32_t)(rc + 1), 0u,
+               "pdi_timeout: rp1_run returned -1");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_ERROR,
+               "pdi_timeout: node ERROR");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_PENDING,
+               "pdi_timeout: downstream blocked");
+    CHECK_EQ32(G_SIGS[30].value, 0u,
+               "pdi_timeout: downstream had no effect");
+    CHECK_EQ32(G_CTRL->rp1_state, RP1_STATE_ERROR,
+               "pdi_timeout: terminal state");
+    CHECK_EQ32(G_CTRL->result.error_code, RP1_ERR_PDI_TIMEOUT,
+               "pdi_timeout: result error");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_UNKNOWN,
+               "pdi_timeout: image state unknown");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 0u,
+               "pdi_timeout: unknown image has no id");
+    CHECK((G_CTRL->result.flags &
+           RP1_RESULT_EFFECTS_MAY_BE_PARTIAL) != 0u,
+          "pdi_timeout: started operation may have partial effects");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_RECOVERY_REQUIRED) != 0u,
+          "pdi_timeout: delayed response requires recovery");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_UNREACHED_NODES) != 0u,
+          "pdi_timeout: dependent is unreached");
 
-    CHECK_EQ32(g_node_status[0],       RP1_NODE_ERROR,  "pdi_timeout[non-fatal]: node ERROR");
-    CHECK_EQ32(G_CTRL->rp1_error_code, 3u,              "pdi_timeout[non-fatal]: err code 3");
-    CHECK_EQ32(G_CQ[0].status,         RP1_CQ_TIMEOUT,  "pdi_timeout[non-fatal]: CQ TIMEOUT");
-    CHECK_EQ32(g_barriers[0] & 0x1u,   0x1u,            "pdi_timeout[non-fatal]: barrier still set");
-    CHECK_EQ32(G_SIGS[30].value,       0xFEEDBEEFu,     "pdi_timeout[non-fatal]: downstream ran");
-    CHECK_EQ32(G_CTRL->rp1_state,      RP1_STATE_READY, "pdi_timeout[non-fatal]: rp1_state");
-
-    /* ---- Run 2: fatal timeout (HALT_ON_ERROR set) ---- */
-    setup_graph(/* node_count */ 2, /* fake_kernels */ 0);
-    pdi_override_reset();
-    s_pdi_force_timeout = 1u;
-
-    make_pdi_load(&G_NODES[0],
-                  0xDEAD0000u, 0u, 3u,
-                  /* flags */ RP1_FLAG_HALT_ON_ERROR,
-                  0, 0x00, 0, 0x01);
-    make_signal(&G_NODES[1], 30, 0xFEEDBEEFu, RP1_SIGOP_SET,
-                0, 0x01, 0, 0x02);
-
-    rc = rp1_run(&s_hooks);
-    CHECK_EQ32((uint32_t)(rc + 1), 0u, "pdi_timeout[fatal]: rp1_run returned -1");
-
-    CHECK_EQ32(g_node_status[0],       RP1_NODE_ERROR,  "pdi_timeout[fatal]: node ERROR");
-    CHECK_EQ32(g_node_status[1],       RP1_NODE_PENDING,"pdi_timeout[fatal]: downstream blocked");
-    CHECK_EQ32(G_SIGS[30].value,       0u,              "pdi_timeout[fatal]: downstream silent");
-    CHECK_EQ32(G_CTRL->rp1_state,      RP1_STATE_ERROR, "pdi_timeout[fatal]: rp1_state ERROR");
-    CHECK_EQ32(G_CTRL->rp1_error_code, 3u,              "pdi_timeout[fatal]: err code 3");
-
-    /* ---- Run 3: PLM completed the command with an error response ---- */
+    /* PLM completed the command with an error response. */
     setup_graph(/* node_count */ 1, /* fake_kernels */ 0);
     pdi_override_reset();
     s_pdi_status = 0x80002001u;
@@ -1423,21 +1761,23 @@ static int test_pdi_load_timeout(void)
 
     make_pdi_load(&G_NODES[0],
                   0xDEAD0000u, 0u, 0u,
-                  /* flags */ RP1_FLAG_HALT_ON_ERROR,
+                  /* flags */ 0u,
                   0, 0x00, 0, 0x01);
 
     rc = rp1_run(&s_hooks);
     CHECK_EQ32((uint32_t)(rc + 1), 0u, "pdi_error: rp1_run returned -1");
     CHECK_EQ32(G_CTRL->rp1_error_code, RP1_ERR_PDI_FAILED,
                "pdi_error: PLM failure code");
-    CHECK_EQ32(G_CQ[0].status, RP1_CQ_ERROR,
-               "pdi_error: CQ status ERROR");
-    CHECK_EQ32(G_CQ[0].error_detail, 0x80002001u,
-               "pdi_error: CQ preserves high-bit PLM status");
     CHECK_EQ32(G_CTRL->terminal_error_detail, 0x80002001u,
                "pdi_error: terminal record preserves PLM status");
     CHECK_EQ32(G_CTRL->terminal_error_aux, 0xDEADCAFEu,
                "pdi_error: terminal record preserves PLM detail");
+    CHECK_EQ32(G_CTRL->result.error_detail, 0x80002001u,
+               "pdi_error: result preserves PLM status");
+    CHECK_EQ32(G_CTRL->result.error_aux, 0xDEADCAFEu,
+               "pdi_error: result preserves PLM detail");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_UNKNOWN,
+               "pdi_error: rejected load leaves unknown image");
     return 0;
 }
 
@@ -1467,6 +1807,7 @@ static int test_pdi_load_chained(void)
                   /* flags   */ 0,
                   /* await   */ 0, 0x00,
                   /* set     */ 0, 0x01);
+    G_NODES[0].payload.pdi_load.image_id = 1u;
     make_pdi_load(&G_NODES[1],
                   /* addr_lo */ 0x22220000u,
                   /* addr_hi */ 0x00000002u,
@@ -1474,6 +1815,7 @@ static int test_pdi_load_chained(void)
                   /* flags   */ 0,
                   /* await   */ 0, 0x01,
                   /* set     */ 0, 0x02);
+    G_NODES[1].payload.pdi_load.image_id = 2u;
 
     int rc = rp1_run(&s_hooks);
     CHECK_EQ32(rc, 0u, "pdi_chain: rp1_run rc");
@@ -1483,12 +1825,51 @@ static int test_pdi_load_chained(void)
     CHECK_EQ32(s_pdi_last_addr_lo,     0x22220000u,   "pdi_chain: last addr_lo (node 1)");
     CHECK_EQ32(s_pdi_last_addr_hi,     0x00000002u,   "pdi_chain: last addr_hi (node 1)");
 
-    CHECK_EQ32(g_node_status[0],     RP1_NODE_DONE, "pdi_chain: node 0 DONE");
-    CHECK_EQ32(g_node_status[1],     RP1_NODE_DONE, "pdi_chain: node 1 DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "pdi_chain: node 0 DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_DONE,
+               "pdi_chain: node 1 DONE");
     CHECK_EQ32(g_barriers[0] & 0x3u, 0x3u,          "pdi_chain: both barriers raised");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 2u,            "pdi_chain: two CQ entries");
-    CHECK_EQ32(G_CQ[0].node_index,   0u,            "pdi_chain: CQ[0] is node 0");
-    CHECK_EQ32(G_CQ[1].node_index,   1u,            "pdi_chain: CQ[1] is node 1");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 2u,
+               "pdi_chain: both operations counted");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 2u,
+               "pdi_chain: final image id");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_KNOWN,
+               "pdi_chain: final image is known");
+    return 0;
+}
+
+/*
+ * A successful PDI is durable evidence even if a later kernel fails. The
+ * failed graph remains partial, but its result still names the installed
+ * image so the host can reconcile physical state before surfacing the error.
+ */
+static int test_image_survives_later_error(void)
+{
+    setup_graph(/* node_count */ 2, /* fake_kernels */ 1);
+    pdi_override_reset();
+    make_pdi_load(&G_NODES[0], 0x12340000u, 0u, 20u, 0u,
+                  0, 0u, 0, 1u);
+    G_NODES[0].payload.pdi_load.image_id = 42u;
+    make_kernel(&G_NODES[1], 0, 0, 1u, 0, 2u, 0u, 0u);
+    G_NODES[1].payload.kernel_dispatch.expected_image_id = 42u;
+    G_NODES[1].payload.kernel_dispatch.timeout_cycles = 3u;
+    s_skip_completion_node = 1u;
+
+    int rc = rp1_run(&s_hooks);
+    CHECK_EQ32((uint32_t)(rc + 1), 0u,
+               "image_later_error: fatal kernel result");
+    CHECK_EQ32(G_CTRL->result.error_code, RP1_ERR_KERNEL_TIMEOUT,
+               "image_later_error: kernel error retained");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 42u,
+               "image_later_error: installed image retained");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_KNOWN,
+               "image_later_error: installed image remains known");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 1u,
+               "image_later_error: successful PDI counted");
+    CHECK((G_CTRL->result.flags &
+           RP1_RESULT_EFFECTS_MAY_BE_PARTIAL) != 0u,
+          "image_later_error: failed graph reports partial effects");
     return 0;
 }
 
@@ -1496,13 +1877,14 @@ static int test_pdi_load_chained(void)
  * test_image_guard
  *
  * Exercises the expected-image guard. g_active_image_id persists across graph
- * submissions (it mirrors physical reconfig state and is not cleared by
- * rp1_store_reset_graph), so the three sub-runs below share it:
+ * submissions in one firmware instance. The bounded QEMU harness re-enters
+ * rp1_run() for each sub-run, so Run 2 seeds the prior known image from its
+ * idle hook after startup; Run 3 deliberately verifies reboot state:
  *
  *   Run 1 (match):      PDI_LOAD{image_id=7} -> DISPATCH{expected=7} launches.
  *   Run 2 (mismatch):   DISPATCH{expected=9} with active image still 7 fails
- *                       fast -- NODE_ERROR, ERR_IMAGE_MISMATCH, CQ ERROR, and
- *                       the kernel is never launched (ctrl reg untouched).
+ *                       fast and reports the still-known image; the kernel is
+ *                       never launched.
  *   Run 3 (unguarded):  DISPATCH{expected=0} launches regardless of image.
  * ---------------------------------------------------------------------- */
 
@@ -1526,12 +1908,19 @@ static int test_image_guard(void)
     int rc = rp1_run(&s_hooks);
     CHECK_EQ32(rc, 0u, "image_guard[match]: rp1_run rc");
     CHECK_EQ32(g_active_image_id, 7u, "image_guard[match]: active image recorded");
-    CHECK_EQ32(g_node_status[1], RP1_NODE_DONE, "image_guard[match]: dispatch DONE");
+    CHECK_EQ32(g_active_image_state, RP1_IMAGE_STATE_KNOWN,
+               "image_guard[match]: image state known");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[1]), RP1_NODE_DONE,
+               "image_guard[match]: dispatch DONE");
     {
         volatile uint32_t *ctrl = (volatile uint32_t *)(uintptr_t)FAKE_KERNEL(0);
         CHECK_EQ32(ctrl[0], 0x3u, "image_guard[match]: kernel launched (ap_start|ap_done)");
     }
     CHECK_EQ32(G_CTRL->rp1_error_code, 0u, "image_guard[match]: no error");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 7u,
+               "image_guard[match]: result image id");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_KNOWN,
+               "image_guard[match]: result image known");
 
     /* ---- Run 2: separate submission, stale expected image -> fail fast. ---- */
     setup_graph(/* node_count */ 1, /* fake_kernels */ 1);
@@ -1541,14 +1930,24 @@ static int test_image_guard(void)
                 /* arg_buf_offset */ 0u, /* arg_count */ 0);
     G_NODES[0].payload.kernel_dispatch.expected_image_id = 9u;  /* active is still 7 */
 
-    rc = rp1_run(&s_hooks);
-    CHECK_EQ32(rc, 0u, "image_guard[mismatch]: rp1_run rc (non-fatal)");
+    rc = rp1_run(&s_known_image_hooks);
+    CHECK_EQ32((uint32_t)(rc + 1), 0u,
+               "image_guard[mismatch]: fatal result");
     CHECK_EQ32(g_active_image_id, 7u, "image_guard[mismatch]: active image unchanged");
-    CHECK_EQ32(g_node_status[0], RP1_NODE_ERROR, "image_guard[mismatch]: node ERROR");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_ERROR,
+               "image_guard[mismatch]: node ERROR");
     CHECK_EQ32(G_CTRL->rp1_error_code, RP1_ERR_IMAGE_MISMATCH,
                "image_guard[mismatch]: err code");
-    CHECK_EQ32(G_CQ[0].status, RP1_CQ_ERROR, "image_guard[mismatch]: CQ ERROR");
-    CHECK_EQ32(G_CQ[0].error_detail, 7u, "image_guard[mismatch]: CQ carries active image");
+    CHECK_EQ32(G_CTRL->result.error_detail, 9u,
+               "image_guard[mismatch]: expected image detail");
+    CHECK_EQ32(G_CTRL->result.error_aux, 7u,
+               "image_guard[mismatch]: active image detail");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 7u,
+               "image_guard[mismatch]: known image survives later failure");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_KNOWN,
+               "image_guard[mismatch]: known state survives later failure");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 0u,
+               "image_guard[mismatch]: no operation completed");
     {
         volatile uint32_t *ctrl = (volatile uint32_t *)(uintptr_t)FAKE_KERNEL(0);
         CHECK_EQ32(ctrl[0], 0u, "image_guard[mismatch]: kernel NOT launched");
@@ -1564,11 +1963,55 @@ static int test_image_guard(void)
 
     rc = rp1_run(&s_hooks);
     CHECK_EQ32(rc, 0u, "image_guard[unguarded]: rp1_run rc");
-    CHECK_EQ32(g_node_status[0], RP1_NODE_DONE, "image_guard[unguarded]: dispatch DONE");
+    CHECK_EQ32(rp1_node_get_status(&g_nodes[0]), RP1_NODE_DONE,
+               "image_guard[unguarded]: dispatch DONE");
+    CHECK_EQ32(G_CTRL->result.active_image_id, 0u,
+               "image_guard[unguarded]: reboot forgets prior image id");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_NONE,
+               "image_guard[unguarded]: reboot image state is none");
     {
         volatile uint32_t *ctrl = (volatile uint32_t *)(uintptr_t)FAKE_KERNEL(0);
         CHECK_EQ32(ctrl[0], 0x3u, "image_guard[unguarded]: kernel launched");
     }
+    return 0;
+}
+
+/*
+ * Explicit HALT is a committed HALTED outcome, not an error. Activation stops
+ * at the HALT node even when a later command is already barrier-ready.
+ */
+static int test_explicit_halt(void)
+{
+    setup_graph(/* node_count */ 3, /* fake_kernels */ 0);
+    make_signal(&G_NODES[0], 0u, 0x1111u, RP1_SIGOP_SET,
+                0, 0u, 0, 1u);
+    make_header(&G_NODES[1], RP1_OP_HALT, 0u, 0u, 1u, 0u, 0u);
+    make_signal(&G_NODES[2], 1u, 0x2222u, RP1_SIGOP_SET,
+                0, 1u, 0, 2u);
+
+    int rc = rp1_run(&s_hooks);
+    CHECK_EQ32((uint32_t)(rc + 2), 0u, "halt: rp1_run returned -2");
+    CHECK_EQ32(G_CTRL->rp1_state, RP1_STATE_HALTED,
+               "halt: terminal state");
+    CHECK_EQ32(G_CTRL->rp1_error_code, 0u,
+               "halt: no error code");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_HALTED,
+               "halt: distinct outcome");
+    CHECK_EQ32(G_CTRL->result.terminal_node, 1u,
+               "halt: terminal node");
+    CHECK_EQ32(G_CTRL->result.terminal_opcode, RP1_OP_HALT,
+               "halt: terminal opcode");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 2u,
+               "halt: signal and HALT counted");
+    CHECK_EQ32(G_CTRL->result.quiescence, 0u,
+               "halt: no inflight work");
+    CHECK((G_CTRL->result.flags &
+           RP1_RESULT_EFFECTS_MAY_BE_PARTIAL) != 0u,
+          "halt: prior effects may be partial");
+    CHECK((G_CTRL->result.flags & RP1_RESULT_UNREACHED_NODES) != 0u,
+          "halt: later node reported unreached");
+    CHECK_EQ32(G_SIGS[1].value, 0u,
+               "halt: later ready node was not activated");
     return 0;
 }
 
@@ -1582,7 +2025,6 @@ static int test_fatal_kernel_quiesce_and_reject(void)
     setup_graph(/* node_count */ 3, /* fake_kernels */ 2);
     pdi_override_reset();
     make_kernel(&G_NODES[0], 0, 0, 0u, 0, 1u, 0u, 0u);
-    G_NODES[0].flags = RP1_FLAG_HALT_ON_ERROR;
     G_NODES[0].payload.kernel_dispatch.timeout_cycles = 3u;
     make_kernel(&G_NODES[1], 1, 0, 0u, 0, 2u, 0u, 0u);
     G_NODES[1].payload.kernel_dispatch.timeout_cycles = 100u;
@@ -1596,10 +2038,9 @@ static int test_fatal_kernel_quiesce_and_reject(void)
                "fatal_kernel: terminal error result");
     CHECK_EQ32(G_CTRL->rp1_state, RP1_STATE_ERROR,
                "fatal_kernel: terminal state");
-    CHECK_EQ32(G_CTRL->rp1_error_code & RP1_ERR_CODE_MASK,
-               RP1_ERR_KERNEL_TIMEOUT,
+    CHECK_EQ32(G_CTRL->rp1_error_code, RP1_ERR_KERNEL_TIMEOUT,
                "fatal_kernel: first error code");
-    CHECK((G_CTRL->rp1_error_code & RP1_ERR_RECOVERY_REQUIRED) != 0u,
+    CHECK((G_CTRL->result.flags & RP1_RESULT_RECOVERY_REQUIRED) != 0u,
           "fatal_kernel: unresponsive work requires recovery");
     CHECK_EQ32(G_CTRL->terminal_error_node, 0u,
                "fatal_kernel: failing node latched");
@@ -1609,14 +2050,18 @@ static int test_fatal_kernel_quiesce_and_reject(void)
                "fatal_kernel: timeout ticks");
     CHECK_EQ32(G_SIGS[40].value, 0u,
                "fatal_kernel: sentinel did not run");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 2u,
-               "fatal_kernel: error and quiesced CQ evidence");
-    CHECK_EQ32(G_CQ[0].status, RP1_CQ_TIMEOUT,
-               "fatal_kernel: timeout evidence first");
-    CHECK_EQ32(G_CQ[1].node_index, 1u,
-               "fatal_kernel: finite peer quiesced");
-    CHECK_EQ32(G_CQ[1].status, RP1_CQ_OK,
-               "fatal_kernel: finite peer completion retained");
+    CHECK_EQ32(G_CTRL->result.outcome, RP1_GRAPH_RESULT_FAILED,
+               "fatal_kernel: failed graph result");
+    CHECK_EQ32(G_CTRL->result.terminal_opcode, RP1_OP_KERNEL_DISPATCH,
+               "fatal_kernel: terminal opcode");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 1u,
+               "fatal_kernel: finite peer completed during quiescence");
+    CHECK_EQ32(G_CTRL->result.quiescence,
+               RP1_QUIESCE_PACK(1u, 1u, 0u),
+               "fatal_kernel: quiescence counts");
+    CHECK((G_CTRL->result.flags &
+           RP1_RESULT_EFFECTS_MAY_BE_PARTIAL) != 0u,
+          "fatal_kernel: started graph may have partial effects");
     CHECK_EQ32(G_CTRL->graph_seq, 2u,
                "fatal_kernel: later graph was submitted");
     CHECK_EQ32(G_CTRL->graph_done_seq, 1u,
@@ -1636,10 +2081,10 @@ static int test_fatal_pdi_quiesce_and_recovery(void)
     make_kernel(&G_NODES[0], 0, 0, 0u, 0, 1u, 0u, 0u);
     G_NODES[0].payload.kernel_dispatch.timeout_cycles = 100u;
     make_kernel(&G_NODES[1], 1, 0, 0u, 0, 2u, 0u, 0u);
-    G_NODES[1].flags = RP1_FLAG_INFINITE;
+    rp1_node_set_flags(&G_NODES[1], RP1_FLAG_INFINITE);
     G_NODES[1].payload.kernel_dispatch.timeout_cycles = 100u;
     make_pdi_load(&G_NODES[2], 0x10000000u, 0u, 20u,
-                  RP1_FLAG_HALT_ON_ERROR, 0, 0u, 0, 4u);
+                  0u, 0, 0u, 0, 4u);
     make_signal(&G_NODES[3], 41u, 0x51514E54u, RP1_SIGOP_SET,
                 0, 7u, 0, 8u);
     s_skip_completion_node = 1u;
@@ -1647,10 +2092,9 @@ static int test_fatal_pdi_quiesce_and_recovery(void)
     int rc = rp1_run(&s_hooks);
     CHECK_EQ32((uint32_t)(rc + 1), 0u,
                "fatal_pdi: terminal error result");
-    CHECK_EQ32(G_CTRL->rp1_error_code & RP1_ERR_CODE_MASK,
-               RP1_ERR_PDI_FAILED,
+    CHECK_EQ32(G_CTRL->rp1_error_code, RP1_ERR_PDI_FAILED,
                "fatal_pdi: first error remains PDI");
-    CHECK((G_CTRL->rp1_error_code & RP1_ERR_RECOVERY_REQUIRED) != 0u,
+    CHECK((G_CTRL->result.flags & RP1_RESULT_RECOVERY_REQUIRED) != 0u,
           "fatal_pdi: infinite kernel requires recovery");
     CHECK_EQ32(G_CTRL->terminal_error_node, 2u,
                "fatal_pdi: failing node latched");
@@ -1660,14 +2104,18 @@ static int test_fatal_pdi_quiesce_and_recovery(void)
                "fatal_pdi: full PLM detail");
     CHECK_EQ32(G_SIGS[41].value, 0u,
                "fatal_pdi: sentinel did not run");
-    CHECK_EQ32(G_CTRL->cq_write_idx, 3u,
-               "fatal_pdi: infinite, PDI, finite evidence");
-    CHECK_EQ32(G_CQ[1].node_index, 2u,
-               "fatal_pdi: PDI CQ evidence");
-    CHECK_EQ32(G_CQ[1].error_detail, 0x8000F00Du,
-               "fatal_pdi: CQ preserves PLM status");
-    CHECK_EQ32(G_CQ[2].node_index, 0u,
-               "fatal_pdi: finite kernel quiesced");
+    CHECK_EQ32(G_CTRL->result.terminal_opcode, RP1_OP_PDI_LOAD,
+               "fatal_pdi: terminal opcode");
+    CHECK_EQ32(G_CTRL->result.completed_operations, 2u,
+               "fatal_pdi: launched kernels counted");
+    CHECK_EQ32(G_CTRL->result.quiescence,
+               RP1_QUIESCE_PACK(1u, 0u, 1u),
+               "fatal_pdi: quiescence counts");
+    CHECK((G_CTRL->result.flags &
+           RP1_RESULT_INFINITE_WORK_REMAINS) != 0u,
+          "fatal_pdi: infinite work reported");
+    CHECK_EQ32(G_CTRL->result.image_state, RP1_IMAGE_STATE_UNKNOWN,
+               "fatal_pdi: failed load makes image unknown");
     return 0;
 }
 
@@ -1687,29 +2135,38 @@ static int run(const char *name, int (*fn)(void))
 void rp1_graph_test_run(void)
 {
     run("diamond_dag",         test_diamond_dag);
-    run("cq_timestamps",       test_cq_timestamps);
+    run("cu_clean_tracking",   test_cu_clean_tracking);
     run("trace_disabled_by_default", test_trace_disabled_by_default);
     run("trace_queue",         test_trace_queue);
+    run("trace_btcm_flush",    test_trace_btcm_flush);
     run("kernel_unblocks_signal", test_kernel_unblocks_signal);
     run("signal_chain",        test_signal_chain);
-    run("cq_flow_control",     test_cq_flow_control);
-    run("cq_config_validation", test_cq_config_validation);
-    run("cq_cursor_wrap",      test_cq_cursor_wrap);
     run("graph_sequence_wrap", test_graph_sequence_wrap);
-    run("signal_slot_validation", test_signal_slot_validation);
+    run("compact_operation_validation",
+        test_compact_operation_validation);
+    run("phase1_payload_validation",
+        test_phase1_payload_validation);
+    run("btcm_node_snapshot",  test_btcm_node_snapshot);
+    run("exact_node_limit",    test_exact_node_limit);
     run("loop_decrement",      test_loop_decrement);
     run("loop_fixed_count",    test_loop_fixed_count);
     run("cond_boolean",        test_cond_boolean);
     run("scalar_read",         test_scalar_read);
     run("wait_blocks",         test_wait_blocks);
+    run("barrier_variants",    test_barrier_variants);
+    run("result_publication_order", test_result_publication_order);
+    run("boot_sequence_baseline", test_boot_sequence_baseline);
+    run("reserved_cq_config_rejected", test_reserved_cq_config_rejected);
     run("pdi_mmio_contract", test_pdi_mmio_contract);
     run("pdi_timeout_invariant", test_pdi_timeout_invariant);
     run("kernel_timeout_invariant", test_kernel_timeout_invariant);
-    run("silent_pdi_rejected", test_silent_pdi_rejected);
     run("pdi_load_basic",   test_pdi_load_basic);
     run("pdi_load_timeout", test_pdi_load_timeout);
     run("pdi_load_chained", test_pdi_load_chained);
+    run("image_survives_later_error",
+        test_image_survives_later_error);
     run("image_guard",      test_image_guard);
+    run("explicit_halt",     test_explicit_halt);
     run("fatal_kernel_quiesce_and_reject",
         test_fatal_kernel_quiesce_and_reject);
     run("fatal_pdi_quiesce_and_recovery",

--- a/linker/slashkit/resources/aved/rp1/src/rp1_hal.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_hal.c
@@ -7,6 +7,8 @@
 
 #include <stddef.h>
 
+#ifdef QEMU_SEMIHOSTING
+
 static rp1_hal_hooks_t g_hooks;
 
 void rp1_hal_set_hooks(const rp1_hal_hooks_t *hooks)
@@ -42,14 +44,43 @@ void rp1_mmio_write32(uintptr_t address, uint32_t value)
     *(volatile uint32_t *)address = value;
 }
 
-void rp1_barrier(void)
+void rp1_dsb_st(void)
 {
     if (g_hooks.barrier) {
-        g_hooks.barrier(g_hooks.context);
+        g_hooks.barrier(RP1_BARRIER_DSB_ST, g_hooks.context);
+        return;
+    }
+    __asm__ volatile("dsb st" ::: "memory");
+}
+
+void rp1_dsb_sy(void)
+{
+    if (g_hooks.barrier) {
+        g_hooks.barrier(RP1_BARRIER_DSB_SY, g_hooks.context);
         return;
     }
     __asm__ volatile("dsb sy" ::: "memory");
 }
+
+void rp1_dmb_st(void)
+{
+    if (g_hooks.barrier) {
+        g_hooks.barrier(RP1_BARRIER_DMB_ST, g_hooks.context);
+        return;
+    }
+    __asm__ volatile("dmb st" ::: "memory");
+}
+
+void rp1_dmb_sy(void)
+{
+    if (g_hooks.barrier) {
+        g_hooks.barrier(RP1_BARRIER_DMB_SY, g_hooks.context);
+        return;
+    }
+    __asm__ volatile("dmb sy" ::: "memory");
+}
+
+#endif /* QEMU_SEMIHOSTING */
 
 void rp1_pmu_init(void)
 {
@@ -66,6 +97,8 @@ void rp1_pmu_init(void)
     __asm__ volatile("mcr p15, 0, %0, c9, c12, 1" :: "r"(1u << 31) : "memory");
 }
 
+#ifdef QEMU_SEMIHOSTING
+
 uint32_t rp1_cycles(void)
 {
     uint32_t cycles;
@@ -75,6 +108,8 @@ uint32_t rp1_cycles(void)
     __asm__ volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(cycles));
     return cycles;
 }
+
+#endif /* QEMU_SEMIHOSTING */
 
 _Static_assert(RP1_DEFAULT_KERNEL_TIMEOUT_TICKS != 0u,
                "kernel timeout must be non-zero");

--- a/linker/slashkit/resources/aved/rp1/src/rp1_hal.h
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_hal.h
@@ -11,10 +11,24 @@
 
 #include "rp1_platform_config.h"
 
+#ifdef QEMU_SEMIHOSTING
+
+/** Barrier instruction selected by a firmware ordering or completion point. */
+typedef enum {
+    /** Complete prior stores before later instructions execute. */
+    RP1_BARRIER_DSB_ST,
+    /** Complete all prior explicit accesses before later instructions execute. */
+    RP1_BARRIER_DSB_SY,
+    /** Order prior stores before later stores. */
+    RP1_BARRIER_DMB_ST,
+    /** Order all prior explicit accesses before later explicit accesses. */
+    RP1_BARRIER_DMB_SY,
+} rp1_barrier_kind_t;
+
 typedef struct {
     uint32_t (*read32)(uintptr_t address, void *context);
     void (*write32)(uintptr_t address, uint32_t value, void *context);
-    void (*barrier)(void *context);
+    void (*barrier)(rp1_barrier_kind_t kind, void *context);
     uint32_t (*cycles)(void *context);
     void *context;
 } rp1_hal_hooks_t;
@@ -24,9 +38,62 @@ void rp1_hal_reset_hooks(void);
 
 uint32_t rp1_mmio_read32(uintptr_t address);
 void rp1_mmio_write32(uintptr_t address, uint32_t value);
-void rp1_barrier(void);
-void rp1_pmu_init(void);
+void rp1_dsb_st(void);
+void rp1_dsb_sy(void);
+void rp1_dmb_st(void);
+void rp1_dmb_sy(void);
 uint32_t rp1_cycles(void);
+
+#else
+
+/** Read one 32-bit device register. */
+static inline uint32_t rp1_mmio_read32(uintptr_t address)
+{
+    return *(volatile uint32_t *)address;
+}
+
+/** Write one 32-bit device register. */
+static inline void rp1_mmio_write32(uintptr_t address, uint32_t value)
+{
+    *(volatile uint32_t *)address = value;
+}
+
+/** Complete prior stores before executing later instructions. */
+static inline void rp1_dsb_st(void)
+{
+    __asm__ volatile("dsb st" ::: "memory");
+}
+
+/** Complete all prior explicit accesses before executing later instructions. */
+static inline void rp1_dsb_sy(void)
+{
+    __asm__ volatile("dsb sy" ::: "memory");
+}
+
+/** Order prior stores before later stores without requiring completion. */
+static inline void rp1_dmb_st(void)
+{
+    __asm__ volatile("dmb st" ::: "memory");
+}
+
+/** Order explicit accesses across the barrier without requiring completion. */
+static inline void rp1_dmb_sy(void)
+{
+    __asm__ volatile("dmb sy" ::: "memory");
+}
+
+/** Read the hardware PMU cycle counter. */
+static inline uint32_t rp1_cycles(void)
+{
+    uint32_t cycles;
+
+    __asm__ volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(cycles));
+    return cycles;
+}
+
+#endif /* QEMU_SEMIHOSTING */
+
+void rp1_pmu_init(void);
 
 /*
  * Unsigned elapsed subtraction is wrap-safe for protocol deadlines shorter

--- a/linker/slashkit/resources/aved/rp1/src/rp1_loop.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_loop.c
@@ -11,17 +11,16 @@
 #include "rp1_cycles.h"
 #include "rp1_hal.h"
 #include "rp1_pdi.h"
+#include "rp1_scheduler.h"
 #include "rp1_store.h"
 #include <slash/uapi/rp1_protocol.h>
 #include <stdint.h>
-
-static uint32_t g_cq_blocked;
 
 /* -------------------------------------------------------------------------
  * Condition evaluation  (shared with LOOP, COND)
  * ---------------------------------------------------------------------- */
 
-static uint32_t compare(uint32_t sig, uint16_t op, uint32_t val)
+static uint32_t compare(uint32_t sig, uint8_t op, uint32_t val)
 {
     switch (op) {
     case RP1_COP_EQ:     return sig == val;
@@ -35,73 +34,65 @@ static uint32_t compare(uint32_t sig, uint16_t op, uint32_t val)
 }
 
 /* -------------------------------------------------------------------------
- * Completion queue
- * ---------------------------------------------------------------------- */
-
-/*
- * Producer and consumer cursors are monotonic, so unsigned subtraction remains
- * valid across wrap. A full ring backpressures every non-silent side effect;
- * occupancy beyond the ring is corruption, while silent nodes need no slot.
- */
-static int cq_can_write(uint16_t flags)
-{
-    if (flags & RP1_FLAG_SILENT)
-        return 1;
-
-    uint32_t used = g_ctrl->cq_write_idx - g_ctrl->cq_read_idx;
-    if (used > g_ctrl->cq_size) {
-        rp1_latch_error(RP1_ERR_CQ_CORRUPT,
-                        RP1_TERMINAL_ERROR_NODE_NONE,
-                        used, g_ctrl->cq_size);
-        return -1;
-    }
-    return used != g_ctrl->cq_size;
-}
-
-/*
- * Fill the selected slot completely before publishing cq_write_idx. The host
- * advances cq_read_idx only after copying that slot, making the two cursors the
- * ownership handoff for reusable ring storage.
- */
-static int write_cq_entry(uint16_t flags, uint32_t node_index,
-                          uint32_t status, uint32_t error_detail)
-{
-    int available = cq_can_write(flags);
-    if (available <= 0)
-        return available;
-    if (flags & RP1_FLAG_SILENT)
-        return 1;
-
-    uint32_t idx = g_ctrl->cq_write_idx & (g_ctrl->cq_size - 1u);
-    g_cq[idx].node_index   = node_index;
-    g_cq[idx].status       = status;
-    g_cq[idx].error_detail = error_detail;
-    g_cq[idx].timestamp    = rp1_cycles() - g_graph_start_cycles;
-    rp1_barrier();
-    g_ctrl->cq_write_idx++;
-    rp1_barrier();
-    return 1;
-}
-
-static void trace(uint16_t event, uint32_t node_index, uint32_t aux0, uint32_t aux1)
-{
-    if (!g_trace_enable || !g_trace || !g_trace_size)
-        return;
-
-    uint32_t idx = g_ctrl->trace_write_idx % g_trace_size;
-    g_trace[idx].timestamp  = rp1_cycles() - g_graph_start_cycles;
-    g_trace[idx].event      = event;
-    g_trace[idx].node_index = (uint16_t)node_index;
-    g_trace[idx].aux0       = aux0;
-    g_trace[idx].aux1       = aux1;
-    rp1_barrier();
-    g_ctrl->trace_write_idx++;
-    rp1_barrier();
-}
-
-/* -------------------------------------------------------------------------
  * Inflight kernel management
  * ---------------------------------------------------------------------- */
+
+/*
+ * A cached base has had sticky ap_done cleared before its latest launch.
+ * g_inflight supplies the RUNNING state; its completion read clears ap_done
+ * and makes the retained cache entry CLEAN again. The physical design exposes
+ * at most 15 CUs, so the 32-entry inflight bound also bounds this cache.
+ */
+static uint32_t
+    g_clean_cu_bases[RP1_MAX_INFLIGHT] __attribute__((section(".btcm")));
+
+/* Number of valid entries at the front of g_clean_cu_bases. */
+static uint32_t g_clean_cu_count __attribute__((section(".btcm")));
+
+/*
+ * Invalidate the persistent CU state without clearing dead entries. The count
+ * is authoritative, so startup and PDI transitions remain constant-time.
+ */
+void rp1_cu_tracking_reset(void)
+{
+    g_clean_cu_count = 0u;
+}
+
+/*
+ * Return non-zero while the named CU already has a tracked invocation.
+ * Dispatches to one physical control port must serialize even when their graph
+ * barriers are independent.
+ */
+static uint32_t cu_is_inflight(uint32_t base_addr)
+{
+    for (uint32_t i = 0u; i < g_inflight_count; i++) {
+        if (g_inflight[i].base_addr == base_addr)
+            return 1u;
+    }
+    return 0u;
+}
+
+/*
+ * Clear an unrecognized CU's sticky completion before first use. Known CUs
+ * skip both the NoC read and its ordering barrier; the completion read which
+ * removed their preceding inflight entry already performed the clear.
+ *
+ * Cache exhaustion is a safe performance fallback: leave the base untracked
+ * so every later launch repeats the clear instead of assuming clean state.
+ */
+static void prepare_cu_for_launch(uint32_t base_addr)
+{
+    for (uint32_t i = 0u; i < g_clean_cu_count; i++) {
+        if (g_clean_cu_bases[i] == base_addr)
+            return;
+    }
+
+    (void)rp1_mmio_read32(base_addr + 0x00u);
+    rp1_dmb_sy();
+
+    if (g_clean_cu_count < RP1_MAX_INFLIGHT)
+        g_clean_cu_bases[g_clean_cu_count++] = base_addr;
+}
 
 static void add_inflight(const rp1_node_t *node, uint32_t node_index)
 {
@@ -116,7 +107,8 @@ static void add_inflight(const rp1_node_t *node, uint32_t node_index)
     slot->timeout_cycles    = kd->timeout_cycles ?
                               kd->timeout_cycles :
                               RP1_DEFAULT_KERNEL_TIMEOUT_TICKS;
-    slot->infinite = (node->flags & RP1_FLAG_INFINITE) ? 1 : 0;
+    slot->infinite =
+        (rp1_node_get_flags(node) & RP1_FLAG_INFINITE) ? 1 : 0;
     slot->settle_polls = 0;
 }
 
@@ -127,10 +119,21 @@ static void remove_inflight(uint32_t idx)
         g_inflight[idx] = g_inflight[g_inflight_count];
 }
 
-static void set_node_status(uint32_t node_index, uint16_t status)
+static void set_node_status(uint32_t node_index, uint8_t status)
 {
-    g_node_status[node_index] = (uint8_t)status;
-    g_nodes[node_index].status = status;
+    rp1_node_set_status(&g_nodes[node_index], status);
+    if (status != RP1_NODE_PENDING)
+        rp1_scheduler_remove_node(node_index);
+}
+
+/*
+ * Finish one successful node execution. Counts are per execution rather than
+ * per node, so LOOP/RERUN cycles contribute on every pass.
+ */
+static void complete_node(uint32_t node_index)
+{
+    set_node_status(node_index, RP1_NODE_DONE);
+    g_completed_operations++;
 }
 
 /* -------------------------------------------------------------------------
@@ -146,17 +149,17 @@ static void launch_kernel(const rp1_node_t *node)
     const rp1_kernel_arg_t *args =
         (const rp1_kernel_arg_t *)(g_arg_buf + kd->arg_buffer_offset / 4);
 
-    /* HLS ap_done is sticky/clear-on-read. Clear any stale completion from a
-     * previous invocation before writing arguments and pulsing ap_start.
+    /*
+     * HLS ap_done is sticky and clear-on-read. Pay that NoC read once per CU
+     * reset epoch; normal completion polling keeps a reused CU clean.
      */
-    (void)rp1_mmio_read32(kd->kernel_base_addr + 0x00);
-    rp1_barrier();
+    prepare_cu_for_launch(kd->kernel_base_addr);
 
     for (uint16_t i = 0; i < kd->arg_count; i++)
         rp1_mmio_write32(kd->kernel_base_addr + args[i].reg_offset,
                          args[i].value);
 
-    rp1_barrier();
+    rp1_dmb_st();
     rp1_mmio_write32(kd->kernel_base_addr + 0x00, 0x01); /* ap_start */
 }
 
@@ -166,7 +169,7 @@ static void launch_kernel(const rp1_node_t *node)
 
 static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
 {
-    switch (node->opcode) {
+    switch (rp1_node_get_opcode(node)) {
     case RP1_OP_NOP:
         break;
 
@@ -185,13 +188,13 @@ static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
 
     case RP1_OP_SCALAR_WRITE: {
         const rp1_payload_scalar_write_t *p = &node->payload.scalar_write;
-#pragma GCC unroll 6
+#pragma GCC unroll 2
         for (uint32_t w = 0; w < RP1_SCALAR_WRITE_MAX; w++) {
             if (!p->writes[w].addr)
                 break;
             rp1_mmio_write32(p->writes[w].addr, p->writes[w].value);
         }
-        rp1_barrier();
+        rp1_dsb_st();
         break;
     }
 
@@ -205,7 +208,7 @@ static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
     case RP1_OP_SCALAR_COPY: {
         const rp1_payload_scalar_copy_t *p = &node->payload.scalar_copy;
         rp1_mmio_write32(p->dest_addr, g_signals[p->source_slot].value);
-        rp1_barrier();
+        rp1_dsb_st();
         break;
     }
 
@@ -214,10 +217,10 @@ static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
         /* Phase 1: DDR-DDR software memcpy (32-bit addresses only). */
         uint32_t *src = (uint32_t *)(uintptr_t)p->src_addr_lo;
         uint32_t *dst = (uint32_t *)(uintptr_t)p->dst_addr_lo;
-        uint32_t words = p->length / 4;
+        uint32_t words = rp1_dma_get_length(p->length_types) / 4u;
         for (uint32_t w = 0; w < words; w++)
             dst[w] = src[w];
-        rp1_barrier();
+        rp1_dsb_st();
         break;
     }
 
@@ -227,7 +230,7 @@ static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
         uint32_t words = p->length / 4;
         for (uint32_t w = 0; w < words; w++)
             dst[w] = p->pattern;
-        rp1_barrier();
+        rp1_dsb_st();
         break;
     }
 
@@ -240,7 +243,7 @@ static void execute_immediate(const rp1_node_t *node, uint32_t node_index)
  * Packet validation
  * ---------------------------------------------------------------------- */
 
-static uint32_t valid_condition(uint16_t op)
+static uint32_t valid_condition(uint8_t op)
 {
     return op <= RP1_COP_AND_Z;
 }
@@ -248,6 +251,18 @@ static uint32_t valid_condition(uint16_t op)
 static uint32_t valid_signal_slot(uint32_t slot)
 {
     return slot < RP1_MAX_SIGNALS;
+}
+
+/*
+ * Validate one endpoint for the phase-1 software DMA path. Only low-word DDR
+ * addresses are implemented. Word-aligned zero-byte transfers are valid, and
+ * non-empty ranges may reach but must not wrap past the 32-bit address space.
+ */
+static uint32_t valid_phase1_dma_range(uint32_t lo, uint32_t hi,
+                                       uint32_t bytes)
+{
+    return hi == 0u && ((lo | bytes) & 3u) == 0u &&
+           (uint64_t)lo + bytes <= (1ULL << 32);
 }
 
 /*
@@ -263,10 +278,21 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
 
     for (uint32_t i = 0; i < node_count; i++) {
         const rp1_node_t *node = &g_nodes[i];
+        uint16_t opcode = rp1_node_get_opcode(node);
+        uint8_t flags = rp1_node_get_flags(node);
         /*
-         * Phase 1: every opcode shares barrier buckets, so reject an invalid
-         * header before interpreting its payload union.
+         * Phase 1: reject reserved control bits, opcode-specific flag misuse,
+         * and invalid barrier buckets before interpreting the payload union.
          */
+        if ((rp1_node_get_control(node) & RP1_NODE_RESERVED_MASK) != 0u ||
+            (flags & (uint8_t)~RP1_FLAG_INFINITE) != 0u ||
+            ((flags & RP1_FLAG_INFINITE) != 0u &&
+             opcode != RP1_OP_KERNEL_DISPATCH)) {
+            *bad_node = i;
+            *detail = RP1_NODE_BAD_OPERATION;
+            *aux = rp1_node_get_control(node);
+            return -1;
+        }
         if (node->barrier_await_bucket >= RP1_MAX_BUCKETS ||
             node->barrier_set_bucket >= RP1_MAX_BUCKETS) {
             *bad_node = i;
@@ -280,13 +306,39 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
          * Phase 2: validate only the active union member. Simple opcodes have
          * no indexed fields; the remaining cases prove every later dereference.
          */
-        switch (node->opcode) {
+        switch (opcode) {
         case RP1_OP_NOP:
         case RP1_OP_SCALAR_WRITE:
-        case RP1_OP_DMA_COPY:
-        case RP1_OP_DMA_FILL:
+        case RP1_OP_PDI_LOAD:
         case RP1_OP_HALT:
             break;
+        case RP1_OP_DMA_COPY: {
+            const rp1_payload_dma_copy_t *dma = &node->payload.dma_copy;
+            uint32_t packed = dma->length_types;
+            uint32_t length = rp1_dma_get_length(packed);
+            if (rp1_dma_get_src_type(packed) == 0u &&
+                rp1_dma_get_dst_type(packed) == 0u &&
+                valid_phase1_dma_range(
+                    dma->src_addr_lo, dma->src_addr_hi, length) &&
+                valid_phase1_dma_range(
+                    dma->dst_addr_lo, dma->dst_addr_hi, length))
+                break;
+            *bad_node = i;
+            *detail = RP1_NODE_BAD_ARGUMENTS;
+            *aux = packed;
+            return -1;
+        }
+        case RP1_OP_DMA_FILL: {
+            const rp1_payload_dma_fill_t *dma = &node->payload.dma_fill;
+            if (dma->dst_type == 0u &&
+                valid_phase1_dma_range(
+                    dma->dst_addr_lo, dma->dst_addr_hi, dma->length))
+                break;
+            *bad_node = i;
+            *detail = RP1_NODE_BAD_ARGUMENTS;
+            *aux = dma->dst_type;
+            return -1;
+        }
         case RP1_OP_SIGNAL:
             if (!valid_signal_slot(node->payload.signal.target_slot)) {
                 *detail = RP1_NODE_BAD_SIGNAL_SLOT;
@@ -331,6 +383,7 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
             uint32_t bytes = (uint32_t)kd->arg_count *
                              (uint32_t)sizeof(rp1_kernel_arg_t);
             if (kd->kernel_base_addr != 0u &&
+                kd->ctrl_flags == 0u &&
                 (kd->arg_buffer_offset & 7u) == 0u &&
                 kd->arg_buffer_offset <= arg_available &&
                 bytes <= arg_available - kd->arg_buffer_offset)
@@ -340,13 +393,6 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
             *aux = kd->arg_buffer_offset;
             return -1;
         }
-        case RP1_OP_PDI_LOAD:
-            if ((node->flags & RP1_FLAG_SILENT) == 0u)
-                break;
-            *bad_node = i;
-            *detail = RP1_NODE_PDI_WITHOUT_CQ;
-            *aux = 0u;
-            return -1;
         case RP1_OP_LOOP: {
             const rp1_payload_loop_t *loop = &node->payload.loop;
             if (valid_signal_slot(loop->condition_signal) &&
@@ -387,6 +433,8 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
         }
         case RP1_OP_RERUN:
             if (node->payload.rerun.target_node < node_count &&
+                (node->payload.rerun.rerun_flags &
+                 (uint8_t)~RP1_RERUN_CLEAR_STATE) == 0u &&
                 ((node->payload.rerun.rerun_flags &
                   RP1_RERUN_CLEAR_STATE) == 0u ||
                  node->payload.rerun.loop_id < RP1_MAX_LOOPS))
@@ -398,7 +446,7 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
         default:
             *bad_node = i;
             *detail = RP1_NODE_BAD_OPERATION;
-            *aux = node->opcode;
+            *aux = opcode;
             return -1;
         }
     }
@@ -410,12 +458,12 @@ static int validate_nodes(uint32_t node_count, uint32_t *bad_node,
  * ---------------------------------------------------------------------- */
 
 /*
- * Cases are complete, expired, or still pending. A full CQ parks finite work
- * before reading sticky/clear-on-read ap_done, preserving evidence until it
- * can be published; infinite work needs no eventual completion entry.
+ * Cases are complete, expired, or still pending. Every finite timeout is
+ * fatal; the timed-out tracker remains present so quiescence can determine
+ * whether it subsequently finished or requires recovery.
  *
- * Returns 1 for progress, 0 for none, and -1 for a fatal timeout/corruption.
- * PMU elapsed ticks, not scan passes, define every timeout.
+ * Returns 1 for progress, 0 for none, and -1 for a fatal timeout. PMU elapsed
+ * ticks, not scan passes, define every deadline.
  */
 static int check_inflight(void)
 {
@@ -424,27 +472,15 @@ static int check_inflight(void)
 
     while (i < g_inflight_count) {
         rp1_inflight_t *k = &g_inflight[i];
-        uint16_t flags = g_nodes[k->node_index].flags;
-        int cq_available = cq_can_write(flags);
-        if (cq_available < 0)
-            return -1;
-        if (!k->infinite && cq_available == 0) {
-            g_cq_blocked = 1u;
-            i++;
-            continue;
-        }
-
         uint32_t ctrl = rp1_mmio_read32(k->base_addr + 0x00);
 
         if (ctrl & 0x2) { /* ap_done */
             if (!k->infinite) {
-                set_node_status(k->node_index, RP1_NODE_DONE);
-                g_barriers[k->set_bucket] |= k->set_mask;
-                if (write_cq_entry(flags, k->node_index,
-                                   RP1_CQ_OK, 0) < 0)
-                    return -1;
+                complete_node(k->node_index);
+                rp1_scheduler_set_barriers(k->set_bucket, k->set_mask);
             }
-            trace(RP1_TRACE_KERNEL_DONE, k->node_index, k->base_addr, k->infinite);
+            rp1_trace_emit(RP1_TRACE_KERNEL_DONE, k->node_index,
+                           k->base_addr, k->infinite);
             remove_inflight(i);
             made_progress = 1;
             /* don't increment i — slot was replaced by swap */
@@ -452,29 +488,12 @@ static int check_inflight(void)
             uint32_t now = rp1_cycles();
             if (rp1_timeout_elapsed(k->timeout_start,
                                     k->timeout_cycles, now)) {
-                if (cq_available == 0) {
-                    g_cq_blocked = 1u;
-                    i++;
-                    continue;
-                }
                 set_node_status(k->node_index, RP1_NODE_ERROR);
                 rp1_latch_error(RP1_ERR_KERNEL_TIMEOUT, k->node_index,
                                 k->base_addr, k->timeout_cycles);
-                if (write_cq_entry(flags, k->node_index,
-                                   RP1_CQ_TIMEOUT, k->base_addr) < 0)
-                    return -1;
-                trace(RP1_TRACE_KERNEL_TIMEOUT, k->node_index,
-                      k->base_addr, k->timeout_cycles);
-
-                if (flags & RP1_FLAG_HALT_ON_ERROR) {
-                    /* Keep the timed-out kernel tracked for fatal quiesce. */
-                    return -1;
-                }
-
-                /* Non-fatal: set barriers so dependents can proceed. */
-                g_barriers[k->set_bucket] |= k->set_mask;
-                remove_inflight(i);
-                made_progress = 1;
+                rp1_trace_emit(RP1_TRACE_KERNEL_TIMEOUT, k->node_index,
+                               k->base_addr, k->timeout_cycles);
+                return -1;
             } else {
                 i++;
             }
@@ -496,31 +515,29 @@ static int check_inflight(void)
 static int check_waits(uint32_t node_count)
 {
     int made_progress = 0;
+    uint32_t cursor = 0u;
 
-    for (uint32_t i = 0; i < node_count; i++) {
-        if (g_node_status[i] != RP1_NODE_WAITING)
-            continue;
+    while (cursor < node_count) {
+        uint32_t i = cursor;
+        if (rp1_scheduler_enabled()) {
+            if (!rp1_scheduler_next_waiting(cursor, &i) || i >= node_count)
+                break;
+            cursor = i + 1u;
+        } else {
+            cursor++;
+            if (rp1_node_get_status(&g_nodes[i]) != RP1_NODE_WAITING)
+                continue;
+        }
 
         const rp1_node_t *node = &g_nodes[i];
         const rp1_payload_wait_t *w = &node->payload.wait;
-        /*
-         * Reserve CQ capacity before changing WAIT status or barriers; once a
-         * dependent can run, its wake evidence cannot be reconstructed.
-         */
-        int cq_available = cq_can_write(node->flags);
-        if (cq_available < 0)
-            return -1;
-        if (cq_available == 0) {
-            g_cq_blocked = 1u;
-            continue;
-        }
         uint32_t sig_val = g_signals[w->condition_signal].value;
         if (compare(sig_val, w->condition_op, w->condition_value)) {
-            set_node_status(i, RP1_NODE_DONE);
-            g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-            if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                return -1;
-            trace(RP1_TRACE_WAIT_WAKE, i, w->condition_signal, sig_val);
+            complete_node(i);
+            rp1_scheduler_set_barriers(
+                node->barrier_set_bucket, node->barrier_set_mask);
+            rp1_trace_emit(RP1_TRACE_WAIT_WAKE, i,
+                           w->condition_signal, sig_val);
             made_progress = 1;
         }
     }
@@ -532,8 +549,8 @@ static int check_waits(uint32_t node_count)
  * Node activation (one full scan pass)
  *
  * Eligible packets split into asynchronous kernel work, synchronous PDI work,
- * scanner control, and immediate operations. CQ capacity is checked before
- * side effects because non-silent completion evidence cannot be recreated.
+ * scanner control, and immediate operations. Any error returns immediately;
+ * the caller then quiesces work already launched by this graph.
  *
  * Returns 1 for progress, 0 for none, -1 for error, and -2 for HALT.
  * ---------------------------------------------------------------------- */
@@ -541,73 +558,81 @@ static int check_waits(uint32_t node_count)
 static int activate_nodes(uint32_t node_count)
 {
     int made_progress = 0;
+    uint32_t scan_index = 0u;
 
-    for (uint32_t i = 0; i < node_count; i++) {
-        if (g_node_status[i] != RP1_NODE_PENDING)
+    while (1) {
+        uint32_t i;
+        if (rp1_scheduler_enabled()) {
+            if (!rp1_scheduler_pop_ready(&i))
+                break;
+        } else {
+            if (scan_index >= node_count)
+                break;
+            i = scan_index++;
+        }
+        if (rp1_node_get_status(&g_nodes[i]) != RP1_NODE_PENDING)
             continue;
 
         const rp1_node_t *node = &g_nodes[i];
+        uint8_t opcode = rp1_node_get_opcode(node);
+        uint8_t flags = rp1_node_get_flags(node);
 
         if ((g_barriers[node->barrier_await_bucket] & node->barrier_await_mask)
-                != node->barrier_await_mask)
+                != node->barrier_await_mask) {
+            rp1_scheduler_rearm_node(i);
             continue;
+        }
 
-        int cq_available = cq_can_write(node->flags);
-        if (cq_available < 0)
-            return -1;
-        if (cq_available == 0) {
-            g_cq_blocked = 1u;
+        /*
+         * Resource readiness is separate from graph barriers. Skip before
+         * publishing activation so a busy CU cannot produce duplicate trace
+         * events or receive a second ap_start.
+         */
+        if (opcode == RP1_OP_KERNEL_DISPATCH &&
+            cu_is_inflight(node->payload.kernel_dispatch.kernel_base_addr)) {
+            rp1_scheduler_defer_ready(i);
             continue;
         }
 
         g_ctrl->rp1_current_node = i;
-        trace(RP1_TRACE_NODE_ACTIVATE, i, node->opcode, node->flags);
+        g_operation_started = 1u;
+        rp1_trace_emit(RP1_TRACE_NODE_ACTIVATE, i,
+                       opcode, flags);
 
         /*
          * Phase 1: launch asynchronous fabric work or perform the serialized
          * platform-image transition; both may establish later dispatch state.
          */
-        switch (node->opcode) {
+        switch (opcode) {
 
         case RP1_OP_KERNEL_DISPATCH: {
             /* Expected-image guard: a dispatch that names an image (non-zero)
              * must match the image last installed by PDI_LOAD. Fail fast
              * instead of poking an absent kernel and hanging. */
             const rp1_payload_kernel_dispatch_t *kd = &node->payload.kernel_dispatch;
-            if (kd->expected_image_id != 0 &&
-                kd->expected_image_id != g_active_image_id) {
+            if (kd->expected_image_id != 0u &&
+                (g_active_image_state != RP1_IMAGE_STATE_KNOWN ||
+                 kd->expected_image_id != g_active_image_id)) {
                 set_node_status(i, RP1_NODE_ERROR);
                 rp1_latch_error(RP1_ERR_IMAGE_MISMATCH, i,
                                 kd->expected_image_id, g_active_image_id);
-                if (write_cq_entry(node->flags, i, RP1_CQ_ERROR,
-                                   g_active_image_id) < 0)
-                    return -1;
-                trace(RP1_TRACE_IMAGE_MISMATCH, i,
-                      kd->expected_image_id, g_active_image_id);
-                if (node->flags & RP1_FLAG_HALT_ON_ERROR)
-                    return -1;
-                /* Non-fatal: set barriers so dependents can proceed. */
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-                made_progress = 1;
-                break;
+                rp1_trace_emit(RP1_TRACE_IMAGE_MISMATCH, i,
+                               kd->expected_image_id, g_active_image_id);
+                return -1;
             }
             if (g_inflight_count >= RP1_MAX_INFLIGHT) {
                 set_node_status(i, RP1_NODE_ERROR);
                 rp1_latch_error(RP1_ERR_INFLIGHT_FULL, i,
                                 g_inflight_count, RP1_MAX_INFLIGHT);
-                if (write_cq_entry(node->flags, i, RP1_CQ_ERROR,
-                                   g_inflight_count) < 0)
-                    return -1;
                 return -1;
             }
             launch_kernel(node);
-            trace(RP1_TRACE_KERNEL_LAUNCH, i,
-                  kd->kernel_base_addr, kd->arg_count);
-            if (node->flags & RP1_FLAG_INFINITE) {
-                set_node_status(i, RP1_NODE_DONE);
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-                if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                    return -1;
+            rp1_trace_emit(RP1_TRACE_KERNEL_LAUNCH, i,
+                           kd->kernel_base_addr, kd->arg_count);
+            if (flags & RP1_FLAG_INFINITE) {
+                complete_node(i);
+                rp1_scheduler_set_barriers(
+                    node->barrier_set_bucket, node->barrier_set_mask);
             } else {
                 set_node_status(i, RP1_NODE_DISPATCHED);
             }
@@ -618,41 +643,51 @@ static int activate_nodes(uint32_t node_count)
 
         case RP1_OP_PDI_LOAD: {
             const rp1_payload_pdi_load_t *p = &node->payload.pdi_load;
+            /*
+             * PLM may alter or partially alter the fabric on every attempt.
+             * Forget all control-port state before issuing the request.
+             */
+            rp1_cu_tracking_reset();
             rp1_pdi_result_t result =
                 rp1_pdi_load(p->pdi_addr_lo, p->pdi_addr_hi,
                              p->timeout_cycles);
-            trace(RP1_TRACE_PDI_LOAD, i, result.status, result.detail);
+            rp1_trace_emit(RP1_TRACE_PDI_LOAD, i,
+                           result.status, result.detail);
 
             if (result.outcome == RP1_PDI_RESULT_OK) {
-                /* Record the now-active image for the dispatch guard. */
+                /* A successful named image restores a previously unknown state. */
                 g_active_image_id = p->image_id;
-                set_node_status(i, RP1_NODE_DONE);
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-                if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                    return -1;
+                g_active_image_state = p->image_id != 0u ?
+                                       RP1_IMAGE_STATE_KNOWN :
+                                       RP1_IMAGE_STATE_NONE;
+                complete_node(i);
+                rp1_scheduler_set_barriers(
+                    node->barrier_set_bucket, node->barrier_set_mask);
             } else {
+                /*
+                 * A timed-out or rejected reconfiguration can leave physical
+                 * state partially changed. Forget the previous image before
+                 * entering fatal quiescence.
+                 */
+                g_active_image_id = 0u;
+                g_active_image_state = RP1_IMAGE_STATE_UNKNOWN;
                 set_node_status(i, RP1_NODE_ERROR);
                 if (result.outcome == RP1_PDI_RESULT_TIMEOUT) {
                     uint32_t timeout = p->timeout_cycles ?
                                        p->timeout_cycles :
                                        RP1_DEFAULT_PDI_TIMEOUT_TICKS;
+                    /*
+                     * The observation bit can remain asserted after timeout,
+                     * so a delayed PLM response may still reconfigure the
+                     * device. Only reset can establish a safe image state.
+                     */
+                    rp1_mark_recovery_required();
                     rp1_latch_error(RP1_ERR_PDI_TIMEOUT, i, 0u, timeout);
-                    if (write_cq_entry(node->flags, i,
-                                       RP1_CQ_TIMEOUT, 0) < 0)
-                        return -1;
                 } else {
                     rp1_latch_error(RP1_ERR_PDI_FAILED, i,
                                     result.status, result.detail);
-                    if (write_cq_entry(node->flags, i, RP1_CQ_ERROR,
-                                       result.status) < 0)
-                        return -1;
                 }
-
-                if (node->flags & RP1_FLAG_HALT_ON_ERROR)
-                    return -1;
-
-                /* Non-fatal: set barriers so dependents can proceed. */
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
+                return -1;
             }
             made_progress = 1;
             break;
@@ -674,21 +709,24 @@ static int activate_nodes(uint32_t node_count)
                 exit_loop = 1;
             if (compare(sig_val, lp->condition_op, lp->condition_value))
                 exit_loop = 1;
-            trace(RP1_TRACE_LOOP_ITER, i, lp->loop_id,
-                  (g_loop_iters[lp->loop_id] << 1) | (uint32_t)exit_loop);
+            rp1_trace_emit(
+                RP1_TRACE_LOOP_ITER, i, lp->loop_id,
+                (g_loop_iters[lp->loop_id] << 1) |
+                    (uint32_t)exit_loop);
 
             if (exit_loop) {
-                set_node_status(i, RP1_NODE_DONE);
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-                if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                    return -1;
+                complete_node(i);
+                rp1_scheduler_set_barriers(
+                    node->barrier_set_bucket, node->barrier_set_mask);
             } else {
                 for (uint8_t b = lp->bucket_clear_start;
                      b <= lp->bucket_clear_end; b++)
-                    g_barriers[b] = 0;
-                for (uint32_t n = lp->body_start; n <= lp->body_end; n++)
+                    rp1_scheduler_clear_barriers(b, UINT32_MAX);
+                for (uint32_t n = lp->body_start; n <= lp->body_end; n++) {
                     set_node_status(n, RP1_NODE_PENDING);
-                set_node_status(i, RP1_NODE_DONE);
+                    rp1_scheduler_rearm_node(n);
+                }
+                complete_node(i);
                 /* Do NOT set barrier_set — body + RERUN must fire first. */
             }
             made_progress = 1;
@@ -700,22 +738,25 @@ static int activate_nodes(uint32_t node_count)
             uint32_t sig_val = g_signals[cd->condition_signal].value;
             uint32_t cond_met = compare(sig_val, cd->condition_op, cd->condition_value);
 
-            trace(RP1_TRACE_COND_EVAL, i, cd->condition_signal, cond_met);
+            rp1_trace_emit(RP1_TRACE_COND_EVAL, i,
+                           cd->condition_signal, cond_met);
             if (cond_met) {
                 /* Condition met — set done barriers. */
-                g_barriers[cd->done_bucket] |= cd->done_mask;
+                rp1_scheduler_set_barriers(
+                    cd->done_bucket, cd->done_mask);
             } else {
                 /* Condition not met — clear body for execution. */
                 for (uint8_t b = cd->bucket_clear_start;
                      b <= cd->bucket_clear_end; b++)
-                    g_barriers[b] = 0;
-                for (uint32_t n = cd->body_start; n <= cd->body_end; n++)
+                    rp1_scheduler_clear_barriers(b, UINT32_MAX);
+                for (uint32_t n = cd->body_start; n <= cd->body_end; n++) {
                     set_node_status(n, RP1_NODE_PENDING);
+                    rp1_scheduler_rearm_node(n);
+                }
             }
-            set_node_status(i, RP1_NODE_DONE);
-            g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-            if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                return -1;
+            complete_node(i);
+            rp1_scheduler_set_barriers(
+                node->barrier_set_bucket, node->barrier_set_mask);
             made_progress = 1;
             break;
         }
@@ -723,12 +764,12 @@ static int activate_nodes(uint32_t node_count)
         case RP1_OP_RERUN: {
             const rp1_payload_rerun_t *rr = &node->payload.rerun;
             set_node_status(rr->target_node, RP1_NODE_PENDING);
+            rp1_scheduler_rearm_node(rr->target_node);
             if (rr->rerun_flags & RP1_RERUN_CLEAR_STATE)
                 g_loop_iters[rr->loop_id] = 0;
-            set_node_status(i, RP1_NODE_DONE);
-            g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-            if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                return -1;
+            complete_node(i);
+            rp1_scheduler_set_barriers(
+                node->barrier_set_bucket, node->barrier_set_mask);
             made_progress = 1;
             break;
         }
@@ -737,49 +778,50 @@ static int activate_nodes(uint32_t node_count)
             const rp1_payload_wait_t *w = &node->payload.wait;
             if (compare(g_signals[w->condition_signal].value,
                         w->condition_op, w->condition_value)) {
-                set_node_status(i, RP1_NODE_DONE);
-                g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-                if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                    return -1;
+                complete_node(i);
+                rp1_scheduler_set_barriers(
+                    node->barrier_set_bucket, node->barrier_set_mask);
                 made_progress = 1;
             } else {
                 /* Park the node; check_waits() re-polls the slot each pass. */
                 set_node_status(i, RP1_NODE_WAITING);
-                trace(RP1_TRACE_WAIT_PARK, i,
-                      w->condition_signal, w->condition_value);
+                rp1_scheduler_park_wait(i);
+                rp1_trace_emit(RP1_TRACE_WAIT_PARK, i,
+                               w->condition_signal,
+                               w->condition_value);
             }
             break;
         }
 
         case RP1_OP_HALT:
-            set_node_status(i, RP1_NODE_DONE);
-            if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                return -1;
+            complete_node(i);
+            g_ctrl->terminal_error_node = i;
+            g_terminal_opcode = RP1_OP_HALT;
             return -2;
 
         /*
          * Phase 3: remaining packets complete synchronously, so side effects,
-         * status, barriers, and CQ publication all happen in this scan pass.
+         * status, and barriers all complete in this scan pass.
          */
         default: /* NOP, SIGNAL, SCALAR_*, DMA_* */
             execute_immediate(node, i);
-            set_node_status(i, RP1_NODE_DONE);
-            g_barriers[node->barrier_set_bucket] |= node->barrier_set_mask;
-            if (write_cq_entry(node->flags, i, RP1_CQ_OK, 0) < 0)
-                return -1;
+            complete_node(i);
+            rp1_scheduler_set_barriers(
+                node->barrier_set_bucket, node->barrier_set_mask);
             made_progress = 1;
             break;
         }
     }
 
+    rp1_scheduler_restore_deferred();
     return made_progress;
 }
 
 /*
  * Fatal quiescence schedules nothing new, then classifies tracked work:
- * completed finite kernels retain CQ evidence; pending finite kernels are
- * polled to their deadline; infinite or expired work requires device recovery.
- * CQ-full work waits for host draining, and no completion releases barriers.
+ * completed finite kernels count as done; pending finite kernels are polled to
+ * their deadline; infinite or expired work requires recovery. No completion
+ * releases barriers because activation has already stopped.
  */
 #ifdef QEMU_SEMIHOSTING
 static void quiesce_inflight(const rp1_hooks_t *hooks)
@@ -792,36 +834,24 @@ static void quiesce_inflight(void)
 
         while (i < g_inflight_count) {
             rp1_inflight_t *kernel = &g_inflight[i];
-            uint16_t flags = g_nodes[kernel->node_index].flags;
 
             if (kernel->infinite) {
+                g_quiesce_infinite++;
                 rp1_mark_recovery_required();
                 remove_inflight(i);
-                continue;
-            }
-
-            int available = cq_can_write(flags);
-            if (available < 0) {
-                rp1_mark_recovery_required();
-                remove_inflight(i);
-                continue;
-            }
-            if (available == 0) {
-                i++;
                 continue;
             }
 
             uint32_t control =
                 rp1_mmio_read32(kernel->base_addr + 0x00u);
             if ((control & 0x2u) != 0u) {
-                if (g_node_status[kernel->node_index] != RP1_NODE_ERROR) {
-                    set_node_status(kernel->node_index, RP1_NODE_DONE);
-                    if (write_cq_entry(flags, kernel->node_index,
-                                       RP1_CQ_OK, 0u) < 0)
-                        rp1_mark_recovery_required();
-                }
-                trace(RP1_TRACE_KERNEL_DONE, kernel->node_index,
-                      kernel->base_addr, 0u);
+                if (rp1_node_get_status(&g_nodes[kernel->node_index]) !=
+                    RP1_NODE_ERROR)
+                    complete_node(kernel->node_index);
+                g_quiesce_finite_done++;
+                rp1_trace_emit(RP1_TRACE_KERNEL_DONE,
+                               kernel->node_index,
+                               kernel->base_addr, 0u);
                 remove_inflight(i);
                 continue;
             }
@@ -829,13 +859,10 @@ static void quiesce_inflight(void)
             if (rp1_timeout_elapsed(kernel->timeout_start,
                                     kernel->timeout_cycles,
                                     rp1_cycles())) {
-                if (g_node_status[kernel->node_index] != RP1_NODE_ERROR) {
+                if (rp1_node_get_status(&g_nodes[kernel->node_index]) !=
+                    RP1_NODE_ERROR)
                     set_node_status(kernel->node_index, RP1_NODE_ERROR);
-                    if (write_cq_entry(flags, kernel->node_index,
-                                       RP1_CQ_TIMEOUT,
-                                       kernel->base_addr) < 0)
-                        rp1_mark_recovery_required();
-                }
+                g_quiesce_finite_timeout++;
                 rp1_mark_recovery_required();
                 remove_inflight(i);
                 continue;
@@ -861,36 +888,33 @@ int rp1_loop(const rp1_hooks_t *hooks)
 int rp1_loop(void)
 #endif
 {
-    uint32_t node_count = g_ctrl->node_count;
+    uint32_t node_count = g_node_count;
     uint32_t bad_node = RP1_TERMINAL_ERROR_NODE_NONE;
     uint32_t detail = 0u;
     uint32_t aux = 0u;
 
     /*
      * Validation is an all-or-nothing phase before activation. Invalid packets
-     * publish one forced CQ error when cursor state is usable; a merely full
-     * ring waits for space instead of dropping node-level evidence.
+     * latch the first error and return before any node can affect hardware.
      */
     if (validate_nodes(node_count, &bad_node, &detail, &aux) != 0) {
         rp1_latch_error(RP1_ERR_INVALID_NODE, bad_node, detail, aux);
         set_node_status(bad_node, RP1_NODE_ERROR);
-        while (write_cq_entry(0u, bad_node,
-                              RP1_CQ_ERROR, detail) == 0) {
-#ifdef QEMU_SEMIHOSTING
-            if (hooks && hooks->on_scan_pass)
-                hooks->on_scan_pass();
-#endif
-            g_ctrl->heartbeat++;
-        }
         return -1;
     }
 
+    /*
+     * Sparse graphs use a reverse barrier index and ready bitset. Dense graphs
+     * above the local ATCM ceiling retain the scanner without changing ABI or
+     * execution semantics.
+     */
+    (void)rp1_scheduler_build(node_count);
+
     while (1) {
-        g_cq_blocked = 0u;
         /*
          * Each pass activates ready nodes, harvests asynchronous kernels, then
          * wakes parked waits. Any fatal phase quiesces tracked work before
-         * returning; CQ backpressure alone always retries.
+         * returning.
          */
         int activated = activate_nodes(node_count);
         if (activated < 0) {
@@ -931,14 +955,13 @@ int rp1_loop(void)
             hooks->on_scan_pass();
 #endif
 
-        if (!activated && !inflight_progress && !wait_progress &&
-            !g_cq_blocked) {
+        if (!activated && !inflight_progress && !wait_progress) {
             /* No scan progress — keep looping while kernels are in flight or a
              * WAIT is still gated on a signal a peer/host may yet raise. */
             uint32_t has_dispatched = 0;
             uint32_t has_waiting = 0;
             for (uint32_t i = 0; i < node_count; i++) {
-                uint8_t st = g_node_status[i];
+                uint8_t st = rp1_node_get_status(&g_nodes[i]);
                 if (st == RP1_NODE_DISPATCHED) has_dispatched = 1;
                 else if (st == RP1_NODE_WAITING) has_waiting = 1;
             }

--- a/linker/slashkit/resources/aved/rp1/src/rp1_loop.h
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_loop.h
@@ -9,9 +9,15 @@
 #define RP1_LOOP_H
 
 /*
+ * Forget which compute units have had sticky ap_done cleared. Firmware startup
+ * and every partial-reconfiguration attempt call this before later dispatches.
+ */
+void rp1_cu_tracking_reset(void);
+
+/*
  * A scanner pass activates barrier-ready nodes, polls inflight kernels, then
  * revisits parked WAITs. It repeats while asynchronous or externally signalled
- * work can progress; fatal exits first quiesce all tracked finite kernels.
+ * work can progress; fatal and HALT exits first classify all tracked work.
  */
 #ifdef QEMU_SEMIHOSTING
 

--- a/linker/slashkit/resources/aved/rp1/src/rp1_lscript.ld
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_lscript.ld
@@ -36,6 +36,21 @@ SECTIONS
         *(.rodata.*)
     } > r5_1_atcm
 
+    /*
+     * Writable scheduler adjacency storage uses otherwise idle ATCM capacity.
+     * It is initialized from the accepted BTCM node snapshot before execution.
+     */
+    .atcm_data (NOLOAD) : {
+        . = ALIGN(4);
+        __atcm_data_start = .;
+        *(.atcm_data)
+        . = ALIGN(4);
+        __atcm_data_end = .;
+    } > r5_1_atcm
+
+    ASSERT(__atcm_data_end <= ORIGIN(r5_1_atcm) + LENGTH(r5_1_atcm),
+           "RP1 code and scheduler index exceed 64 KB ATCM")
+
     .data : {
         __data_start = .;
         *(.data)
@@ -43,12 +58,14 @@ SECTIONS
         __data_end = .;
     } > r5_1_btcm
 
-    /* Hot BTCM data: barriers, node status, loop counters, inflight table.
-     * Explicitly placed before BSS so we know where they land. */
+    /* Hot BTCM data: node snapshot, barriers, loop counters, inflight table.
+     * Explicitly placed before BSS so the complete footprint is checkable. */
     .btcm (NOLOAD) : {
         . = ALIGN(4);
+        __btcm_snapshot_start = .;
         *(.btcm)
         . = ALIGN(4);
+        __btcm_snapshot_end = .;
     } > r5_1_btcm
 
     .bss (NOLOAD) : {
@@ -68,6 +85,9 @@ SECTIONS
         . = ALIGN(16);
         __stack_top = .;
     } > r5_1_btcm
+
+    ASSERT(__stack_top <= ORIGIN(r5_1_btcm) + LENGTH(r5_1_btcm),
+           "RP1 BTCM data and stack exceed 64 KB")
 
     /* BAR-visible shared DDR region for control/status structures. */
     .rp1_shared (NOLOAD) : {

--- a/linker/slashkit/resources/aved/rp1/src/rp1_pdi.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_pdi.c
@@ -40,10 +40,10 @@ rp1_pdi_result_t rp1_pdi_load(uint32_t addr_lo, uint32_t addr_hi,
     rp1_mmio_write32(RP1_PDI_IPI_REQUEST_BASE + 4u, RP1_PDI_SRC_DDR);
     rp1_mmio_write32(RP1_PDI_IPI_REQUEST_BASE + 8u, addr_hi);
     rp1_mmio_write32(RP1_PDI_IPI_REQUEST_BASE + 12u, addr_lo);
-    rp1_barrier();
+    rp1_dmb_st();
 
     rp1_mmio_write32(RP1_PDI_IPI_TRIGGER_REG, RP1_PDI_IPI_TARGET_MASK);
-    rp1_barrier();
+    rp1_dsb_st();
 
     /*
      * Phase 2: the target observation bit owns the request until it clears.
@@ -57,11 +57,11 @@ rp1_pdi_result_t rp1_pdi_load(uint32_t addr_lo, uint32_t addr_hi,
         if (rp1_timeout_elapsed(start, timeout, rp1_cycles()))
             return result;
     }
-    rp1_barrier();
+    rp1_dmb_sy();
 
     /*
      * Phase 3: acknowledgement releases both unsigned response words. Preserve
-     * them verbatim so CQ and terminal diagnostics retain PLM-specific detail.
+     * them verbatim so terminal diagnostics retain PLM-specific detail.
      */
     result.status = rp1_mmio_read32(RP1_PDI_IPI_RESPONSE_BASE + 0u);
     result.detail = rp1_mmio_read32(RP1_PDI_IPI_RESPONSE_BASE + 4u);

--- a/linker/slashkit/resources/aved/rp1/src/rp1_pdi.h
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_pdi.h
@@ -22,7 +22,7 @@ typedef enum {
 
 /*
  * outcome separates transport timeout from a completed PLM rejection.
- * status/detail remain unsigned and unmodified for CQ and terminal evidence.
+ * status/detail remain unsigned and unmodified for terminal evidence.
  */
 typedef struct {
     rp1_pdi_outcome_t outcome;

--- a/linker/slashkit/resources/aved/rp1/src/rp1_run.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_run.c
@@ -15,20 +15,108 @@
 #include <slash/uapi/rp1_protocol.h>
 #include <stdint.h>
 
-static void trace(uint16_t event, uint32_t node_index, uint32_t aux0, uint32_t aux1)
+/* Return non-zero when a successful graph leaves an infinite kernel running. */
+static uint32_t has_infinite_work(void)
 {
-    if (!g_trace_enable || !g_trace || !g_trace_size)
-        return;
+    for (uint32_t i = 0u; i < g_inflight_count; i++) {
+        if (g_inflight[i].infinite)
+            return 1u;
+    }
+    return 0u;
+}
 
-    uint32_t idx = g_ctrl->trace_write_idx % g_trace_size;
-    g_trace[idx].timestamp  = rp1_cycles() - g_graph_start_cycles;
-    g_trace[idx].event      = event;
-    g_trace[idx].node_index = (uint16_t)node_index;
-    g_trace[idx].aux0       = aux0;
-    g_trace[idx].aux1       = aux1;
-    rp1_barrier();
-    g_ctrl->trace_write_idx++;
-    rp1_barrier();
+/*
+ * Report nodes never reached before terminal publication. A configuration
+ * failure cannot safely inspect node storage, but any submitted node is then
+ * necessarily unreached.
+ */
+static uint32_t has_unreached_nodes(uint32_t node_count, int store_ready)
+{
+    if (!store_ready)
+        return node_count != 0u;
+
+    for (uint32_t i = 0u; i < node_count; i++) {
+        uint8_t status = rp1_node_get_status(&g_nodes[i]);
+        if (status == RP1_NODE_PENDING ||
+            status == RP1_NODE_DISPATCHED ||
+            status == RP1_NODE_WAITING)
+            return 1u;
+    }
+    return 0u;
+}
+
+/* Initialize every result word while its commit magic is invalid. */
+static void initialize_result(void)
+{
+    g_ctrl->result.magic = 0u;
+    g_ctrl->result.graph_seq = 0u;
+    g_ctrl->result.outcome = RP1_GRAPH_RESULT_NONE;
+    g_ctrl->result.flags = 0u;
+    g_ctrl->result.error_code = 0u;
+    g_ctrl->result.terminal_node = RP1_TERMINAL_ERROR_NODE_NONE;
+    g_ctrl->result.terminal_opcode = RP1_TERMINAL_OPCODE_NONE;
+    g_ctrl->result.error_detail = 0u;
+    g_ctrl->result.error_aux = 0u;
+    g_ctrl->result.active_image_id = 0u;
+    g_ctrl->result.image_state = RP1_IMAGE_STATE_NONE;
+    g_ctrl->result.completed_operations = 0u;
+    g_ctrl->result.graph_elapsed_ticks = 0u;
+    g_ctrl->result.publish_elapsed_ticks = 0u;
+    g_ctrl->result.trace_write_idx = 0u;
+    g_ctrl->result.quiescence = 0u;
+}
+
+/*
+ * Fill the uncommitted graph result after trace finalization. The caller
+ * publishes magic only after this function returns and a barrier completes.
+ */
+static void populate_result(uint32_t accepted_seq, int result,
+                            int store_ready, uint32_t node_count,
+                            uint32_t graph_elapsed)
+{
+    uint32_t outcome = result == -1 ? RP1_GRAPH_RESULT_FAILED :
+                       result == -2 ? RP1_GRAPH_RESULT_HALTED :
+                                      RP1_GRAPH_RESULT_SUCCESS;
+    uint32_t flags = 0u;
+    uint32_t trace_write = 0u;
+
+    if (g_recovery_required)
+        flags |= RP1_RESULT_RECOVERY_REQUIRED;
+    if (outcome != RP1_GRAPH_RESULT_SUCCESS && g_operation_started)
+        flags |= RP1_RESULT_EFFECTS_MAY_BE_PARTIAL;
+    if (g_quiesce_infinite != 0u || has_infinite_work())
+        flags |= RP1_RESULT_INFINITE_WORK_REMAINS;
+    if (store_ready && g_trace_enable) {
+        flags |= RP1_RESULT_TRACE_ENABLED;
+        trace_write = g_ctrl->trace_write_idx;
+        if (trace_write > g_trace_size)
+            flags |= RP1_RESULT_TRACE_OVERFLOW;
+    }
+    if (has_unreached_nodes(node_count, store_ready))
+        flags |= RP1_RESULT_UNREACHED_NODES;
+
+    g_ctrl->result.graph_seq = accepted_seq;
+    g_ctrl->result.outcome = outcome;
+    g_ctrl->result.flags = flags;
+    g_ctrl->result.error_code = g_ctrl->rp1_error_code;
+    g_ctrl->result.terminal_node = g_ctrl->terminal_error_node;
+    g_ctrl->result.terminal_opcode = g_terminal_opcode;
+    g_ctrl->result.error_detail = g_ctrl->terminal_error_detail;
+    g_ctrl->result.error_aux = g_ctrl->terminal_error_aux;
+    g_ctrl->result.active_image_id =
+        g_active_image_state == RP1_IMAGE_STATE_KNOWN ?
+        g_active_image_id : 0u;
+    g_ctrl->result.image_state = g_active_image_state;
+    g_ctrl->result.completed_operations = g_completed_operations;
+    g_ctrl->result.graph_elapsed_ticks = graph_elapsed;
+    g_ctrl->result.trace_write_idx = trace_write;
+    g_ctrl->result.quiescence =
+        RP1_QUIESCE_PACK(g_quiesce_finite_done,
+                         g_quiesce_finite_timeout,
+                         g_quiesce_infinite);
+    /* This is the final payload word sampled before the commit barrier. */
+    g_ctrl->result.publish_elapsed_ticks =
+        rp1_cycles() - g_graph_start_cycles;
 }
 
 #ifdef QEMU_SEMIHOSTING
@@ -53,14 +141,26 @@ int rp1_run(void)
     g_ctrl->version               = RP1_PROTOCOL_VERSION;
     g_ctrl->capabilities          = RP1_REQUIRED_CAPABILITIES;
     g_ctrl->pdi_ipi_platform_id   = RP1_PLATFORM_ID;
+    /* BTCM is NOLOAD, so establish reset-only persistent state explicitly. */
+    g_active_image_id             = 0u;
+    g_active_image_state          = RP1_IMAGE_STATE_NONE;
+    rp1_cu_tracking_reset();
     rp1_clear_error_latch();
+    /*
+     * Firmware owns the doorbell only while magic is invalid. Reset both
+     * sequence words to the same idle baseline before advertising readiness,
+     * so a graph left in DDR by an earlier firmware instance cannot replay.
+     */
+    g_ctrl->graph_seq             = 0;
     g_ctrl->graph_done_seq        = 0;
-    g_ctrl->cq_write_idx          = 0;
+    g_ctrl->_reserved_cq_write_idx = 0u;
+    g_ctrl->_reserved_cq_read_idx = 0u;
     g_ctrl->heartbeat             = 0;
+    initialize_result();
     g_ctrl->rp1_state             = RP1_STATE_READY;
-    rp1_barrier();
+    rp1_dmb_st();
     g_ctrl->magic = RP1_CTRL_MAGIC;
-    rp1_barrier();
+    rp1_dsb_st();
 
     /*
      * The outer loop has three cases: terminal firmware remains quiescent,
@@ -93,6 +193,7 @@ int rp1_run(void)
         }
 
         uint32_t accepted_seq = g_ctrl->graph_seq;
+        uint32_t submitted_node_count = g_ctrl->node_count;
         uint32_t config_detail = 0u;
         uint32_t config_aux = 0u;
         int store_ready = 0;
@@ -101,10 +202,14 @@ int rp1_run(void)
          * Phase 1: latch the accepted sequence, enter RUNNING, then validate
          * every host-owned range before resolving or dereferencing DDR pointers.
          */
+        g_ctrl->result.magic = 0u;
+        rp1_dmb_st();
         rp1_clear_error_latch();
+        rp1_store_reset_graph();
         g_ctrl->rp1_current_node = RP1_TERMINAL_ERROR_NODE_NONE;
         g_ctrl->rp1_state = RP1_STATE_RUNNING;
-        rp1_barrier();
+        rp1_dsb_st();
+        g_graph_start_cycles = rp1_cycles();
         if (rp1_store_init(&config_detail, &config_aux) != 0) {
             rp1_latch_error(RP1_ERR_INVALID_CONFIG,
                             RP1_TERMINAL_ERROR_NODE_NONE,
@@ -112,10 +217,9 @@ int rp1_run(void)
         } else {
             store_ready = 1;
         }
-        g_graph_start_cycles = rp1_cycles();
         if (store_ready)
-            trace(RP1_TRACE_GRAPH_START, 0xFFFFu,
-                  accepted_seq, g_ctrl->node_count);
+            rp1_trace_emit(RP1_TRACE_GRAPH_START, 0xFFFFu,
+                           accepted_seq, g_node_count);
 
         /*
          * Phase 2: run only a fully initialized store. Configuration failure
@@ -132,9 +236,20 @@ int rp1_run(void)
 #endif
         }
 
-        if (store_ready)
-            trace(RP1_TRACE_GRAPH_DONE, 0xFFFFu,
-                  (uint32_t)result, accepted_seq);
+        uint32_t graph_elapsed;
+        if (store_ready) {
+            rp1_trace_emit(RP1_TRACE_GRAPH_DONE, 0xFFFFu,
+                           (uint32_t)result, accepted_seq);
+            graph_elapsed = rp1_cycles() - g_graph_start_cycles;
+            /*
+             * Publish the final partial BTCM page after graph work ends.
+             * Periodic flushes are measured by FLUSH_START/END; this terminal
+             * drain intentionally adds no recursive marker pair.
+             */
+            rp1_trace_flush_final();
+        } else {
+            graph_elapsed = rp1_cycles() - g_graph_start_cycles;
+        }
 
         /*
          * Phase 3: classify scanner completion without clearing its first-error
@@ -149,15 +264,20 @@ int rp1_run(void)
             terminal_state = RP1_STATE_READY;
 
         /*
-         * Publish CQ, trace, and the error latch before terminal state; publish
-         * state before graph_done_seq. Exact sequence completion is therefore
-         * the host's release point for every result belonging to this graph.
+         * Commit the complete result before terminal state, then publish state
+         * before graph_done_seq. Exact sequence completion is the host's
+         * release point for the committed sequence-tagged result.
          */
-        rp1_barrier();
+        populate_result(accepted_seq, result, store_ready,
+                        store_ready ? g_node_count : submitted_node_count,
+                        graph_elapsed);
+        rp1_dmb_st();
+        g_ctrl->result.magic = RP1_GRAPH_RESULT_MAGIC;
+        rp1_dmb_st();
         g_ctrl->rp1_state = terminal_state;
-        rp1_barrier();
+        rp1_dmb_st();
         g_ctrl->graph_done_seq = accepted_seq;
-        rp1_barrier();
+        rp1_dsb_st();
 #ifdef QEMU_SEMIHOSTING
         terminal_result = result;
 #endif

--- a/linker/slashkit/resources/aved/rp1/src/rp1_scheduler.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_scheduler.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * RP1 barrier-event execution index.
+ */
+
+#include "rp1_scheduler.h"
+#include "rp1_store.h"
+
+#include <slash/uapi/rp1_protocol.h>
+#include <stdint.h>
+
+#define BTCM_SECTION __attribute__((section(".btcm")))
+#define ATCM_DATA_SECTION __attribute__((section(".atcm_data")))
+#define RP1_EVENT_COUNT (RP1_MAX_BUCKETS * 32u)
+#define RP1_NODE_WORDS  ((RP1_MAX_NODES + 31u) / 32u)
+
+/*
+ * Sparse event-to-node references. ATCM is writable and otherwise mostly
+ * unused after code placement, while these sequential reads avoid DDR stalls.
+ *
+ * ponytail: dense graphs above this ceiling use the flat scanner. Increase the
+ * split ATCM/BTCM capacity or stage host-built CSR data to raise the ceiling.
+ */
+static uint16_t
+    g_event_subscribers[RP1_SCHEDULER_MAX_SUBSCRIPTIONS] ATCM_DATA_SECTION;
+
+/* CSR offsets indexed by flattened bucket/bit event id. */
+static uint16_t g_event_offsets[RP1_EVENT_COUNT + 1u] BTCM_SECTION;
+
+/* Number of currently unset awaited bits for each node. */
+static uint8_t g_remaining[RP1_MAX_NODES] BTCM_SECTION;
+
+/* Dependency-ready PENDING nodes, with one summary bit per 32-node word. */
+static uint32_t g_ready[RP1_NODE_WORDS] BTCM_SECTION;
+static uint32_t g_ready_summary BTCM_SECTION;
+
+/* Resource-blocked ready nodes restored after the current activation pass. */
+static uint32_t g_deferred[RP1_NODE_WORDS] BTCM_SECTION;
+static uint32_t g_deferred_summary BTCM_SECTION;
+
+/* WAIT nodes whose barrier dependencies resolved but signal did not. */
+static uint32_t g_waiting[RP1_NODE_WORDS] BTCM_SECTION;
+static uint32_t g_waiting_summary BTCM_SECTION;
+
+/* Per-graph index state; zero selects the scanner fallback. */
+static uint32_t g_enabled BTCM_SECTION;
+static uint32_t g_subscription_count BTCM_SECTION;
+
+_Static_assert(RP1_SCHEDULER_MAX_SUBSCRIPTIONS <= UINT16_MAX,
+               "scheduler offsets must represent every subscription");
+_Static_assert(RP1_NODE_WORDS == 32u,
+               "scheduler bitsets must cover exactly 1024 nodes");
+
+/* Return the index of the least-significant set bit in a non-zero word. */
+static uint32_t first_set(uint32_t word)
+{
+    return (uint32_t)__builtin_ctz(word);
+}
+
+/* Clear every word and its summary for one node bitset. */
+static void clear_bitset(uint32_t *words, uint32_t *summary)
+{
+    for (uint32_t i = 0u; i < RP1_NODE_WORDS; i++)
+        words[i] = 0u;
+    *summary = 0u;
+}
+
+/* Add one node to a summarized bitset. */
+static void add_bit(uint32_t *words, uint32_t *summary, uint32_t node_index)
+{
+    uint32_t word = node_index >> 5;
+    words[word] |= 1u << (node_index & 31u);
+    *summary |= 1u << word;
+}
+
+/* Remove one node from a summarized bitset. */
+static void remove_bit(uint32_t *words, uint32_t *summary,
+                       uint32_t node_index)
+{
+    uint32_t word = node_index >> 5;
+    words[word] &= ~(1u << (node_index & 31u));
+    if (words[word] == 0u)
+        *summary &= ~(1u << word);
+}
+
+/* Add one pending node whose complete await mask is already satisfied. */
+static void add_ready(uint32_t node_index)
+{
+    if (rp1_node_get_status(&g_nodes[node_index]) == RP1_NODE_PENDING &&
+        g_remaining[node_index] == 0u)
+        add_bit(g_ready, &g_ready_summary, node_index);
+}
+
+/* Flatten one barrier bucket and bit into its CSR event id. */
+static uint32_t event_id(uint8_t bucket, uint32_t bit)
+{
+    return (uint32_t)bucket * 32u + bit;
+}
+
+/* Return the unresolved await-bit count against current barrier state. */
+static uint8_t unresolved_count(const rp1_node_t *node)
+{
+    uint32_t unresolved =
+        node->barrier_await_mask &
+        ~g_barriers[node->barrier_await_bucket];
+    return (uint8_t)__builtin_popcount(unresolved);
+}
+
+uint32_t rp1_scheduler_build(uint32_t node_count)
+{
+    g_enabled = 0u;
+    g_subscription_count = 0u;
+    for (uint32_t i = 0u; i <= RP1_EVENT_COUNT; i++)
+        g_event_offsets[i] = 0u;
+    for (uint32_t i = 0u; i < RP1_MAX_NODES; i++)
+        g_remaining[i] = 0u;
+    clear_bitset(g_ready, &g_ready_summary);
+    clear_bitset(g_deferred, &g_deferred_summary);
+    clear_bitset(g_waiting, &g_waiting_summary);
+
+    /*
+     * Count subscriptions into offset[event + 1]. Abort before prefixing when
+     * the sparse graph cannot fit; scanner fallback needs no partial index.
+     */
+    uint32_t total = 0u;
+    for (uint32_t node_index = 0u; node_index < node_count; node_index++) {
+        const rp1_node_t *node = &g_nodes[node_index];
+        uint32_t bits = node->barrier_await_mask;
+        while (bits != 0u) {
+            uint32_t bit = first_set(bits);
+            uint32_t event = event_id(node->barrier_await_bucket, bit);
+            total++;
+            if (total > RP1_SCHEDULER_MAX_SUBSCRIPTIONS)
+                return 0u;
+            g_event_offsets[event + 1u]++;
+            bits &= bits - 1u;
+        }
+    }
+
+    for (uint32_t event = 0u; event < RP1_EVENT_COUNT; event++)
+        g_event_offsets[event + 1u] += g_event_offsets[event];
+
+    /*
+     * Fill each event range backwards by decrementing its end offset. After
+     * filling, offset[event + 1] holds that event's start; shift starts left
+     * once to restore conventional CSR [start, end) ranges without cursors.
+     */
+    for (uint32_t node_index = 0u; node_index < node_count; node_index++) {
+        const rp1_node_t *node = &g_nodes[node_index];
+        uint32_t bits = node->barrier_await_mask;
+        while (bits != 0u) {
+            uint32_t bit = first_set(bits);
+            uint32_t event = event_id(node->barrier_await_bucket, bit);
+            uint16_t position = --g_event_offsets[event + 1u];
+            g_event_subscribers[position] = (uint16_t)node_index;
+            bits &= bits - 1u;
+        }
+    }
+    for (uint32_t event = 0u; event < RP1_EVENT_COUNT; event++)
+        g_event_offsets[event] = g_event_offsets[event + 1u];
+    g_event_offsets[RP1_EVENT_COUNT] = (uint16_t)total;
+
+    g_subscription_count = total;
+    g_enabled = 1u;
+    for (uint32_t node_index = 0u; node_index < node_count; node_index++) {
+        g_remaining[node_index] = unresolved_count(&g_nodes[node_index]);
+        add_ready(node_index);
+    }
+    return 1u;
+}
+
+uint32_t rp1_scheduler_enabled(void)
+{
+    return g_enabled;
+}
+
+uint32_t rp1_scheduler_subscription_count(void)
+{
+    return g_subscription_count;
+}
+
+uint32_t rp1_scheduler_pop_ready(uint32_t *node_index)
+{
+    if (!g_enabled || g_ready_summary == 0u)
+        return 0u;
+
+    uint32_t word = first_set(g_ready_summary);
+    uint32_t bit = first_set(g_ready[word]);
+    *node_index = word * 32u + bit;
+    remove_bit(g_ready, &g_ready_summary, *node_index);
+    return 1u;
+}
+
+void rp1_scheduler_defer_ready(uint32_t node_index)
+{
+    if (g_enabled)
+        add_bit(g_deferred, &g_deferred_summary, node_index);
+}
+
+void rp1_scheduler_restore_deferred(void)
+{
+    while (g_enabled && g_deferred_summary != 0u) {
+        uint32_t word = first_set(g_deferred_summary);
+        uint32_t bit = first_set(g_deferred[word]);
+        uint32_t node_index = word * 32u + bit;
+        remove_bit(g_deferred, &g_deferred_summary, node_index);
+        add_ready(node_index);
+    }
+}
+
+void rp1_scheduler_set_barriers(uint8_t bucket, uint32_t mask)
+{
+    uint32_t new_bits = mask & ~g_barriers[bucket];
+    g_barriers[bucket] |= mask;
+    if (!g_enabled)
+        return;
+
+    while (new_bits != 0u) {
+        uint32_t bit = first_set(new_bits);
+        uint32_t event = event_id(bucket, bit);
+        for (uint16_t i = g_event_offsets[event];
+             i < g_event_offsets[event + 1u]; i++) {
+            uint32_t node_index = g_event_subscribers[i];
+            if (rp1_node_get_status(&g_nodes[node_index]) ==
+                    RP1_NODE_PENDING &&
+                g_remaining[node_index] != 0u) {
+                g_remaining[node_index]--;
+                add_ready(node_index);
+            }
+        }
+        new_bits &= new_bits - 1u;
+    }
+}
+
+void rp1_scheduler_clear_barriers(uint8_t bucket, uint32_t mask)
+{
+    uint32_t cleared = mask & g_barriers[bucket];
+    g_barriers[bucket] &= ~mask;
+    if (!g_enabled)
+        return;
+
+    while (cleared != 0u) {
+        uint32_t bit = first_set(cleared);
+        uint32_t event = event_id(bucket, bit);
+        for (uint16_t i = g_event_offsets[event];
+             i < g_event_offsets[event + 1u]; i++) {
+            uint32_t node_index = g_event_subscribers[i];
+            if (rp1_node_get_status(&g_nodes[node_index]) ==
+                RP1_NODE_PENDING) {
+                remove_bit(g_ready, &g_ready_summary, node_index);
+                remove_bit(g_deferred, &g_deferred_summary, node_index);
+                g_remaining[node_index]++;
+            }
+        }
+        cleared &= cleared - 1u;
+    }
+}
+
+void rp1_scheduler_rearm_node(uint32_t node_index)
+{
+    if (!g_enabled)
+        return;
+
+    rp1_scheduler_remove_node(node_index);
+    g_remaining[node_index] = unresolved_count(&g_nodes[node_index]);
+    add_ready(node_index);
+}
+
+void rp1_scheduler_remove_node(uint32_t node_index)
+{
+    if (!g_enabled)
+        return;
+    remove_bit(g_ready, &g_ready_summary, node_index);
+    remove_bit(g_deferred, &g_deferred_summary, node_index);
+    remove_bit(g_waiting, &g_waiting_summary, node_index);
+}
+
+void rp1_scheduler_park_wait(uint32_t node_index)
+{
+    if (!g_enabled)
+        return;
+    remove_bit(g_ready, &g_ready_summary, node_index);
+    remove_bit(g_deferred, &g_deferred_summary, node_index);
+    add_bit(g_waiting, &g_waiting_summary, node_index);
+}
+
+uint32_t rp1_scheduler_next_waiting(uint32_t start_index,
+                                    uint32_t *node_index)
+{
+    if (!g_enabled || start_index >= RP1_MAX_NODES)
+        return 0u;
+
+    uint32_t word = start_index >> 5;
+    uint32_t bits =
+        g_waiting[word] & (~0u << (start_index & 31u));
+    while (bits == 0u) {
+        word++;
+        if (word >= RP1_NODE_WORDS)
+            return 0u;
+        bits = g_waiting[word];
+    }
+    *node_index = word * 32u + first_set(bits);
+    return 1u;
+}

--- a/linker/slashkit/resources/aved/rp1/src/rp1_scheduler.h
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_scheduler.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * RP1 barrier-event execution index.
+ */
+
+#ifndef RP1_SCHEDULER_H
+#define RP1_SCHEDULER_H
+
+#include <stdint.h>
+
+/*
+ * ATCM capacity for barrier-event subscriber references. Graphs above this
+ * sparse-edge ceiling retain the flat scanner as a correctness fallback.
+ */
+#ifdef QEMU_SEMIHOSTING
+#define RP1_SCHEDULER_MAX_SUBSCRIPTIONS 4096u
+#else
+#define RP1_SCHEDULER_MAX_SUBSCRIPTIONS 16384u
+#endif
+
+/*
+ * Build the event-to-subscriber CSR and initial ready set from g_nodes.
+ *
+ * @return 1 when the event index fits local TCM, or 0 when execution must use
+ *         the flat scanner fallback.
+ */
+uint32_t rp1_scheduler_build(uint32_t node_count);
+
+/* Return non-zero when the current graph uses the event index. */
+uint32_t rp1_scheduler_enabled(void);
+
+/* Return the number of event-to-node references in the current graph. */
+uint32_t rp1_scheduler_subscription_count(void);
+
+/* Pop the lowest-index ready node, returning zero when no node is ready. */
+uint32_t rp1_scheduler_pop_ready(uint32_t *node_index);
+
+/* Defer one resource-blocked ready node until the next activation pass. */
+void rp1_scheduler_defer_ready(uint32_t node_index);
+
+/* Restore all deferred nodes that remain pending and dependency-ready. */
+void rp1_scheduler_restore_deferred(void);
+
+/*
+ * Publish barrier bits and wake subscribers on each zero-to-one transition.
+ * The barrier array remains authoritative in indexed and fallback modes.
+ */
+void rp1_scheduler_set_barriers(uint8_t bucket, uint32_t mask);
+
+/*
+ * Clear selected barrier bits and make pending subscribers unresolved again.
+ * Rearmed DONE nodes are handled separately by rp1_scheduler_rearm_node().
+ */
+void rp1_scheduler_clear_barriers(uint8_t bucket, uint32_t mask);
+
+/* Recompute one PENDING node's unresolved count and ready membership. */
+void rp1_scheduler_rearm_node(uint32_t node_index);
+
+/* Remove a node from ready, deferred, and parked-WAIT sets. */
+void rp1_scheduler_remove_node(uint32_t node_index);
+
+/* Move one dependency-ready WAIT node into the parked signal-poll set. */
+void rp1_scheduler_park_wait(uint32_t node_index);
+
+/*
+ * Find the first parked WAIT at or after start_index.
+ *
+ * @return 1 and populate node_index on success, or 0 when none remain.
+ */
+uint32_t rp1_scheduler_next_waiting(uint32_t start_index,
+                                    uint32_t *node_index);
+
+#endif /* RP1_SCHEDULER_H */

--- a/linker/slashkit/resources/aved/rp1/src/rp1_store.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_store.c
@@ -5,6 +5,8 @@
  * RP1 static storage definitions and initialisation.
  */
 
+#include "rp1_cycles.h"
+#include "rp1_hal.h"
 #include "rp1_store.h"
 #include <slash/uapi/rp1_protocol.h>
 #include <stddef.h>
@@ -22,24 +24,41 @@
 #define BTCM_SECTION __attribute__((section(".btcm")))
 
 uint32_t      g_barriers[RP1_MAX_BUCKETS]  BTCM_SECTION;
-uint8_t       g_node_status[RP1_MAX_NODES] BTCM_SECTION;
+rp1_node_t    g_nodes[RP1_MAX_NODES]       BTCM_SECTION;
+uint32_t      g_node_count                 BTCM_SECTION;
 uint32_t      g_loop_iters[RP1_MAX_LOOPS]  BTCM_SECTION;
 rp1_inflight_t g_inflight[RP1_MAX_INFLIGHT] BTCM_SECTION;
 uint32_t      g_inflight_count             BTCM_SECTION;
 uint32_t      g_graph_start_cycles         BTCM_SECTION;
 uint32_t      g_trace_size                 BTCM_SECTION;
 uint32_t      g_trace_enable               BTCM_SECTION;
+uint32_t      g_completed_operations       BTCM_SECTION;
+uint32_t      g_operation_started          BTCM_SECTION;
+uint32_t      g_quiesce_finite_done         BTCM_SECTION;
+uint32_t      g_quiesce_finite_timeout      BTCM_SECTION;
+uint32_t      g_quiesce_infinite            BTCM_SECTION;
+uint32_t      g_recovery_required           BTCM_SECTION;
+uint32_t      g_terminal_opcode             BTCM_SECTION;
+/* Fixed on-chip trace page; only explicit flushes touch the DDR trace ring. */
+static rp1_trace_entry_t
+    g_trace_staging[RP1_TRACE_STAGING_ENTRIES] BTCM_SECTION;
+/* Number of valid entries at the front of g_trace_staging. */
+static uint32_t g_trace_staging_count       BTCM_SECTION;
 
-/* Persists across graphs (physical reconfig state); zeroed only at boot. */
+/* Persistent physical reconfiguration state; zeroed only at boot. */
 uint32_t      g_active_image_id            BTCM_SECTION;
+uint32_t      g_active_image_state         BTCM_SECTION;
+
+_Static_assert(sizeof(g_trace_staging) == RP1_TRACE_STAGING_BYTES,
+               "BTCM trace staging must occupy exactly 4 KB");
+_Static_assert(sizeof(g_nodes) == 32u * RP1_MAX_NODES,
+               "BTCM node snapshot must occupy exactly 32 KB");
 
 /* -------------------------------------------------------------------------
  * DDR-backed pointer table (set by rp1_store_init)
  * ---------------------------------------------------------------------- */
 
 rp1_ctrl_t       *g_ctrl    = (rp1_ctrl_t *)RP1_CTRL_PHYS_ADDR;
-rp1_node_t       *g_nodes   = NULL;
-rp1_cq_entry_t   *g_cq      = NULL;
 rp1_signal_slot_t *g_signals = NULL;
 uint32_t         *g_arg_buf  = NULL;
 rp1_trace_entry_t *g_trace   = NULL;
@@ -75,47 +94,119 @@ static uint32_t valid_window_range(uint32_t lo, uint32_t hi,
     return lo - RP1_CTRL_PHYS_ADDR <= RP1_CTRL_WINDOW_SIZE - size;
 }
 
+/*
+ * GCC's may_alias word keeps this hot snapshot defined under -O2 strict
+ * aliasing while preserving one aligned NoC transaction per 32-bit word.
+ */
+typedef uint32_t rp1_alias_u32_t __attribute__((may_alias));
+
+/*
+ * Copy each source word exactly once after the caller validates and orders the
+ * host-owned range. The volatile source prevents later scanner reads from
+ * folding into DDR; all execution subsequently uses the mutable BTCM copy.
+ */
+static void snapshot_nodes(uint32_t source_lo, uint32_t source_hi,
+                           uint32_t node_count)
+{
+    const volatile rp1_alias_u32_t *source =
+        (const volatile rp1_alias_u32_t *)
+            (uintptr_t)make64(source_lo, source_hi);
+    rp1_alias_u32_t *destination = (rp1_alias_u32_t *)(void *)g_nodes;
+    uint32_t words =
+        node_count * (uint32_t)sizeof(rp1_node_t) / sizeof(uint32_t);
+
+    rp1_dmb_sy();
+    for (uint32_t i = 0u; i < words; i++)
+        destination[i] = source[i];
+
+    /*
+     * Node state is firmware-owned. Ignore stale host status while retaining
+     * opcode, flags, and reserved control bits from the submitted snapshot.
+     */
+    for (uint32_t i = 0u; i < node_count; i++)
+        rp1_node_set_status(&g_nodes[i], RP1_NODE_PENDING);
+    rp1_dmb_sy();
+}
+
+/*
+ * Stage one event without testing the flush threshold. Callers reserve space
+ * first so marker insertion cannot recurse or overrun the fixed BTCM page.
+ */
+static void trace_stage(uint16_t event, uint32_t node_index,
+                        uint32_t aux0, uint32_t aux1)
+{
+    rp1_trace_entry_t *entry = &g_trace_staging[g_trace_staging_count++];
+    entry->timestamp = rp1_cycles() - g_graph_start_cycles;
+    entry->event = event;
+    entry->node_index = (uint16_t)node_index;
+    entry->aux0 = aux0;
+    entry->aux1 = aux1;
+}
+
+/*
+ * Copy the staged prefix into the monotonic DDR ring and publish its producer
+ * cursor only after every entry is visible. Ring wrap deliberately overwrites
+ * the oldest records, matching the existing host-side overflow contract.
+ */
+static void trace_flush_staged(void)
+{
+    uint32_t count = g_trace_staging_count;
+    if (count == 0u)
+        return;
+
+    uint32_t write = g_ctrl->trace_write_idx;
+    for (uint32_t i = 0; i < count; i++) {
+        uint32_t idx = (write + i) % g_trace_size;
+        g_trace[idx].timestamp = g_trace_staging[i].timestamp;
+        g_trace[idx].event = g_trace_staging[i].event;
+        g_trace[idx].node_index = g_trace_staging[i].node_index;
+        g_trace[idx].aux0 = g_trace_staging[i].aux0;
+        g_trace[idx].aux1 = g_trace_staging[i].aux1;
+    }
+    rp1_dmb_st();
+    g_ctrl->trace_write_idx = write + count;
+    rp1_dsb_st();
+    g_trace_staging_count = 0u;
+}
+
 /* -------------------------------------------------------------------------
  * Public API
  * ---------------------------------------------------------------------- */
 
 /*
- * Configuration validation has three classes: bounded counts/ring shape,
- * monotonic CQ occupancy, and aligned ranges wholly inside the shared window.
- * No host-provided address becomes a pointer until every class has passed.
+ * Configuration validation checks bounded counts and aligned ranges wholly
+ * inside the shared window. No host address becomes a pointer until every
+ * field needed by the scanner has passed.
  */
 int rp1_store_init(uint32_t *detail, uint32_t *aux)
 {
     uint32_t node_count = g_ctrl->node_count;
-    uint32_t cq_size = g_ctrl->cq_size;
+    uint32_t node_base_lo = g_ctrl->node_base_lo;
+    uint32_t node_base_hi = g_ctrl->node_base_hi;
 
     *detail = 0u;
     *aux = 0u;
+    g_node_count = 0u;
     if (node_count == 0u || node_count > RP1_MAX_NODES) {
         *detail = RP1_CONFIG_NODE_COUNT;
         *aux = node_count;
         return -1;
     }
-    if (!valid_window_range(g_ctrl->node_base_lo, g_ctrl->node_base_hi,
-                            node_count * (uint32_t)sizeof(rp1_node_t), 64u)) {
+    uint32_t reserved_cq =
+        (g_ctrl->_reserved_cq_size != 0u ? 1u << 0 : 0u) |
+        (g_ctrl->_reserved_cq_base_lo != 0u ? 1u << 1 : 0u) |
+        (g_ctrl->_reserved_cq_base_hi != 0u ? 1u << 2 : 0u) |
+        (g_ctrl->_reserved_cq_write_idx != 0u ? 1u << 3 : 0u) |
+        (g_ctrl->_reserved_cq_read_idx != 0u ? 1u << 4 : 0u);
+    if (reserved_cq != 0u) {
+        *detail = RP1_CONFIG_RESERVED_CQ;
+        *aux = reserved_cq;
+        return -1;
+    }
+    if (!valid_window_range(node_base_lo, node_base_hi,
+                            node_count * (uint32_t)sizeof(rp1_node_t), 4u)) {
         *detail = RP1_CONFIG_NODE_BASE;
-        *aux = g_ctrl->node_base_lo;
-        return -1;
-    }
-    if (!is_power_of_two(cq_size) || cq_size > RP1_MAX_CQ_ENTRIES) {
-        *detail = RP1_CONFIG_CQ_SIZE;
-        *aux = cq_size;
-        return -1;
-    }
-    if (!valid_window_range(g_ctrl->cq_base_lo, g_ctrl->cq_base_hi,
-                            cq_size * (uint32_t)sizeof(rp1_cq_entry_t), 16u)) {
-        *detail = RP1_CONFIG_CQ_BASE;
-        *aux = g_ctrl->cq_base_lo;
-        return -1;
-    }
-    if ((uint32_t)(g_ctrl->cq_write_idx - g_ctrl->cq_read_idx) > cq_size) {
-        *detail = RP1_CONFIG_CQ_CURSORS;
-        *aux = g_ctrl->cq_write_idx - g_ctrl->cq_read_idx;
+        *aux = node_base_lo;
         return -1;
     }
     if (!valid_window_range(g_ctrl->arg_buf_base_lo,
@@ -147,13 +238,10 @@ int rp1_store_init(uint32_t *detail, uint32_t *aux)
     }
 
     /*
-     * Phase 2: all ranges are now proven 32-bit, aligned, and in-window, so
-     * resolving them cannot expose the scanner to a partially valid store.
+     * Phase 2: all ranges are now proven 32-bit, aligned, and in-window.
+     * Resolve non-node stores, reset stale graph state, then take the sole DDR
+     * node read before publishing the valid BTCM prefix.
      */
-    g_nodes   = (rp1_node_t *)
-                    (uintptr_t)make64(g_ctrl->node_base_lo, g_ctrl->node_base_hi);
-    g_cq      = (rp1_cq_entry_t *)
-                    (uintptr_t)make64(g_ctrl->cq_base_lo, g_ctrl->cq_base_hi);
     g_signals = (rp1_signal_slot_t *)
                     (uintptr_t)make64(g_ctrl->sig_array_base_lo, g_ctrl->sig_array_base_hi);
     g_arg_buf = (uint32_t *)
@@ -163,24 +251,59 @@ int rp1_store_init(uint32_t *detail, uint32_t *aux)
     g_trace_size = g_ctrl->trace_size;
     g_trace_enable = g_ctrl->trace_enable;
     g_ctrl->trace_write_idx = 0;
+    g_trace_staging_count = 0u;
 
-    /*
-     * Phase 3: reset only per-graph state and status. The active image id is
-     * physical reconfiguration state and deliberately survives submissions.
-     */
     rp1_store_reset_graph();
-    for (uint32_t i = 0; i < node_count; i++)
-        g_nodes[i].status = RP1_NODE_PENDING;
+    snapshot_nodes(node_base_lo, node_base_hi, node_count);
+    g_node_count = node_count;
     return 0;
 }
 
 void rp1_store_reset_graph(void)
 {
     memzero(g_barriers,    sizeof(g_barriers));
-    memzero(g_node_status, sizeof(g_node_status));
     memzero(g_loop_iters,  sizeof(g_loop_iters));
     memzero(g_inflight,    sizeof(g_inflight));
-    g_inflight_count = 0;
+    g_node_count = 0u;
+    g_inflight_count = 0u;
+    g_completed_operations = 0u;
+    g_operation_started = 0u;
+    g_quiesce_finite_done = 0u;
+    g_quiesce_finite_timeout = 0u;
+    g_quiesce_infinite = 0u;
+    g_recovery_required = 0u;
+    g_terminal_opcode = RP1_TERMINAL_OPCODE_NONE;
+}
+
+/*
+ * A normal event may consume at most the penultimate slot. The final slot
+ * names the synchronous flush, and the first entry staged afterward records
+ * when that blocking copy returned.
+ */
+void rp1_trace_emit(uint16_t event, uint32_t node_index,
+                    uint32_t aux0, uint32_t aux1)
+{
+    if (!g_trace_enable || !g_trace || !g_trace_size)
+        return;
+
+    trace_stage(event, node_index, aux0, aux1);
+    if (RP1_TRACE_STAGING_ENTRIES - g_trace_staging_count != 1u)
+        return;
+
+    uint32_t write = g_ctrl->trace_write_idx;
+    trace_stage(RP1_TRACE_FLUSH_START, 0xFFFFu,
+                RP1_TRACE_STAGING_ENTRIES, write);
+    trace_flush_staged();
+    trace_stage(RP1_TRACE_FLUSH_END, 0xFFFFu,
+                RP1_TRACE_STAGING_ENTRIES,
+                g_ctrl->trace_write_idx);
+}
+
+void rp1_trace_flush_final(void)
+{
+    if (!g_trace_enable || !g_trace || !g_trace_size)
+        return;
+    trace_flush_staged();
 }
 
 void rp1_clear_error_latch(void)
@@ -189,26 +312,27 @@ void rp1_clear_error_latch(void)
     g_ctrl->terminal_error_node = RP1_TERMINAL_ERROR_NODE_NONE;
     g_ctrl->terminal_error_detail = 0u;
     g_ctrl->terminal_error_aux = 0u;
+    g_terminal_opcode = RP1_TERMINAL_OPCODE_NONE;
 }
 
 /*
- * The first base error owns node/detail/aux for the whole graph. Later
- * quiescence may only OR recovery-required, preserving the original cause
- * while telling the host that reset is mandatory.
+ * The first error owns node/opcode/detail/aux for the whole graph. Quiescence
+ * records recovery separately so it cannot alter the initiating cause.
  */
 void rp1_latch_error(uint32_t code, uint32_t node,
                      uint32_t detail, uint32_t aux)
 {
-    if ((g_ctrl->rp1_error_code & RP1_ERR_CODE_MASK) != 0u)
+    if (g_ctrl->rp1_error_code != 0u)
         return;
-    g_ctrl->rp1_error_code =
-        (g_ctrl->rp1_error_code & RP1_ERR_RECOVERY_REQUIRED) | code;
+    g_ctrl->rp1_error_code = code;
     g_ctrl->terminal_error_node = node;
     g_ctrl->terminal_error_detail = detail;
     g_ctrl->terminal_error_aux = aux;
+    if (node != RP1_TERMINAL_ERROR_NODE_NONE && node < g_node_count)
+        g_terminal_opcode = rp1_node_get_opcode(&g_nodes[node]);
 }
 
 void rp1_mark_recovery_required(void)
 {
-    g_ctrl->rp1_error_code |= RP1_ERR_RECOVERY_REQUIRED;
+    g_recovery_required = 1u;
 }

--- a/linker/slashkit/resources/aved/rp1/src/rp1_store.h
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_store.h
@@ -2,28 +2,37 @@
  * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * SPDX-License-Identifier: MIT
  *
- * RP1 static storage — BTCM-resident hot data and DDR pointers.
+ * RP1 static storage — BTCM-resident graph data and DDR pointers.
  *
  * All BTCM objects are in a dedicated .btcm section so the linker script
  * can place them there explicitly.  DDR-backed objects are accessed through
  * pointers that are initialised from the control block at startup.
  *
  * BTCM budget (of 64 KB):
- *   completed_barriers[32]    128 B
- *   node_status[4096]        4096 B
- *   loop_iterations[64]       256 B
- *   inflight[32]              768 B   (32 * sizeof(rp1_inflight_t) = 24)
- *   inflight_count              4 B
- *   stack                    4096 B   (linker script)
- *   code variables           ~1 KB
+ *   nodes[1024]              32768 B
+ *   completed_barriers[32]     128 B
+ *   loop_iterations[64]        256 B
+ *   inflight[32]               768 B   (32 * sizeof(rp1_inflight_t) = 24)
+ *   clean CU cache              132 B   (32 addresses + count)
+ *   scheduler fixed state      ~3.5 KB  (CSR offsets/counts + bitsets)
+ *   trace staging             4096 B   (256 * sizeof(rp1_trace_entry_t))
+ *   stack                     4096 B   (linker script)
+ *   bookkeeping and BSS       ~6 KB
  *   ─────────────────────────────
- *   Total hot data           ~10.3 KB
+ *   Total                    <64 KB (enforced by the linker script)
+ *
+ * The sparse subscriber array uses 32 KB of otherwise free ATCM.
  */
 
 #ifndef RP1_STORE_H
 #define RP1_STORE_H
 
 #include <slash/uapi/rp1_protocol.h>
+
+/* One fixed 4 KB BTCM page stages trace entries before a blocking DDR flush. */
+#define RP1_TRACE_STAGING_BYTES   4096u
+#define RP1_TRACE_STAGING_ENTRIES \
+    (RP1_TRACE_STAGING_BYTES / (uint32_t)sizeof(rp1_trace_entry_t))
 
 /* -------------------------------------------------------------------------
  * BTCM-resident hot stores
@@ -32,8 +41,14 @@
 /* Flat barrier array: 32 buckets of 32 bits each = 1024 barrier signals. */
 extern uint32_t g_barriers[RP1_MAX_BUCKETS];
 
-/* Per-node status cache: one byte per node, mirrors rp1_node_t.status. */
-extern uint8_t g_node_status[RP1_MAX_NODES];
+/*
+ * Authoritative graph snapshot. The active DDR prefix is copied here once
+ * after validation; payloads and packed status are never read back from DDR.
+ */
+extern rp1_node_t g_nodes[RP1_MAX_NODES];
+
+/* Valid prefix of g_nodes for the accepted graph. */
+extern uint32_t g_node_count;
 
 /* Per-loop iteration counter, indexed by loop_id. */
 extern uint32_t g_loop_iters[RP1_MAX_LOOPS];
@@ -46,14 +61,21 @@ extern uint32_t       g_inflight_count;
 extern uint32_t g_graph_start_cycles;
 
 /*
- * Image id last installed by a successful PDI_LOAD (0 = none loaded yet).
- * This reflects physical partial-reconfiguration state, so unlike the other
- * BTCM stores it PERSISTS across graph submissions and is deliberately not
- * cleared by rp1_store_reset_graph(); only a PDI_LOAD node changes it. A
- * KERNEL_DISPATCH with a non-zero expected_image_id that does not match this
- * is failed fast instead of poking an absent kernel.
+ * Persistent partial-reconfiguration state. A successful named PDI makes the
+ * image KNOWN; any PDI timeout or rejection makes it UNKNOWN until a later
+ * successful load. Both fields survive graph resets.
  */
 extern uint32_t g_active_image_id;
+extern uint32_t g_active_image_state;
+
+/* Per-graph result counters and terminal metadata, reset before activation. */
+extern uint32_t g_completed_operations;
+extern uint32_t g_operation_started;
+extern uint32_t g_quiesce_finite_done;
+extern uint32_t g_quiesce_finite_timeout;
+extern uint32_t g_quiesce_infinite;
+extern uint32_t g_recovery_required;
+extern uint32_t g_terminal_opcode;
 
 /* -------------------------------------------------------------------------
  * DDR-backed stores (pointers into shared DDR, set at graph init)
@@ -61,12 +83,6 @@ extern uint32_t g_active_image_id;
 
 /* Pointer to the control block (fixed at RP1_DDR_CTRL_BASE). */
 extern rp1_ctrl_t *g_ctrl;
-
-/* Pointer to the node array (from g_ctrl->node_base_lo/hi). */
-extern rp1_node_t *g_nodes;
-
-/* Pointer to the CQ ring (from g_ctrl->cq_base_lo/hi). */
-extern rp1_cq_entry_t *g_cq;
 
 /* Pointer to the signal array (from g_ctrl->sig_array_base_lo/hi). */
 extern rp1_signal_slot_t *g_signals;
@@ -84,24 +100,40 @@ extern uint32_t g_trace_enable;
  * ---------------------------------------------------------------------- */
 
 /*
- * Validate the host-owned control fields, resolve DDR pointers, and zero the
- * per-graph BTCM stores.
+ * Validate host-owned control fields, snapshot the active node prefix into
+ * BTCM, resolve the remaining DDR pointers, and reset per-graph state.
  *
  * @return 0 on success, -1 with protocol detail/aux populated on failure.
  */
 int rp1_store_init(uint32_t *detail, uint32_t *aux);
 
 /*
- * rp1_store_reset_graph() — reset per-graph BTCM state (barriers, node
- * statuses, loop counters, inflight table) without touching the DDR pointers.
- * Called at the start of every new graph submission.
+ * rp1_store_reset_graph() — reset per-graph BTCM state (barriers, counters,
+ * loop state, and inflight table) without touching the node snapshot, DDR
+ * pointers, or persistent image state. Called before each graph snapshot.
  */
 void rp1_store_reset_graph(void);
 
 /*
+ * Append one timestamped event to the BTCM trace page. When one slot remains,
+ * the implementation fills it with FLUSH_START, copies the full page to the
+ * configured DDR ring, and makes FLUSH_END the first entry in the new page.
+ * Disabled tracing is a no-op.
+ */
+void rp1_trace_emit(uint16_t event, uint32_t node_index,
+                    uint32_t aux0, uint32_t aux1);
+
+/*
+ * Copy the final partial BTCM page to DDR without adding flush markers.
+ * Graph completion calls this after emitting GRAPH_DONE, so no recursive
+ * marker flush is needed merely to publish FLUSH_END or GRAPH_DONE.
+ */
+void rp1_trace_flush_final(void);
+
+/*
  * First-error-wins diagnostic publication for the current graph. Clear only
- * before accepting a graph; fatal quiescence may add recovery-required but
- * must not replace the node/detail/aux that identify the initiating failure.
+ * before accepting a graph; quiescence recovery metadata is tracked
+ * separately and must not replace the initiating failure.
  */
 void rp1_clear_error_latch(void);
 void rp1_latch_error(uint32_t code, uint32_t node,

--- a/linker/slashkit/resources/aved/rp1/src/rp1_test.c
+++ b/linker/slashkit/resources/aved/rp1/src/rp1_test.c
@@ -21,6 +21,7 @@
 
 #include "rp1_test.h"
 #include "rp1_hal.h"
+#include "rp1_scheduler.h"
 #include "rp1_store.h"
 #include <slash/uapi/rp1_protocol.h>
 #include <stddef.h>
@@ -45,16 +46,25 @@ static int run(const char *name, int (*fn)(void))
 
 static int test_struct_sizes(void)
 {
-    CHECK_EQ32(sizeof(rp1_node_t),         64,     "rp1_node_t size");
-    CHECK_EQ32(offsetof(rp1_node_t, payload), 16,  "payload offset");
+    CHECK_EQ32(sizeof(rp1_node_t),         32,     "rp1_node_t size");
+    CHECK_EQ32(offsetof(rp1_node_t, control), 0,   "control offset");
+    CHECK_EQ32(offsetof(rp1_node_t, barrier_await_bucket), 2,
+               "await bucket offset");
+    CHECK_EQ32(offsetof(rp1_node_t, barrier_set_bucket), 3,
+               "set bucket offset");
+    CHECK_EQ32(offsetof(rp1_node_t, barrier_await_mask), 4,
+               "await mask offset");
+    CHECK_EQ32(offsetof(rp1_node_t, barrier_set_mask), 8,
+               "set mask offset");
+    CHECK_EQ32(offsetof(rp1_node_t, payload), 12,  "payload offset");
     CHECK_EQ32(sizeof(rp1_ctrl_t),         0x1000, "rp1_ctrl_t size");
     CHECK_EQ32(sizeof(rp1_signal_slot_t),  16,     "signal slot size");
-    CHECK_EQ32(sizeof(rp1_cq_entry_t),     16,     "cq entry size");
+    CHECK_EQ32(sizeof(rp1_graph_result_t),  64,     "graph result size");
     CHECK_EQ32(sizeof(rp1_trace_entry_t),  16,     "trace entry size");
     CHECK_EQ32(sizeof(rp1_inflight_t),     24,     "inflight entry size");
-    CHECK_EQ32(RP1_PROTOCOL_VERSION,       4,      "protocol version");
-    CHECK_EQ32(RP1_REQUIRED_CAPABILITIES,  0x1F,   "required capabilities");
-    CHECK_EQ32(RP1_MAX_CQ_ENTRIES,         4096,   "maximum CQ entries");
+    CHECK_EQ32(RP1_PROTOCOL_VERSION,       6,      "protocol version");
+    CHECK_EQ32(RP1_MAX_NODES,              1024,   "maximum nodes");
+    CHECK_EQ32(RP1_REQUIRED_CAPABILITIES,  0x7B,   "required capabilities");
     CHECK_EQ32(RP1_PMU_CYCLE_DIVISOR,      64,     "PMU tick divisor");
     CHECK(RP1_PLATFORM_ID != RP1_PDI_IPI_PLATFORM_UNKNOWN,
           "platform id must be explicit");
@@ -63,26 +73,71 @@ static int test_struct_sizes(void)
 
 static int test_payload_sizes(void)
 {
-    CHECK_EQ32(sizeof(rp1_payload_kernel_dispatch_t), 48, "kernel_dispatch payload");
-    CHECK_EQ32(sizeof(rp1_payload_scalar_write_t),    48, "scalar_write payload");
-    CHECK_EQ32(sizeof(rp1_payload_scalar_read_t),     48, "scalar_read payload");
-    CHECK_EQ32(sizeof(rp1_payload_signal_t),          48, "signal payload");
-    CHECK_EQ32(sizeof(rp1_payload_wait_t),            48, "wait payload");
-    CHECK_EQ32(sizeof(rp1_payload_dma_copy_t),        48, "dma_copy payload");
-    CHECK_EQ32(sizeof(rp1_payload_dma_fill_t),        48, "dma_fill payload");
-    CHECK_EQ32(sizeof(rp1_payload_pdi_load_t),        48, "pdi_load payload");
-    CHECK_EQ32(sizeof(rp1_payload_loop_t),            48, "loop payload");
-    CHECK_EQ32(sizeof(rp1_payload_cond_t),            48, "cond payload");
-    CHECK_EQ32(sizeof(rp1_payload_rerun_t),           48, "rerun payload");
+    CHECK_EQ32(sizeof(rp1_payload_kernel_dispatch_t), 20, "kernel_dispatch payload");
+    CHECK_EQ32(sizeof(rp1_payload_scalar_write_t),    20, "scalar_write payload");
+    CHECK_EQ32(sizeof(rp1_payload_scalar_read_t),      8, "scalar_read payload");
+    CHECK_EQ32(sizeof(rp1_payload_scalar_copy_t),      8, "scalar_copy payload");
+    CHECK_EQ32(sizeof(rp1_payload_signal_t),           8, "signal payload");
+    CHECK_EQ32(sizeof(rp1_payload_wait_t),              8, "wait payload");
+    CHECK_EQ32(sizeof(rp1_payload_dma_copy_t),         20, "dma_copy payload");
+    CHECK_EQ32(sizeof(rp1_payload_dma_fill_t),         20, "dma_fill payload");
+    CHECK_EQ32(sizeof(rp1_payload_pdi_load_t),         20, "pdi_load payload");
+    CHECK_EQ32(sizeof(rp1_payload_loop_t),             20, "loop payload");
+    CHECK_EQ32(sizeof(rp1_payload_cond_t),             20, "cond payload");
+    CHECK_EQ32(sizeof(rp1_payload_rerun_t),            20, "rerun payload");
 
-    /* PDI_LOAD: verify the first three fields land where the host stack
-     * expects them. */
+    CHECK_EQ32(offsetof(rp1_payload_kernel_dispatch_t, arg_count), 8,
+               "dispatch.arg_count offset");
+    CHECK_EQ32(offsetof(rp1_payload_kernel_dispatch_t, ctrl_flags), 10,
+               "dispatch.ctrl_flags offset");
+    CHECK_EQ32(offsetof(rp1_payload_kernel_dispatch_t, timeout_cycles), 12,
+               "dispatch.timeout offset");
+    CHECK_EQ32(offsetof(rp1_payload_kernel_dispatch_t, expected_image_id), 16,
+               "dispatch.image offset");
+    CHECK_EQ32(offsetof(rp1_payload_scalar_read_t, target_slot), 4,
+               "scalar_read.target offset");
+    CHECK_EQ32(offsetof(rp1_payload_scalar_copy_t, source_slot), 4,
+               "scalar_copy.source offset");
+    CHECK_EQ32(offsetof(rp1_payload_signal_t, target_slot), 4,
+               "signal.target offset");
+    CHECK_EQ32(offsetof(rp1_payload_signal_t, operation), 5,
+               "signal.operation offset");
+    CHECK_EQ32(offsetof(rp1_payload_wait_t, condition_signal), 4,
+               "wait.signal offset");
+    CHECK_EQ32(offsetof(rp1_payload_wait_t, condition_op), 5,
+               "wait.operation offset");
+    CHECK_EQ32(offsetof(rp1_payload_dma_copy_t, length_types), 16,
+               "dma_copy.packed offset");
+    CHECK_EQ32(offsetof(rp1_payload_dma_fill_t, dst_type), 16,
+               "dma_fill.type offset");
+
+    /* PDI_LOAD retains its four-word prefix. */
     CHECK_EQ32((uint32_t)offsetof(rp1_payload_pdi_load_t, pdi_addr_lo),
                0,  "pdi_load.pdi_addr_lo offset");
     CHECK_EQ32((uint32_t)offsetof(rp1_payload_pdi_load_t, pdi_addr_hi),
                4,  "pdi_load.pdi_addr_hi offset");
     CHECK_EQ32((uint32_t)offsetof(rp1_payload_pdi_load_t, timeout_cycles),
                8,  "pdi_load.timeout_cycles offset");
+    CHECK_EQ32(offsetof(rp1_payload_loop_t, max_iterations), 4,
+               "loop.max offset");
+    CHECK_EQ32(offsetof(rp1_payload_loop_t, condition_value), 8,
+               "loop.value offset");
+    CHECK_EQ32(offsetof(rp1_payload_loop_t, condition_signal), 12,
+               "loop.signal offset");
+    CHECK_EQ32(offsetof(rp1_payload_loop_t, loop_id), 16,
+               "loop.id offset");
+    CHECK_EQ32(offsetof(rp1_payload_cond_t, done_mask), 4,
+               "cond.done_mask offset");
+    CHECK_EQ32(offsetof(rp1_payload_cond_t, body_start), 8,
+               "cond.body offset");
+    CHECK_EQ32(offsetof(rp1_payload_cond_t, condition_signal), 12,
+               "cond.signal offset");
+    CHECK_EQ32(offsetof(rp1_payload_cond_t, done_bucket), 16,
+               "cond.done_bucket offset");
+    CHECK_EQ32(offsetof(rp1_payload_rerun_t, rerun_flags), 2,
+               "rerun.flags offset");
+    CHECK_EQ32(offsetof(rp1_payload_rerun_t, loop_id), 3,
+               "rerun.loop offset");
     return 0;
 }
 
@@ -94,6 +149,10 @@ static int test_ctrl_offsets(void)
     CHECK_EQ32(offsetof(rp1_ctrl_t, node_count),       0x08, "ctrl.node_count offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, graph_seq),        0x20, "ctrl.graph_seq offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, graph_done_seq),   0x24, "ctrl.graph_done_seq offset");
+    CHECK_EQ32(offsetof(rp1_ctrl_t, _reserved_cq_write_idx),
+               0x28, "ctrl.reserved_cq_write offset");
+    CHECK_EQ32(offsetof(rp1_ctrl_t, _reserved_cq_read_idx),
+               0x2C, "ctrl.reserved_cq_read offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, rp1_state),        0x30, "ctrl.rp1_state offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, heartbeat),        0x3C, "ctrl.heartbeat offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, arg_buf_base_lo),  0x40, "ctrl.arg_buf_base_lo offset");
@@ -112,6 +171,8 @@ static int test_ctrl_offsets(void)
                0x70, "ctrl.terminal_error_detail offset");
     CHECK_EQ32(offsetof(rp1_ctrl_t, terminal_error_aux),
                0x74, "ctrl.terminal_error_aux offset");
+    CHECK_EQ32(offsetof(rp1_ctrl_t, result),
+               0x80, "ctrl.result offset");
     CHECK_EQ32(offsetof(rp1_inflight_t, timeout_start),
                0x0C, "inflight.timeout_start offset");
     CHECK_EQ32(offsetof(rp1_inflight_t, timeout_cycles),
@@ -127,25 +188,47 @@ static int test_store_reset(void)
 {
     /* Dirty everything. */
     for (uint32_t i = 0; i < RP1_MAX_BUCKETS;  i++) g_barriers[i]    = 0xDEADBEEFu;
-    for (uint32_t i = 0; i < RP1_MAX_NODES;    i++) g_node_status[i] = 0xABu;
     for (uint32_t i = 0; i < RP1_MAX_LOOPS;    i++) g_loop_iters[i]  = 0xDEADBEEFu;
     for (uint32_t i = 0; i < RP1_MAX_INFLIGHT; i++) {
         g_inflight[i].base_addr = 0xDEADBEEFu;
         g_inflight[i].node_index = i;
     }
+    g_node_count = 99u;
     g_inflight_count = 99;
+    g_completed_operations = 99u;
+    g_operation_started = 1u;
+    g_quiesce_finite_done = 1u;
+    g_quiesce_finite_timeout = 2u;
+    g_quiesce_infinite = 3u;
+    g_recovery_required = 1u;
+    g_terminal_opcode = RP1_OP_HALT;
+    g_active_image_id = 17u;
+    g_active_image_state = RP1_IMAGE_STATE_KNOWN;
 
     rp1_store_reset_graph();
 
     for (uint32_t i = 0; i < RP1_MAX_BUCKETS; i++)
         CHECK_EQ32(g_barriers[i], 0, "barriers not zeroed");
-    for (uint32_t i = 0; i < RP1_MAX_NODES; i++)
-        CHECK_EQ32(g_node_status[i], 0, "node_status not zeroed");
     for (uint32_t i = 0; i < RP1_MAX_LOOPS; i++)
         CHECK_EQ32(g_loop_iters[i], 0, "loop_iters not zeroed");
     for (uint32_t i = 0; i < RP1_MAX_INFLIGHT; i++)
         CHECK_EQ32(g_inflight[i].base_addr, 0, "inflight not zeroed");
     CHECK_EQ32(g_inflight_count, 0, "inflight_count not zeroed");
+    CHECK_EQ32(g_node_count, 0, "node_count not zeroed");
+    CHECK_EQ32(g_completed_operations, 0u, "operation count not zeroed");
+    CHECK_EQ32(g_operation_started, 0u, "operation-start state not zeroed");
+    CHECK_EQ32(g_quiesce_finite_done, 0u, "quiesce done not zeroed");
+    CHECK_EQ32(g_quiesce_finite_timeout, 0u,
+               "quiesce timeout not zeroed");
+    CHECK_EQ32(g_quiesce_infinite, 0u, "quiesce infinite not zeroed");
+    CHECK_EQ32(g_recovery_required, 0u, "recovery state not zeroed");
+    CHECK_EQ32(g_terminal_opcode, RP1_TERMINAL_OPCODE_NONE,
+               "terminal opcode not reset");
+    CHECK_EQ32(g_active_image_id, 17u, "active image id did not persist");
+    CHECK_EQ32(g_active_image_state, RP1_IMAGE_STATE_KNOWN,
+               "active image state did not persist");
+    g_active_image_id = 0u;
+    g_active_image_state = RP1_IMAGE_STATE_NONE;
     return 0;
 }
 
@@ -332,38 +415,144 @@ static int test_node_header(void)
 {
     rp1_node_t node;
 
-    /* Zero the whole packet (as RP1 would after a graph reset). */
+    /* Host builders zero the packet before composing its compact fields. */
     for (uint32_t i = 0; i < sizeof(node); i++) ((uint8_t *)&node)[i] = 0;
 
-    node.opcode               = RP1_OP_KERNEL_DISPATCH;
-    node.flags                = RP1_FLAG_HALT_ON_ERROR | RP1_FLAG_INFINITE;
+    rp1_node_set_control(
+        &node, rp1_node_make_control(RP1_OP_KERNEL_DISPATCH,
+                                     RP1_FLAG_INFINITE,
+                                     RP1_NODE_WAITING));
     node.barrier_await_mask   = 0x00000003u;
     node.barrier_set_mask     = 0x00000004u;
     node.barrier_await_bucket = 0;
     node.barrier_set_bucket   = 1;
-    node.status               = RP1_NODE_PENDING;
 
-    CHECK_EQ32(node.opcode,               RP1_OP_KERNEL_DISPATCH,         "opcode");
-    CHECK_EQ32(node.flags,                RP1_FLAG_HALT_ON_ERROR |
-                                          RP1_FLAG_INFINITE,               "flags");
+    CHECK_EQ32(rp1_node_get_opcode(&node), RP1_OP_KERNEL_DISPATCH, "opcode");
+    CHECK_EQ32(rp1_node_get_flags(&node),  RP1_FLAG_INFINITE,      "flags");
+    CHECK_EQ32(rp1_node_get_status(&node), RP1_NODE_WAITING,       "status");
     CHECK_EQ32(node.barrier_await_mask,   0x3u,                            "await_mask");
     CHECK_EQ32(node.barrier_set_mask,     0x4u,                            "set_mask");
     CHECK_EQ32(node.barrier_await_bucket, 0u,                              "await_bucket");
     CHECK_EQ32(node.barrier_set_bucket,   1u,                              "set_bucket");
-    CHECK_EQ32(node.status,               RP1_NODE_PENDING,                "status");
+
+    /* Component setters preserve every unrelated nibble, including reserved. */
+    rp1_node_set_control(&node, (uint16_t)(node.control | 0xA000u));
+    rp1_node_set_opcode(&node, RP1_OP_HALT);
+    rp1_node_set_flags(&node, 0xFu);
+    rp1_node_set_status(&node, RP1_NODE_ERROR);
+    CHECK_EQ32(rp1_node_get_control(&node), 0xA4FDu, "packed control");
+    CHECK_EQ32(rp1_node_get_opcode(&node), RP1_OP_HALT, "updated opcode");
+    CHECK_EQ32(rp1_node_get_flags(&node), 0xFu, "updated flags");
+    CHECK_EQ32(rp1_node_get_status(&node), RP1_NODE_ERROR, "updated status");
 
     /* Verify the payload union shares the same storage (no extra padding). */
-    CHECK_EQ32((uint32_t)sizeof(node.payload.raw), 48u, "payload raw size");
+    CHECK_EQ32((uint32_t)sizeof(node.payload.raw), 20u, "payload raw size");
 
     return 0;
 }
 
 static int test_node_alignment(void)
 {
-    /* An array of nodes must be packed 64 bytes apart. */
+    /* Natural four-byte alignment produces the exact 32-byte array stride. */
     rp1_node_t arr[2];
     uintptr_t delta = (uintptr_t)&arr[1] - (uintptr_t)&arr[0];
-    CHECK_EQ32((uint32_t)delta, 64u, "node stride 64");
+    CHECK_EQ32((uint32_t)delta, 32u, "node stride 32");
+    CHECK_EQ32((uint32_t)((uintptr_t)&arr[0] & 3u), 0u,
+               "node natural alignment");
+    return 0;
+}
+
+/* Exercise every packed DMA field getter and replacement helper. */
+static int test_dma_packing(void)
+{
+    uint32_t packed = rp1_dma_pack(0x0ABCDEFCu, 1u, 2u);
+
+    CHECK_EQ32(rp1_dma_get_length(packed), 0x0ABCDEFCu,
+               "dma packed length");
+    CHECK_EQ32(rp1_dma_get_src_type(packed), 1u, "dma packed source");
+    CHECK_EQ32(rp1_dma_get_dst_type(packed), 2u, "dma packed destination");
+    packed = rp1_dma_set_length(packed, 0x1234u);
+    packed = rp1_dma_set_src_type(packed, 3u);
+    packed = rp1_dma_set_dst_type(packed, 0u);
+    CHECK_EQ32(rp1_dma_get_length(packed), 0x1234u,
+               "dma replaced length");
+    CHECK_EQ32(rp1_dma_get_src_type(packed), 3u,
+               "dma replaced source");
+    CHECK_EQ32(rp1_dma_get_dst_type(packed), 0u,
+               "dma replaced destination");
+    return 0;
+}
+
+/*
+ * Exercise CSR fan-out, barrier clear/republication, WAIT parking, and dense
+ * graph fallback without involving the graph execution loop.
+ */
+static int test_event_scheduler(void)
+{
+    rp1_store_reset_graph();
+    for (uint32_t i = 0u; i < 3u; i++) {
+        rp1_node_set_control(
+            &g_nodes[i],
+            rp1_node_make_control(RP1_OP_NOP, 0u, RP1_NODE_PENDING));
+        g_nodes[i].barrier_await_bucket = 0u;
+        g_nodes[i].barrier_await_mask = i == 0u ? 0u : 1u;
+        g_nodes[i].barrier_set_bucket = 0u;
+        g_nodes[i].barrier_set_mask = 1u << i;
+    }
+
+    CHECK_EQ32(rp1_scheduler_build(3u), 1u,
+               "scheduler sparse index enabled");
+    CHECK_EQ32(rp1_scheduler_subscription_count(), 2u,
+               "scheduler fanout subscriptions");
+    uint32_t node = UINT32_MAX;
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 1u,
+               "scheduler root ready");
+    CHECK_EQ32(node, 0u, "scheduler root index");
+    rp1_node_set_status(&g_nodes[0], RP1_NODE_DONE);
+    rp1_scheduler_remove_node(0u);
+    rp1_scheduler_set_barriers(0u, 1u);
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 1u,
+               "scheduler first fanout ready");
+    CHECK_EQ32(node, 1u, "scheduler first fanout index");
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 1u,
+               "scheduler second fanout ready");
+    CHECK_EQ32(node, 2u, "scheduler second fanout index");
+
+    rp1_scheduler_clear_barriers(0u, 1u);
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 0u,
+               "scheduler clear blocks subscribers");
+    rp1_scheduler_set_barriers(0u, 1u);
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 1u,
+               "scheduler republish wakes first");
+    CHECK_EQ32(node, 1u, "scheduler republish first index");
+    CHECK_EQ32(rp1_scheduler_pop_ready(&node), 1u,
+               "scheduler republish wakes second");
+    CHECK_EQ32(node, 2u, "scheduler republish second index");
+
+    rp1_node_set_status(&g_nodes[1], RP1_NODE_WAITING);
+    rp1_scheduler_park_wait(1u);
+    node = UINT32_MAX;
+    CHECK_EQ32(rp1_scheduler_next_waiting(0u, &node), 1u,
+               "scheduler parked wait found");
+    CHECK_EQ32(node, 1u, "scheduler parked wait index");
+    rp1_scheduler_remove_node(1u);
+    CHECK_EQ32(rp1_scheduler_next_waiting(0u, &node), 0u,
+               "scheduler parked wait removed");
+
+    rp1_store_reset_graph();
+    const uint32_t dense_nodes =
+        RP1_SCHEDULER_MAX_SUBSCRIPTIONS / 32u + 1u;
+    for (uint32_t i = 0u; i < dense_nodes; i++) {
+        rp1_node_set_control(
+            &g_nodes[i],
+            rp1_node_make_control(RP1_OP_NOP, 0u, RP1_NODE_PENDING));
+        g_nodes[i].barrier_await_bucket = 0u;
+        g_nodes[i].barrier_await_mask = UINT32_MAX;
+    }
+    CHECK_EQ32(rp1_scheduler_build(dense_nodes), 0u,
+               "scheduler dense graph fallback");
+    CHECK_EQ32(rp1_scheduler_enabled(), 0u,
+               "scheduler fallback disabled index");
     return 0;
 }
 
@@ -391,6 +580,8 @@ void rp1_main(void)
     run("condops",             test_condops);
     run("node_header",         test_node_header);
     run("node_alignment",      test_node_alignment);
+    run("dma_packing",         test_dma_packing);
+    run("event_scheduler",      test_event_scheduler);
 
     semi_puts("\n=== RP1 graph tests ===\n");
     rp1_graph_test_run();

--- a/linker/test/emit/hw/test_rp1_packaging.py
+++ b/linker/test/emit/hw/test_rp1_packaging.py
@@ -80,6 +80,94 @@ def test_rp1_package_resources_stage_without_generated_dirs(tmp_path):
     _assert_no_generated_dirs(staged)
 
 
+def test_plm_package_resources_patch_sparse_ipi_dispatch(tmp_path):
+    """The staged custom PLM replaces the faulty sparse-mask demultiplexer."""
+    aved_resources = resources.files("slashkit.resources.aved")
+    root = aved_resources.joinpath("plm")
+    required = ("build-plm.sh", "tools/patch_xilplmi.py")
+    assert all(root.joinpath(*name.split("/")).is_file()
+               for name in required)
+    build_all = aved_resources.joinpath("build_all.sh").read_text()
+    bif = aved_resources.joinpath("pdi_combine.bif").read_text()
+    assert "build-plm.sh" not in build_all
+    assert "type=bootloader, file=./build/plm.elf" not in bif
+    _assert_no_generated_dirs(root)
+
+    aved_dir = tmp_path / "AVED"
+    project_gen._copy_plm_sources_to_aved(aved_dir)
+    staged = aved_dir / "fw" / "PLM"
+    assert all((staged / name).is_file() for name in required)
+
+    platform_source = (
+        tmp_path / "bsp" / "libsrc" / "xilplmi" / "src" /
+        "versal" / "server" / "xplmi_plat.c"
+    )
+    platform_source.parent.mkdir(parents=True)
+    platform_source.write_text(
+        """
+\tu32 IpiIndex;
+\tu32 IpiIndexMask;
+\tfor (IpiIndex = 0U; IpiIndex < XPLMI_IPI_MASK_COUNT; ++IpiIndex) {
+\t\tIpiIndexMask = (u32)1U << IpiIndex;
+\t\tif (((IpiIntrVal & IpiIndexMask) != 0U) &&
+\t\t\t((IpiMaskVal & IpiIndexMask) == 0U)) {
+\t\t\tXPlmi_GicIntrAddTask(XPlmi_GetIpiIntrId(IpiIndex));
+\t\t}
+\t}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            str(staged / "tools" / "patch_xilplmi.py"),
+            "--bsp-root",
+            str(tmp_path / "bsp"),
+        ],
+        check=True,
+    )
+
+    patched = platform_source.read_text(encoding="utf-8")
+    assert "IpiInstance->Config.TargetCount" in patched
+    assert "TargetList[IpiIndex].Mask" in patched
+    assert "TargetList[IpiIndex].BufferIndex" in patched
+    assert "1U << IpiIndex" not in patched
+
+
+def test_patched_plm_build_reuses_existing_amc_sdt(tmp_path, monkeypatch):
+    """Firmware-only repacks avoid regenerating SDT metadata when possible."""
+    aved_dir = tmp_path / "AVED"
+    plm_dir = aved_dir / "fw" / "PLM"
+    plm_dir.mkdir(parents=True)
+    (plm_dir / "build-plm.sh").write_text("# fixture\n")
+    xsa = tmp_path / "shell.xsa"
+    xsa.write_bytes(b"xsa")
+    amc_sdt = (
+        aved_dir / "fw" / "AMC" / "amc_bsp" /
+        "versal_sdt" / "system-top.dts"
+    )
+    amc_sdt.parent.mkdir(parents=True)
+    amc_sdt.write_text("/dts-v1/;\n")
+    calls = []
+
+    def fake_run(command, cwd, env, check):
+        calls.append((command, Path(cwd), env, check))
+        output = plm_dir / "build" / "plm.elf"
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"plm")
+
+    monkeypatch.setattr(project_gen.subprocess, "run", fake_run)
+
+    output = project_gen._build_patched_plm(aved_dir, xsa)
+
+    assert output.read_bytes() == b"plm"
+    assert calls[0][0] == ["bash", "build-plm.sh"]
+    assert calls[0][1] == plm_dir
+    assert calls[0][2]["XSA"] == str(xsa)
+    assert calls[0][2]["PLM_SDT"] == str(amc_sdt)
+    assert calls[0][3] is True
+
+
 def test_packaged_rp1_protocol_header_is_synchronized():
     repo_root = Path(__file__).resolve().parents[4]
     subprocess.run(
@@ -116,6 +204,7 @@ def test_rp1_repack_installs_fpt_and_nofpt_outputs(tmp_path, monkeypatch):
         aved_build_dir / "top_wrapper.pdi",
         aved_build_dir / f"{project_gen.AVED_DESIGN_NAME}.xsa",
         aved_build_dir / "amc.elf",
+        aved_build_dir / "plm.elf",
         aved_build_dir / "fpt.bin",
         fpt_dir / "pdi_combine.bif",
         fpt_dir / "fpt_pdi_gen.py",

--- a/scripts/extra/test-graph-hardware.sh
+++ b/scripts/extra/test-graph-hardware.sh
@@ -56,7 +56,7 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
-REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd -P)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd -P)
 BDF=$1
 ROOT=${2:-${GRAPH_EXAMPLES_ROOT:-"$REPO_ROOT/examples/graph"}}
 
@@ -256,13 +256,11 @@ run_foreground() {
 verify_case_evidence() {
     local label=$1
     local log=$2
-    local expected_pdis=$3
+    local expected_pdi_traces=$3
     local pass_text=$4
 
     grep -Fq "$pass_text" "$log" ||
         die "$label did not report its host-reference PASS"
-    grep -Eq '^\[rp1-cq\] entries=[0-9]+' "$log" ||
-        die "$label is missing VRT_RP1_CQ output"
     grep -Eq '^\[rp1-trace\] written=[0-9]+ entries=[0-9]+' "$log" ||
         die "$label is missing VRT_RP1_TRACE output"
     if grep -Eq '^\[rp1-trace\].*([[:space:]]|^)overflow([[:space:]]|$)' "$log"; then
@@ -271,16 +269,71 @@ verify_case_evidence() {
     grep -Eq 'event=GRAPH_DONE\([0-9]+\).*aux0=0x0([[:space:]]|$)' "$log" ||
         die "$label is missing successful RP1 GRAPH_DONE evidence"
 
+    # Every diagnostic is one complete result line. Validate all fields rather
+    # than accepting a success token detached from recovery, image, timing,
+    # trace, or quiescence evidence.
+    local result_count=0
+    local last_result_seq=
+    local line
+    while IFS= read -r line; do
+        [[ -n $line ]] || continue
+        local fields
+        read -r -a fields <<<"$line"
+        ((${#fields[@]} == 10)) ||
+            die "$label has a malformed RP1 result diagnostic: $line"
+        [[ ${fields[0]} == "[rp1-result]" ]] ||
+            die "$label has an invalid RP1 result prefix"
+
+        local seq=${fields[1]#seq=}
+        local outcome=${fields[2]#outcome=}
+        local flags=${fields[3]#flags=}
+        local image=${fields[4]#image=}
+        local completed=${fields[5]#completed=}
+        local graph_ticks=${fields[6]#graph_ticks=}
+        local publish_ticks=${fields[7]#publish_ticks=}
+        local trace_write_idx=${fields[8]#trace_write_idx=}
+        local quiescence=${fields[9]#quiescence=}
+
+        [[ $seq =~ ^[0-9]+$ ]] ||
+            die "$label result has a non-numeric sequence"
+        [[ $outcome == "SUCCESS(1)" ]] ||
+            die "$label result outcome is $outcome, expected SUCCESS(1)"
+        [[ $flags =~ ^0[xX][0-9a-fA-F]+$ ]] ||
+            die "$label result has malformed flags: $flags"
+        local flag_value=$((flags))
+        (( (flag_value & 0xffffffc0) == 0 )) ||
+            die "$label result reports unknown protocol-v6 flags: $flags"
+        (( (flag_value & 0x08) != 0 )) ||
+            die "$label result does not report trace-enabled execution"
+        (( (flag_value & 0x17) == 0 )) ||
+            die "$label result reports failure/recovery flags: $flags"
+        [[ $image =~ ^KNOWN\(1\):([1-9][0-9]*)$ ]] ||
+            die "$label result does not report a known non-zero image: $image"
+        [[ $completed =~ ^[1-9][0-9]*$ ]] ||
+            die "$label result has no completed operations"
+        [[ $graph_ticks =~ ^[0-9]+$ &&
+           $publish_ticks =~ ^[0-9]+$ &&
+           $trace_write_idx =~ ^[1-9][0-9]*$ ]] ||
+            die "$label result has malformed timing/trace fields"
+        local publish_delta=$(((publish_ticks - graph_ticks) & 0xffffffff))
+        ((publish_delta < 0x80000000)) ||
+            die "$label result publication precedes graph completion"
+        [[ $quiescence == "0/0/0" ]] ||
+            die "$label result required quiescence: $quiescence"
+
+        last_result_seq=$seq
+        ((result_count += 1))
+    done < <(grep -E '^\[rp1-result\]' "$log" || true)
+    ((result_count > 0)) ||
+        die "$label is missing VRT_RP1_RESULT output"
+    CASE_LAST_RESULT_SEQ=$last_result_seq
+
     local pdi_trace_count
-    local pdi_cq_count
     pdi_trace_count=$(grep -Ec \
         'event=PDI_LOAD\([0-9]+\).*aux0=0x0[[:space:]]+aux1=0x[0-9a-fA-F]+([[:space:]]|$)' \
         "$log" || true)
-    pdi_cq_count=$(grep -Ec 'opcode=PDI_LOAD status=OK\(0\)' "$log" || true)
-    ((pdi_trace_count >= expected_pdis)) ||
-        die "$label has $pdi_trace_count successful PDI trace record(s), expected at least $expected_pdis"
-    ((pdi_cq_count >= expected_pdis)) ||
-        die "$label has $pdi_cq_count successful PDI CQ record(s), expected at least $expected_pdis"
+    ((pdi_trace_count >= expected_pdi_traces)) ||
+        die "$label has $pdi_trace_count successful PDI trace record(s), expected at least $expected_pdi_traces"
 }
 
 run_case() {
@@ -290,7 +343,7 @@ run_case() {
     shift 3
     local log="$ARTIFACT_DIR/$label.log"
     run_foreground "$label" "$CASE_TIMEOUT" "$log" \
-        "$ENV_PATH" VRT_RP1_TRACE=1 VRT_RP1_CQ=1 "$@"
+        "$ENV_PATH" VRT_RP1_TRACE=1 VRT_RP1_RESULT=1 "$@"
     verify_case_evidence "$label" "$log" "$expected_pdis" "$pass_text"
 }
 
@@ -307,6 +360,8 @@ is_zero_value() {
 }
 
 RP1_LAST_SEQ=
+RP1_LAST_RESULT_SEQ=
+CASE_LAST_RESULT_SEQ=
 run_rp1_dump() {
     local label=$1
     local log="$ARTIFACT_DIR/$label.log"
@@ -338,7 +393,7 @@ run_rp1_dump() {
     done_seq=$(field_value "$log" graph_done_seq) ||
         die "$label is missing graph_done_seq"
 
-    [[ $version == 4 ]] || die "$label reports protocol v$version, expected v4"
+    [[ $version == 6 ]] || die "$label reports protocol v$version, expected v6"
     is_zero_value "$missing" || die "$label reports missing capabilities: $missing"
     ! is_zero_value "$platform" || die "$label reports an unknown platform/IPI identity"
     [[ $state == 1 ]] || die "$label reports RP1 state $state, expected READY (1)"
@@ -349,7 +404,108 @@ run_rp1_dump() {
         die "$label reports non-numeric graph sequence fields"
     [[ $seq == "$done_seq" ]] ||
         die "$label reports incomplete graph sequence: graph_seq=$seq graph_done_seq=$done_seq"
+
+    local result_magic result_seq result_outcome result_flags
+    local result_error result_node result_opcode result_detail result_aux
+    local result_image result_image_state result_completed
+    local result_graph_ticks result_publish_ticks result_trace_idx
+    local result_quiescence
+    result_magic=$(field_value "$log" result.magic) ||
+        die "$label is missing graph-result magic"
+    result_seq=$(field_value "$log" result.graph_seq) ||
+        die "$label is missing graph-result sequence"
+    result_outcome=$(field_value "$log" result.outcome) ||
+        die "$label is missing graph-result outcome"
+    result_flags=$(field_value "$log" result.flags) ||
+        die "$label is missing graph-result flags"
+    result_error=$(field_value "$log" result.error_code) ||
+        die "$label is missing graph-result error code"
+    result_node=$(field_value "$log" result.terminal_node) ||
+        die "$label is missing graph-result terminal node"
+    result_opcode=$(field_value "$log" result.terminal_opcode) ||
+        die "$label is missing graph-result terminal opcode"
+    result_detail=$(field_value "$log" result.error_detail) ||
+        die "$label is missing graph-result error detail"
+    result_aux=$(field_value "$log" result.error_aux) ||
+        die "$label is missing graph-result error auxiliary detail"
+    result_image=$(field_value "$log" result.active_image_id) ||
+        die "$label is missing graph-result active image"
+    result_image_state=$(field_value "$log" result.image_state) ||
+        die "$label is missing graph-result image state"
+    result_completed=$(field_value "$log" result.completed_operations) ||
+        die "$label is missing graph-result completed-operation count"
+    result_graph_ticks=$(field_value "$log" result.graph_elapsed_ticks) ||
+        die "$label is missing graph-result graph timing"
+    result_publish_ticks=$(field_value "$log" result.publish_elapsed_ticks) ||
+        die "$label is missing graph-result publication timing"
+    result_trace_idx=$(field_value "$log" result.trace_write_idx) ||
+        die "$label is missing graph-result trace cursor"
+    result_quiescence=$(field_value "$log" result.quiescence) ||
+        die "$label is missing graph-result quiescence"
+
+    if is_zero_value "$result_magic"; then
+        [[ $done_seq == 0 ]] ||
+            die "$label has no committed result for graph_done_seq=$done_seq"
+        is_zero_value "$result_seq" ||
+            die "$label has an uncommitted non-zero result sequence"
+        is_zero_value "$result_outcome" ||
+            die "$label has an uncommitted terminal result outcome"
+    else
+        [[ ${result_magic,,} == 0x52534c54 ]] ||
+            die "$label has invalid graph-result magic: $result_magic"
+        [[ $result_seq == "$done_seq" ]] ||
+            die "$label result sequence $result_seq does not match graph_done_seq=$done_seq"
+        [[ $result_outcome == 1 ]] ||
+            die "$label result outcome is $result_outcome, expected SUCCESS (1)"
+        [[ $result_flags =~ ^0[xX][0-9a-fA-F]+$ ]] ||
+            die "$label has malformed graph-result flags: $result_flags"
+        local result_flag_value=$((result_flags))
+        (( (result_flag_value & 0xffffffc0) == 0 )) ||
+            die "$label result reports unknown protocol-v6 flags: $result_flags"
+        (( (result_flag_value & 0x17) == 0 )) ||
+            die "$label result reports failure/recovery flags: $result_flags"
+        if (( (result_flag_value & 0x08) != 0 )); then
+            [[ $result_trace_idx =~ ^[1-9][0-9]*$ ]] ||
+                die "$label traced result has no trace records"
+        else
+            is_zero_value "$result_trace_idx" ||
+                die "$label untraced result carries trace cursor $result_trace_idx"
+        fi
+        is_zero_value "$result_error" ||
+            die "$label result reports error code $result_error"
+        [[ ${result_node,,} == 0xffffffff ]] ||
+            die "$label result reports terminal node $result_node"
+        [[ ${result_opcode,,} == 0xffffffff ]] ||
+            die "$label result reports terminal opcode $result_opcode"
+        is_zero_value "$result_detail" ||
+            die "$label result reports error detail $result_detail"
+        is_zero_value "$result_aux" ||
+            die "$label result reports error auxiliary detail $result_aux"
+        if [[ $result_image_state == 0 ]]; then
+            is_zero_value "$result_image" ||
+                die "$label result NONE image state carries id $result_image"
+        elif [[ $result_image_state == 1 ]]; then
+            ! is_zero_value "$result_image" ||
+                die "$label result KNOWN image state carries id zero"
+        else
+            die "$label result reports unhealthy image state $result_image_state"
+        fi
+        [[ $result_completed =~ ^[1-9][0-9]*$ ]] ||
+            die "$label result has no completed operations"
+        [[ $result_graph_ticks =~ ^[0-9]+$ &&
+           $result_publish_ticks =~ ^[0-9]+$ &&
+           $result_trace_idx =~ ^[0-9]+$ ]] ||
+            die "$label result has malformed timing/trace fields"
+        local result_publish_delta=$((
+            (result_publish_ticks - result_graph_ticks) & 0xffffffff
+        ))
+        ((result_publish_delta < 0x80000000)) ||
+            die "$label result publication precedes graph completion"
+        is_zero_value "$result_quiescence" ||
+            die "$label result reports quiescence $result_quiescence"
+    fi
     RP1_LAST_SEQ=$seq
+    RP1_LAST_RESULT_SEQ=$result_seq
 }
 
 run_case_and_dump() {
@@ -359,9 +515,12 @@ run_case_and_dump() {
     shift 3
     local previous_seq=$RP1_LAST_SEQ
     run_case "$label" "$expected_pdis" "$pass_text" "$@"
+    local case_result_seq=$CASE_LAST_RESULT_SEQ
     run_rp1_dump "$label.rp1"
     [[ $RP1_LAST_SEQ != "$previous_seq" ]] ||
         die "$label returned success without advancing graph_done_seq"
+    [[ $RP1_LAST_RESULT_SEQ == "$case_result_seq" ]] ||
+        die "$label VRT result seq=$case_result_seq disagrees with RP1 dump seq=$RP1_LAST_RESULT_SEQ"
 }
 
 socket_args=()

--- a/scripts/test-graph-hardware-local.sh
+++ b/scripts/test-graph-hardware-local.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd -P)
-ACCEPTANCE="$SCRIPT_DIR/test-graph-hardware.sh"
+ACCEPTANCE="$SCRIPT_DIR/extra/test-graph-hardware.sh"
 
 git -C "$REPO_ROOT" check-ignore -q tmp ||
     {
@@ -63,8 +63,8 @@ set -euo pipefail
     echo "VRT_RP1_TRACE was not enabled" >&2
     exit 91
 }
-[[ ${VRT_RP1_CQ:-} == 1 ]] || {
-    echo "VRT_RP1_CQ was not enabled" >&2
+[[ ${VRT_RP1_RESULT:-} == 1 ]] || {
+    echo "VRT_RP1_RESULT was not enabled" >&2
     exit 92
 }
 
@@ -136,15 +136,24 @@ if [[ ${FAKE_MODE:-success} == missing-pdi ]]; then
     pdis=0
 fi
 
-echo "[rp1-cq] entries=$pdis"
-for ((i = 0; i < pdis; ++i)); do
-    echo "  cq[$i] node=$i opcode=PDI_LOAD status=OK(0) detail=0x0 timestamp=$((i + 1))"
-done
-
 trace_suffix=
 if [[ ${FAKE_MODE:-success} == overflow ]]; then
     trace_suffix=' overflow'
 fi
+result_flags=0x8
+if [[ $name == sharpen_loop ]]; then
+    # The unchosen conditional branch remains pending on successful hardware.
+    result_flags=0x28
+fi
+printf '%s\n' "$result_flags" >"$FAKE_STATE_DIR/result-flags"
+if [[ ${FAKE_MODE:-success} != missing-result ]]; then
+    result_outcome='SUCCESS(1)'
+    if [[ ${FAKE_MODE:-success} == failed-result ]]; then
+        result_outcome='FAILED(2)'
+    fi
+    echo "[rp1-result] seq=$((seq + 1)) outcome=$result_outcome flags=$result_flags image=KNOWN(1):1 completed=$((pdis + 1)) graph_ticks=$((pdis + 10)) publish_ticks=$((pdis + 12)) trace_write_idx=$((pdis + 2)) quiescence=0/0/0"
+fi
+
 echo "[rp1-trace] written=$((pdis + 2)) entries=$((pdis + 2))$trace_suffix"
 for ((i = 0; i < pdis; ++i)); do
     echo "  trace[$i] t=$((i + 1)) event=PDI_LOAD(9) node=$i aux0=0x0 aux1=0x0"
@@ -170,18 +179,37 @@ dump_count=$(<"$FAKE_STATE_DIR/dump-count")
 printf '%s\n' "$((dump_count + 1))" >"$FAKE_STATE_DIR/dump-count"
 hb=$((1000 + dump_count * 10))
 
+result_magic=0x00000000
+result_outcome=0
+result_flags=0x00000000
+result_image=0
+result_image_state=0
+result_completed=0
+result_graph_ticks=0
+result_publish_ticks=0
+result_trace_idx=0
+if ((seq != 0)); then
+    result_magic=0x52534c54
+    result_outcome=1
+    result_flags=$(<"$FAKE_STATE_DIR/result-flags")
+    result_image=1
+    result_image_state=1
+    result_completed=$((seq + 1))
+    result_graph_ticks=$((seq + 10))
+    result_publish_ticks=$((seq + 12))
+    result_trace_idx=$((seq + 2))
+fi
+
 cat <<DUMP
 RP1 control block @ R5 0x30000000 (BAR4 + 0x4000000):
   magic            = 0x53515231 (SQR1)
-  version          = 4
-  capabilities     = 0x0000001f
-  required_capabilities = 0x0000001f
+  version          = 6
+  capabilities     = 0x0000007b
+  required_capabilities = 0x0000007b
   missing_capabilities  = 0x00000000
   pdi_ipi_platform_id   = 0x1234abcd (generated platform/IPI identity)
   graph_seq        = $seq
   graph_done_seq   = $seq
-  cq_write_idx     = $seq
-  cq_read_idx      = $seq
   rp1_state        = 1 (READY)
   rp1_error_code   = 0
   rp1_current_node = 4294967295
@@ -189,6 +217,23 @@ RP1 control block @ R5 0x30000000 (BAR4 + 0x4000000):
   terminal_error_detail = 0x00000000
   terminal_error_aux    = 0x00000000
   heartbeat        = $hb
+Graph result:
+  result.magic              = $result_magic
+  result.graph_seq          = $seq
+  result.outcome            = $result_outcome
+  result.flags              = $result_flags
+  result.error_code         = 0
+  result.terminal_node      = 0xffffffff (none)
+  result.terminal_opcode    = 0xffffffff (NONE)
+  result.error_detail       = 0x00000000
+  result.error_aux          = 0x00000000
+  result.active_image_id    = $result_image
+  result.image_state        = $result_image_state
+  result.completed_operations = $result_completed
+  result.graph_elapsed_ticks  = $result_graph_ticks
+  result.publish_elapsed_ticks = $result_publish_ticks
+  result.trace_write_idx      = $result_trace_idx
+  result.quiescence           = 0x00000000
 Protocol contract: compatible
 Liveness: heartbeat advanced $hb -> $((hb + 1)) (running)
 DUMP
@@ -215,6 +260,7 @@ reset_state() {
     printf '0\n' >"$FAKE_STATE/seq"
     printf '0\n' >"$FAKE_STATE/multi-count"
     printf '0\n' >"$FAKE_STATE/dump-count"
+    printf '0x0\n' >"$FAKE_STATE/result-flags"
     : >"$FAKE_STATE/invocations"
 }
 
@@ -281,6 +327,8 @@ expect_failure() {
 }
 
 expect_failure missing-pdi missing-pdi
+expect_failure missing-result missing-result
+expect_failure failed-result failed-result
 expect_failure missing-graph missing-graph
 expect_failure overflow trace-overflow
 expect_failure timeout watchdog 1s

--- a/scripts/verify-rp1.sh
+++ b/scripts/verify-rp1.sh
@@ -2,42 +2,206 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# Verify that RP1 firmware is running by reading the shared control block.
+# Verify protocol-v6 firmware liveness and its last committed graph result.
 # Usage: verify_rp1.sh [control_block_base] [bdf]
 #   control_block_base: DDR base of RP1 control block (default: 0x30000000)
 #   bdf:     PCIe BDF of the device (default: auto-detect)
 set -euo pipefail
 
-CTRL_BASE=${1:-0x30000000}
-HEARTBEAT_ADDR=$((CTRL_BASE + 0x3C))
+CTRL_BASE_TEXT=${1:-0x30000000}
+CTRL_BASE=$((CTRL_BASE_TEXT))
 STATE_ADDR=$((CTRL_BASE + 0x30))
+HEARTBEAT_ADDR=$((CTRL_BASE + 0x3C))
+SEQUENCE_ADDR=$((CTRL_BASE + 0x20))
+RESULT_ADDR=$((CTRL_BASE + 0x80))
+CONTRACT_ADDR=$((CTRL_BASE + 0x64))
 
-BDF_ARGS=""
-if [ -n "${2:-}" ]; then
-    BDF_ARGS="--device $2"
+BDF_ARGS=()
+if [[ -n ${2:-} ]]; then
+    BDF_ARGS=(--device "$2")
 fi
 
-echo "Checking RP1 control block at ${CTRL_BASE} (heartbeat ${HEARTBEAT_ADDR})..."
-
-# Read the first four control words: magic, version, node_count, cq_size.
-RESULT=$(v80-smi debug mem-poke ${BDF_ARGS} --region RAW --read --hex "${CTRL_BASE}" --word-size 4 --count 4 2>&1) || {
-    echo "ERROR: Failed to read control block at ${CTRL_BASE}"
-    echo "${RESULT}"
+# Print one fatal verification diagnostic and exit.
+fail() {
+    echo "ERROR: $*" >&2
     exit 1
 }
 
-echo "Control block[0:4]: ${RESULT}"
+# read_words ADDRESS COUNT DESCRIPTION populates WORDS with exact uint32 output.
+WORDS=()
+read_words() {
+    local address=$1
+    local count=$2
+    local description=$3
+    local output
+    output=$(v80-smi debug mem-poke "${BDF_ARGS[@]}" \
+        --region RAW --read --hex "$address" \
+        --word-size 4 --count "$count" 2>&1) ||
+        fail "Failed to read $description at $address: $output"
+    mapfile -t WORDS < <(
+        printf '%s\n' "$output" |
+            awk '/^0[xX][0-9a-fA-F]+$/ { print }'
+    )
+    ((${#WORDS[@]} == count)) ||
+        fail "$description returned ${#WORDS[@]} words, expected $count: $output"
+}
 
-STATE=$(v80-smi debug mem-poke ${BDF_ARGS} --region RAW --read --hex "${STATE_ADDR}" --word-size 4 --count 1 2>&1) || true
-echo "RP1 state @ ${STATE_ADDR}: ${STATE}"
+# Return true when a hexadecimal mem-poke word is zero.
+is_zero_word() {
+    (($1 == 0))
+}
 
-# Read heartbeat, wait, read again to check liveness.
-C1=$(v80-smi debug mem-poke ${BDF_ARGS} --region RAW --read --hex "${HEARTBEAT_ADDR}" --word-size 4 --count 1 2>&1) || true
-sleep 1
-C2=$(v80-smi debug mem-poke ${BDF_ARGS} --region RAW --read --hex "${HEARTBEAT_ADDR}" --word-size 4 --count 1 2>&1) || true
+printf 'Checking RP1 control block at 0x%x (result 0x%x, heartbeat 0x%x)...\n' \
+    "$CTRL_BASE" "$RESULT_ADDR" "$HEARTBEAT_ADDR"
 
-if [ "${C1}" != "${C2}" ]; then
-    echo "PASS: RP1 counter is incrementing (${C1} -> ${C2})"
+# Protocol v6 retains five CQ-era words as zero-only ABI reservations.
+read_words "$(printf '0x%x' "$CTRL_BASE")" 12 "control-block header"
+magic=${WORDS[0],,}
+version=${WORDS[1]}
+node_count=${WORDS[2]}
+reserved_0c=${WORDS[3]}
+reserved_18=${WORDS[6]}
+reserved_1c=${WORDS[7]}
+reserved_28=${WORDS[10]}
+reserved_2c=${WORDS[11]}
+printf 'Header: magic=%s version=%u node_count=%u\n' \
+    "$magic" "$((version))" "$((node_count))"
+printf 'Reserved: [0x0c]=%s [0x18]=%s [0x1c]=%s [0x28]=%s [0x2c]=%s\n' \
+    "$reserved_0c" "$reserved_18" "$reserved_1c" \
+    "$reserved_28" "$reserved_2c"
+[[ $magic == 0x53515231 ]] ||
+    fail "RP1 control magic is $magic, expected 0x53515231 (SQR1)"
+((version == 6)) ||
+    fail "RP1 protocol is v$((version)), expected v6"
+for offset_and_word in \
+    "0x0c:$reserved_0c" "0x18:$reserved_18" "0x1c:$reserved_1c" \
+    "0x28:$reserved_28" "0x2c:$reserved_2c"; do
+    offset=${offset_and_word%%:*}
+    word=${offset_and_word#*:}
+    is_zero_word "$word" ||
+        fail "protocol-v6 reserved control word $offset is non-zero: $word"
+done
+
+# Required capabilities and generated IPI identity commit graph-result behavior.
+read_words "$(printf '0x%x' "$CONTRACT_ADDR")" 2 "protocol capabilities"
+capabilities=${WORDS[0]}
+platform_id=${WORDS[1]}
+printf 'Contract: capabilities=%s platform_id=%s\n' \
+    "$capabilities" "$platform_id"
+(( (capabilities & 0x7b) == 0x7b )) ||
+    fail "RP1 is missing required protocol-v6 capabilities: $capabilities"
+! is_zero_word "$platform_id" ||
+    fail "RP1 reports an unknown platform/IPI identity"
+
+# READY plus a zero live error record is required for safe reuse.
+read_words "$(printf '0x%x' "$STATE_ADDR")" 4 "state diagnostics"
+state=${WORDS[0]}
+error_code=${WORDS[1]}
+current_node=${WORDS[2]}
+heartbeat_before=${WORDS[3]}
+printf 'State: state=%u error=%u current_node=%s heartbeat=%u\n' \
+    "$((state))" "$((error_code))" "$current_node" "$((heartbeat_before))"
+((state == 1)) || fail "RP1 state is $((state)), expected READY (1)"
+is_zero_word "$error_code" ||
+    fail "RP1 live error code is $((error_code)), expected zero"
+
+# Exact sequence equality releases one immutable graph-result snapshot.
+read_words "$(printf '0x%x' "$SEQUENCE_ADDR")" 2 "graph sequences"
+graph_seq=${WORDS[0]}
+graph_done_seq=${WORDS[1]}
+((graph_seq == graph_done_seq)) ||
+    fail "graph_seq=$((graph_seq)) does not match graph_done_seq=$((graph_done_seq))"
+
+read_words "$(printf '0x%x' "$RESULT_ADDR")" 16 "graph result"
+result_magic=${WORDS[0],,}
+result_seq=${WORDS[1]}
+result_outcome=${WORDS[2]}
+result_flags=${WORDS[3]}
+result_error=${WORDS[4]}
+result_node=${WORDS[5],,}
+result_opcode=${WORDS[6],,}
+result_detail=${WORDS[7]}
+result_aux=${WORDS[8]}
+result_image=${WORDS[9]}
+result_image_state=${WORDS[10]}
+result_completed=${WORDS[11]}
+result_graph_ticks=${WORDS[12]}
+result_publish_ticks=${WORDS[13]}
+result_trace_idx=${WORDS[14]}
+result_quiescence=${WORDS[15]}
+
+printf 'Result: magic=%s seq=%u outcome=%u flags=%s error=%u node=%s opcode=%s\n' \
+    "$result_magic" "$((result_seq))" "$((result_outcome))" "$result_flags" \
+    "$((result_error))" "$result_node" "$result_opcode"
+printf '        detail=%s aux=%s image_state=%u image_id=%u completed=%u\n' \
+    "$result_detail" "$result_aux" "$((result_image_state))" \
+    "$((result_image))" "$((result_completed))"
+printf '        graph_ticks=%u publish_ticks=%u trace_write_idx=%u quiescence=%s\n' \
+    "$((result_graph_ticks))" "$((result_publish_ticks))" \
+    "$((result_trace_idx))" "$result_quiescence"
+
+if is_zero_word "$result_magic"; then
+    is_zero_word "$graph_done_seq" ||
+        fail "graph_done_seq is non-zero but no result is committed"
+    is_zero_word "$result_seq" ||
+        fail "uncommitted result carries sequence $((result_seq))"
+    is_zero_word "$result_outcome" ||
+        fail "uncommitted result carries outcome $((result_outcome))"
+    echo "Result status: no graph has completed since firmware boot."
 else
-    echo "WARN: RP1 counter unchanged (${C1}). Firmware may be stuck or not running."
+    [[ $result_magic == 0x52534c54 ]] ||
+        fail "graph-result magic is $result_magic, expected 0x52534c54 (RSLT)"
+    ((result_seq == graph_done_seq)) ||
+        fail "result seq=$((result_seq)) does not match graph_done_seq=$((graph_done_seq))"
+    ((result_outcome == 1)) ||
+        fail "last graph outcome is $((result_outcome)), expected SUCCESS (1)"
+    (( (result_flags & 0xffffffc0) == 0 )) ||
+        fail "last graph reports unknown protocol-v6 flags: $result_flags"
+    (( (result_flags & 0x17) == 0 )) ||
+        fail "last graph reports failure/recovery flags: $result_flags"
+    if (( (result_flags & 0x08) != 0 )); then
+        ((result_trace_idx > 0)) ||
+            fail "trace-enabled result reports no trace records"
+    else
+        is_zero_word "$result_trace_idx" ||
+            fail "untraced result carries trace cursor $((result_trace_idx))"
+    fi
+    is_zero_word "$result_error" ||
+        fail "successful result carries error code $((result_error))"
+    [[ $result_node == 0xffffffff ]] ||
+        fail "successful result carries terminal node $result_node"
+    [[ $result_opcode == 0xffffffff ]] ||
+        fail "successful result carries terminal opcode $result_opcode"
+    is_zero_word "$result_detail" ||
+        fail "successful result carries error detail $result_detail"
+    is_zero_word "$result_aux" ||
+        fail "successful result carries error auxiliary detail $result_aux"
+    if ((result_image_state == 0)); then
+        is_zero_word "$result_image" ||
+            fail "NONE image state carries id $((result_image))"
+    elif ((result_image_state == 1)); then
+        ! is_zero_word "$result_image" ||
+            fail "KNOWN image state carries id zero"
+    else
+        fail "last graph reports unhealthy image state $((result_image_state))"
+    fi
+    ((result_completed > 0)) ||
+        fail "successful result reports no completed operations"
+    publish_delta=$((
+        (result_publish_ticks - result_graph_ticks) & 0xffffffff
+    ))
+    ((publish_delta < 0x80000000)) ||
+        fail "result publication timing precedes graph completion"
+    is_zero_word "$result_quiescence" ||
+        fail "successful result required quiescence: $result_quiescence"
 fi
+
+# Heartbeat liveness is independent of whether a graph has run.
+sleep 1
+read_words "$(printf '0x%x' "$HEARTBEAT_ADDR")" 1 "heartbeat"
+heartbeat_after=${WORDS[0]}
+((heartbeat_after != heartbeat_before)) ||
+    fail "RP1 heartbeat is unchanged at $((heartbeat_before))"
+
+printf 'PASS: RP1 protocol-v6 result is healthy; heartbeat advanced %u -> %u.\n' \
+    "$((heartbeat_before))" "$((heartbeat_after))"

--- a/smi/README.md
+++ b/smi/README.md
@@ -517,19 +517,21 @@ v80-smi debug rp1-dump -d <BDF> [-b <bar>] [--ctrl-offset <offset>]
 | `-b,--bar`        | BAR that maps the RP1 DDR window (default `4`)       |
 | `--ctrl-offset`   | Host BAR offset of the RP1 control block (default `0x4000000`; `0x...` for hex) |
 
-Prints `magic`, `version`, `node_count`, `cq_size`, the node/CQ/arg-buffer/
-signal-array base addresses, trace configuration, the protocol-v4 capability
-mask and each named capability, required/missing capabilities, the generated
-platform/IPI identity, `graph_seq`/`graph_done_seq`, both CQ cursors,
-`rp1_state`, `rp1_error_code`, `rp1_current_node`, all latched terminal-error
-fields, and `heartbeat`, then the protocol-compatibility and liveness verdicts.
+Prints `magic`, `version`, `node_count`, the node/argument/signal base
+addresses, trace configuration, the protocol-v6 capability mask and each named
+capability, required/missing capabilities, the generated platform/IPI identity,
+`graph_seq`/`graph_done_seq`, `rp1_state`, legacy live diagnostics, and
+`heartbeat`. It also decodes the complete committed graph result: commit magic,
+sequence, outcome, flags, first terminal error, final image state, completed
+operation count, graph/publication timing, trace cursor, and quiescence counts.
 It exits non-zero if `magic` isn't `RP1_CTRL_MAGIC` ("SQR1"), the protocol
 version/capability contract is incompatible, or the generated platform/IPI
 identity is zero.
 
-`rp1-dump` is read-only: it does not submit a graph, alter CQ cursors, or issue
-a PDI load. This makes it safe for before/after snapshots around the no-reset
-graph hardware acceptance sequence.
+`rp1-dump` is read-only: it does not submit a graph, alter the result record, or
+issue a PDI load. This makes it safe for before/after snapshots around the
+no-reset graph hardware acceptance sequence. Before the first graph after
+firmware boot, result magic is uncommitted and the outcome is `NONE`.
 
 Example:
 
@@ -545,7 +547,11 @@ Liveness: heartbeat advanced 128841 -> 129091 (running)
 
 Submit a one-node `SIGNAL` graph to RP1 and verify it completes end-to-end:
 programs the control block if needed, submits the graph, polls
-`graph_done_seq`, and checks the signal slot the node was expected to write.
+`graph_done_seq`, validates the sequence-tagged `SUCCESS` result, and checks the
+signal slot the node was expected to write. The probe rejects terminal error
+data, unknown image state, partial/recovery/overflow/unreached flags,
+unexpected quiescence, and inconsistent graph/publication timing. A successful
+probe prints the fully decoded result before its PASS summary.
 
 ```
 v80-smi debug rp1-ping -d <BDF> [-b <bar>] [--ctrl-offset <offset>]
@@ -553,27 +559,30 @@ v80-smi debug rp1-ping -d <BDF> [-b <bar>] [--ctrl-offset <offset>]
 
 Takes the same `-d`, `-b`, and `--ctrl-offset` flags as `debug rp1-dump`.
 Exits non-zero and dumps the control block on timeout, firmware-not-ready,
-or a signal-slot mismatch.
+result-contract failure, or a signal-slot mismatch.
 
 Example:
 
 ```console
 $ v80-smi debug rp1-ping -d 03:00
 rp1-ping: submitted seq=1, polling...
-PASS: slot[0] = 0xdeadbeef, cq_write_idx=1, state=1
+Graph result:
+  ...
+PASS: slot[0] = 0xdeadbeef, result_seq=1, outcome=SUCCESS, graph_ticks=3, publish_ticks=5, state=READY
 ```
 
 ### debug rp1-trace-ping
 
 Run the same one-node `SIGNAL` probe with RP1 tracing enabled, then print the
-completion-queue entries and trace records in chronological order.
+committed graph result and trace records in chronological order.
 
 ```
 v80-smi debug rp1-trace-ping -d <BDF> [-b <bar>] [--ctrl-offset <offset>]
 ```
 
 Takes the same options as `debug rp1-dump`. It exits non-zero if RP1 is not
-ready, the graph times out, or the sentinel signal is not produced.
+ready, the graph times out, the result is not a clean traced success, the
+result/control trace cursors disagree, or the sentinel signal is not produced.
 
 All three `rp1-*` commands require RP1 firmware to be loaded onto R5-1 and
 reporting `RP1_STATE_READY`; see

--- a/smi/src/debug/rp1_probe.cpp
+++ b/smi/src/debug/rp1_probe.cpp
@@ -47,20 +47,63 @@ namespace {
 
 /*
  * A distinctive nonzero sentinel distinguishes this probe's SIGNAL side effect
- * from reset state or stale zeroes; the matching CQ record proves the scanner,
- * rather than an unrelated writer, completed the node.
+ * from reset state or stale zeroes; the sequence-tagged graph result proves
+ * which scanner submission completed the node.
  */
 constexpr uint32_t kSignalMagic     = 0xDEADBEEFu;
-constexpr uint32_t kBringupCqSize   = 64u;
+/// Trace-ring capacity sufficient for the one-node probe lifecycle.
 constexpr uint32_t kBringupTraceSize = 64u;
+/// Absolute graph-result wait limit.
 constexpr auto     kPollTimeout     = std::chrono::seconds(3);
+/// Host polling cadence for sequence and heartbeat reads.
 constexpr auto     kPollInterval    = std::chrono::milliseconds(1);
+/// Heartbeat silence classified as a firmware stall.
 constexpr auto     kStallWindow     = std::chrono::milliseconds(500);
 
+/**
+ * @brief Stable host snapshot of the protocol-v6 graph result.
+ */
+struct GraphResultSnapshot {
+    /// Commit marker written after the result payload.
+    uint32_t magic = 0;
+    /// Exact accepted graph sequence.
+    uint32_t graphSeq = 0;
+    /// Terminal rp1_graph_outcome_t value.
+    uint32_t outcome = 0;
+    /// Raw RP1_RESULT_* mask.
+    uint32_t flags = 0;
+    /// First terminal RP1_ERR_* code.
+    uint32_t errorCode = 0;
+    /// Failing or HALT node.
+    uint32_t terminalNode = RP1_TERMINAL_ERROR_NODE_NONE;
+    /// Opcode associated with the terminal node.
+    uint32_t terminalOpcode = RP1_TERMINAL_OPCODE_NONE;
+    /// Error-specific primary detail.
+    uint32_t errorDetail = 0;
+    /// Error-specific auxiliary detail.
+    uint32_t errorAux = 0;
+    /// Final known image identifier.
+    uint32_t activeImageId = 0;
+    /// Final rp1_image_state_t value.
+    uint32_t imageState = RP1_IMAGE_STATE_NONE;
+    /// Successful operation executions, including loop repeats.
+    uint32_t completedOperations = 0;
+    /// PMU ticks through GRAPH_DONE.
+    uint32_t graphElapsedTicks = 0;
+    /// PMU ticks through final result preparation.
+    uint32_t publishElapsedTicks = 0;
+    /// Final trace producer cursor.
+    uint32_t traceWriteIndex = 0;
+    /// Packed terminal quiescence counts.
+    uint32_t quiescence = 0;
+};
+
+/// Return true when @p text starts with a C-style hexadecimal prefix.
 bool hasHexPrefix(std::string_view text) {
     return text.size() >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X');
 }
 
+/// Parse one decimal or prefixed-hexadecimal unsigned command-line value.
 uint64_t parseUnsigned(std::string_view text, const char* fieldName) {
     if (text.empty()) {
         throw std::invalid_argument(std::string(fieldName) + " is required");
@@ -86,6 +129,7 @@ uint64_t parseUnsigned(std::string_view text, const char* fieldName) {
     return value;
 }
 
+/// Return a diagnostic name for an RP1 firmware state.
 const char* stateStr(uint32_t s) {
     switch (s) {
     case RP1_STATE_INIT:    return "INIT";
@@ -97,6 +141,50 @@ const char* stateStr(uint32_t s) {
     }
 }
 
+/// Return a diagnostic name for a graph-result outcome.
+const char* outcomeStr(uint32_t outcome) {
+    switch (outcome) {
+    case RP1_GRAPH_RESULT_NONE:    return "NONE";
+    case RP1_GRAPH_RESULT_SUCCESS: return "SUCCESS";
+    case RP1_GRAPH_RESULT_FAILED:  return "FAILED";
+    case RP1_GRAPH_RESULT_HALTED:  return "HALTED";
+    default:                       return "?";
+    }
+}
+
+/// Return a diagnostic name for firmware image knowledge.
+const char* imageStateStr(uint32_t state) {
+    switch (state) {
+    case RP1_IMAGE_STATE_NONE:    return "NONE";
+    case RP1_IMAGE_STATE_KNOWN:   return "KNOWN";
+    case RP1_IMAGE_STATE_UNKNOWN: return "UNKNOWN";
+    default:                      return "?";
+    }
+}
+
+/// Return a diagnostic name for an RP1 graph opcode.
+const char* opcodeStr(uint32_t opcode) {
+    switch (opcode) {
+    case RP1_OP_NOP:             return "NOP";
+    case RP1_OP_WAIT:            return "WAIT";
+    case RP1_OP_SIGNAL:          return "SIGNAL";
+    case RP1_OP_KERNEL_DISPATCH: return "KERNEL_DISPATCH";
+    case RP1_OP_SCALAR_WRITE:    return "SCALAR_WRITE";
+    case RP1_OP_SCALAR_READ:     return "SCALAR_READ";
+    case RP1_OP_SCALAR_COPY:     return "SCALAR_COPY";
+    case RP1_OP_DMA_COPY:        return "DMA_COPY";
+    case RP1_OP_DMA_FILL:        return "DMA_FILL";
+    case RP1_OP_PDI_LOAD:        return "PDI_LOAD";
+    case RP1_OP_LOOP:            return "LOOP";
+    case RP1_OP_COND:            return "COND";
+    case RP1_OP_RERUN:           return "RERUN";
+    case RP1_OP_HALT:            return "HALT";
+    case RP1_TERMINAL_OPCODE_NONE: return "NONE";
+    default:                     return "?";
+    }
+}
+
+/// Return a diagnostic name for one optional trace event.
 const char* traceEventStr(uint32_t e) {
     switch (e) {
     case RP1_TRACE_GRAPH_START:    return "GRAPH_START";
@@ -111,23 +199,219 @@ const char* traceEventStr(uint32_t e) {
     case RP1_TRACE_PDI_LOAD:       return "PDI_LOAD";
     case RP1_TRACE_IMAGE_MISMATCH: return "IMAGE_MISMATCH";
     case RP1_TRACE_GRAPH_DONE:     return "GRAPH_DONE";
+    case RP1_TRACE_FLUSH_START:    return "TRACE_FLUSH_START";
+    case RP1_TRACE_FLUSH_END:      return "TRACE_FLUSH_END";
     default:                       return "?";
     }
 }
 
+/// Print whether firmware advertises one named capability.
 void printCapability(const char* name, uint32_t capabilities, uint32_t mask) {
     std::printf("    %-29s = %s\n", name,
                 (capabilities & mask) != 0u ? "yes" : "no");
 }
 
+/// Print whether one graph-result flag is present.
+void printResultFlag(const char* name, uint32_t flags, uint32_t mask) {
+    std::printf("    %-29s = %s\n", name,
+                (flags & mask) != 0u ? "yes" : "no");
+}
+
+/*
+ * Read each volatile word once after the graph_done_seq publication barrier.
+ * The returned object owns its values and cannot observe a later submission.
+ */
+GraphResultSnapshot snapshotResult(volatile rp1_ctrl_t* c) {
+    GraphResultSnapshot result;
+    result.magic = c->result.magic;
+    result.graphSeq = c->result.graph_seq;
+    result.outcome = c->result.outcome;
+    result.flags = c->result.flags;
+    result.errorCode = c->result.error_code;
+    result.terminalNode = c->result.terminal_node;
+    result.terminalOpcode = c->result.terminal_opcode;
+    result.errorDetail = c->result.error_detail;
+    result.errorAux = c->result.error_aux;
+    result.activeImageId = c->result.active_image_id;
+    result.imageState = c->result.image_state;
+    result.completedOperations = c->result.completed_operations;
+    result.graphElapsedTicks = c->result.graph_elapsed_ticks;
+    result.publishElapsedTicks = c->result.publish_elapsed_ticks;
+    result.traceWriteIndex = c->result.trace_write_idx;
+    result.quiescence = c->result.quiescence;
+    return result;
+}
+
+/// Print every field and decoded flag in a graph-result snapshot.
+void printGraphResult(const GraphResultSnapshot& result) {
+    std::printf("  result.magic              = 0x%08x (%s)\n",
+                result.magic,
+                result.magic == RP1_GRAPH_RESULT_MAGIC ? "RSLT" : "UNCOMMITTED");
+    std::printf("  result.graph_seq          = %u\n", result.graphSeq);
+    std::printf("  result.outcome            = %u (%s)\n",
+                result.outcome, outcomeStr(result.outcome));
+    std::printf("  result.flags              = 0x%08x\n", result.flags);
+    printResultFlag("recovery_required", result.flags,
+                    RP1_RESULT_RECOVERY_REQUIRED);
+    printResultFlag("effects_may_be_partial", result.flags,
+                    RP1_RESULT_EFFECTS_MAY_BE_PARTIAL);
+    printResultFlag("infinite_work_remains", result.flags,
+                    RP1_RESULT_INFINITE_WORK_REMAINS);
+    printResultFlag("trace_enabled", result.flags,
+                    RP1_RESULT_TRACE_ENABLED);
+    printResultFlag("trace_overflow", result.flags,
+                    RP1_RESULT_TRACE_OVERFLOW);
+    printResultFlag("unreached_nodes", result.flags,
+                    RP1_RESULT_UNREACHED_NODES);
+    std::printf("  result.error_code         = %u\n", result.errorCode);
+    if (result.terminalNode == RP1_TERMINAL_ERROR_NODE_NONE) {
+        std::printf("  result.terminal_node      = 0x%08x (none)\n",
+                    result.terminalNode);
+    } else {
+        std::printf("  result.terminal_node      = %u\n",
+                    result.terminalNode);
+    }
+    std::printf("  result.terminal_opcode    = 0x%08x (%s)\n",
+                result.terminalOpcode, opcodeStr(result.terminalOpcode));
+    std::printf("  result.error_detail       = 0x%08x\n",
+                result.errorDetail);
+    std::printf("  result.error_aux          = 0x%08x\n",
+                result.errorAux);
+    std::printf("  result.active_image_id    = %u\n",
+                result.activeImageId);
+    std::printf("  result.image_state        = %u (%s)\n",
+                result.imageState, imageStateStr(result.imageState));
+    std::printf("  result.completed_operations = %u\n",
+                result.completedOperations);
+    std::printf("  result.graph_elapsed_ticks  = %u\n",
+                result.graphElapsedTicks);
+    std::printf("  result.publish_elapsed_ticks = %u\n",
+                result.publishElapsedTicks);
+    std::printf("  result.trace_write_idx      = %u\n",
+                result.traceWriteIndex);
+    std::printf("  result.quiescence           = 0x%08x\n",
+                result.quiescence);
+    std::printf("    finite_done/finite_timeout/infinite = %u/%u/%u\n",
+                (result.quiescence >> RP1_QUIESCE_FINITE_DONE_SHIFT) &
+                    RP1_QUIESCE_COUNT_MASK,
+                (result.quiescence >> RP1_QUIESCE_FINITE_TIMEOUT_SHIFT) &
+                    RP1_QUIESCE_COUNT_MASK,
+                (result.quiescence >> RP1_QUIESCE_INFINITE_SHIFT) &
+                    RP1_QUIESCE_COUNT_MASK);
+}
+
+/*
+ * A successful one-node probe has no terminal record, partial effects,
+ * recovery requirement, outstanding work, trace overflow, or unreached node.
+ * Image identity may be NONE or KNOWN because the probe does not reprogram.
+ */
+bool validateProbeResult(const GraphResultSnapshot& result, uint32_t wantSeq,
+                         bool traceExpected) {
+    constexpr uint32_t kKnownFlags =
+        RP1_RESULT_RECOVERY_REQUIRED |
+        RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+        RP1_RESULT_INFINITE_WORK_REMAINS |
+        RP1_RESULT_TRACE_ENABLED |
+        RP1_RESULT_TRACE_OVERFLOW |
+        RP1_RESULT_UNREACHED_NODES;
+    constexpr uint32_t kFailureFlags =
+        RP1_RESULT_RECOVERY_REQUIRED |
+        RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+        RP1_RESULT_INFINITE_WORK_REMAINS |
+        RP1_RESULT_TRACE_OVERFLOW |
+        RP1_RESULT_UNREACHED_NODES;
+
+    bool valid = true;
+    if (result.magic != RP1_GRAPH_RESULT_MAGIC) {
+        std::fprintf(stderr,
+                     "FAIL: graph result magic=0x%08x, expected 0x%08x\n",
+                     result.magic,
+                     static_cast<uint32_t>(RP1_GRAPH_RESULT_MAGIC));
+        valid = false;
+    }
+    if (result.graphSeq != wantSeq) {
+        std::fprintf(stderr,
+                     "FAIL: graph result seq=%u, expected %u\n",
+                     result.graphSeq, wantSeq);
+        valid = false;
+    }
+    if (result.outcome != RP1_GRAPH_RESULT_SUCCESS) {
+        std::fprintf(stderr,
+                     "FAIL: graph outcome=%s(%u), expected SUCCESS(%u)\n",
+                     outcomeStr(result.outcome), result.outcome,
+                     static_cast<uint32_t>(RP1_GRAPH_RESULT_SUCCESS));
+        valid = false;
+    }
+    if ((result.flags & ~kKnownFlags) != 0u ||
+        (result.flags & kFailureFlags) != 0u) {
+        std::fprintf(stderr,
+                     "FAIL: graph result has invalid success flags 0x%08x\n",
+                     result.flags);
+        valid = false;
+    }
+    const bool traceFlag =
+        (result.flags & RP1_RESULT_TRACE_ENABLED) != 0u;
+    if (traceFlag != traceExpected ||
+        (traceExpected && result.traceWriteIndex == 0u) ||
+        (!traceExpected && result.traceWriteIndex != 0u)) {
+        std::fprintf(stderr,
+                     "FAIL: graph trace result flag=%u write_idx=%u, "
+                     "expected enabled=%u\n",
+                     traceFlag ? 1u : 0u, result.traceWriteIndex,
+                     traceExpected ? 1u : 0u);
+        valid = false;
+    }
+    if (result.errorCode != 0u ||
+        result.terminalNode != RP1_TERMINAL_ERROR_NODE_NONE ||
+        result.terminalOpcode != RP1_TERMINAL_OPCODE_NONE ||
+        result.errorDetail != 0u || result.errorAux != 0u) {
+        std::fprintf(stderr,
+                     "FAIL: successful graph result carries terminal error data\n");
+        valid = false;
+    }
+    const bool imageConsistent =
+        (result.imageState == RP1_IMAGE_STATE_NONE &&
+         result.activeImageId == 0u) ||
+        (result.imageState == RP1_IMAGE_STATE_KNOWN &&
+         result.activeImageId != 0u);
+    if (!imageConsistent) {
+        std::fprintf(stderr,
+                     "FAIL: successful graph result has image=%s(%u):%u\n",
+                     imageStateStr(result.imageState), result.imageState,
+                     result.activeImageId);
+        valid = false;
+    }
+    if (result.completedOperations != 1u) {
+        std::fprintf(stderr,
+                     "FAIL: graph result completed %u operations, expected 1\n",
+                     result.completedOperations);
+        valid = false;
+    }
+    if (result.publishElapsedTicks < result.graphElapsedTicks) {
+        std::fprintf(stderr,
+                     "FAIL: publish ticks %u precede graph ticks %u\n",
+                     result.publishElapsedTicks, result.graphElapsedTicks);
+        valid = false;
+    }
+    if (result.quiescence != 0u) {
+        std::fprintf(stderr,
+                     "FAIL: successful probe required quiescence 0x%08x\n",
+                     result.quiescence);
+        valid = false;
+    }
+    return valid;
+}
+
+/// Print the complete RP1 control and graph-result diagnostics.
 void printCtrl(volatile rp1_ctrl_t* c) {
     std::printf("  magic            = 0x%08x (%s)\n",
                 c->magic, (c->magic == RP1_CTRL_MAGIC) ? "SQR1" : "BAD");
     std::printf("  version          = %u\n",   c->version);
     std::printf("  node_count       = %u\n",   c->node_count);
-    std::printf("  cq_size          = %u\n",   c->cq_size);
+    std::printf("  reserved_0x0c    = 0x%08x\n", c->_reserved_cq_size);
     std::printf("  node_base        = 0x%08x_%08x\n", c->node_base_hi, c->node_base_lo);
-    std::printf("  cq_base          = 0x%08x_%08x\n", c->cq_base_hi, c->cq_base_lo);
+    std::printf("  reserved_0x18    = 0x%08x\n", c->_reserved_cq_base_lo);
+    std::printf("  reserved_0x1c    = 0x%08x\n", c->_reserved_cq_base_hi);
     std::printf("  arg_buf_base     = 0x%08x_%08x\n", c->arg_buf_base_hi, c->arg_buf_base_lo);
     std::printf("  sig_array_base   = 0x%08x_%08x\n", c->sig_array_base_hi, c->sig_array_base_lo);
     std::printf("  trace_enable     = %u\n",   c->trace_enable);
@@ -140,12 +424,14 @@ void printCtrl(volatile rp1_ctrl_t* c) {
                     RP1_CAP_PLATFORM_PDI_IPI_CONFIG);
     printCapability("pmu_cycle_timeouts", capabilities,
                     RP1_CAP_PMU_CYCLE_TIMEOUTS);
-    printCapability("cq_flow_control", capabilities,
-                    RP1_CAP_CQ_FLOW_CONTROL);
     printCapability("structured_pdi_response", capabilities,
                     RP1_CAP_STRUCTURED_PDI_RESPONSE);
     printCapability("latched_terminal_errors", capabilities,
                     RP1_CAP_LATCHED_TERMINAL_ERRORS);
+    printCapability("btcm_trace_staging", capabilities,
+                    RP1_CAP_BTCM_TRACE_STAGING);
+    printCapability("graph_result", capabilities,
+                    RP1_CAP_GRAPH_RESULT);
     std::printf("  required_capabilities = 0x%08x\n",
                 static_cast<uint32_t>(RP1_REQUIRED_CAPABILITIES));
     std::printf("  missing_capabilities  = 0x%08x\n",
@@ -154,8 +440,8 @@ void printCtrl(volatile rp1_ctrl_t* c) {
                 c->pdi_ipi_platform_id);
     std::printf("  graph_seq        = %u\n",   c->graph_seq);
     std::printf("  graph_done_seq   = %u\n",   c->graph_done_seq);
-    std::printf("  cq_write_idx     = %u\n",   c->cq_write_idx);
-    std::printf("  cq_read_idx      = %u\n",   c->cq_read_idx);
+    std::printf("  reserved_0x28    = 0x%08x\n", c->_reserved_cq_write_idx);
+    std::printf("  reserved_0x2c    = 0x%08x\n", c->_reserved_cq_read_idx);
     std::printf("  rp1_state        = %u (%s)\n", c->rp1_state, stateStr(c->rp1_state));
     std::printf("  rp1_error_code   = %u\n",   c->rp1_error_code);
     std::printf("  rp1_current_node = %u\n",   c->rp1_current_node);
@@ -168,6 +454,8 @@ void printCtrl(volatile rp1_ctrl_t* c) {
     std::printf("  terminal_error_detail = 0x%08x\n", c->terminal_error_detail);
     std::printf("  terminal_error_aux    = 0x%08x\n", c->terminal_error_aux);
     std::printf("  heartbeat        = %u\n",   c->heartbeat);
+    std::printf("Graph result:\n");
+    printGraphResult(snapshotResult(c));
 }
 
 /*
@@ -175,13 +463,43 @@ void printCtrl(volatile rp1_ctrl_t* c) {
  * layout, every mandatory behavior bit, and a non-unknown IPI identity.
  * Keep this stricter than a heartbeat-only liveness check.
  */
-bool contractCompatible(volatile rp1_ctrl_t* c) {
+constexpr bool contractFieldsCompatible(
+    uint32_t magic, uint32_t version, uint32_t capabilities,
+    uint32_t platform) {
     const uint32_t missing =
-        static_cast<uint32_t>(RP1_REQUIRED_CAPABILITIES) & ~c->capabilities;
-    return c->magic == RP1_CTRL_MAGIC &&
-           c->version == RP1_PROTOCOL_VERSION &&
+        static_cast<uint32_t>(RP1_REQUIRED_CAPABILITIES) & ~capabilities;
+    return magic == RP1_CTRL_MAGIC &&
+           version == RP1_PROTOCOL_VERSION &&
            missing == 0u &&
-           c->pdi_ipi_platform_id != RP1_PDI_IPI_PLATFORM_UNKNOWN;
+           platform != RP1_PDI_IPI_PLATFORM_UNKNOWN;
+}
+
+static_assert(
+    !contractFieldsCompatible(
+        RP1_CTRL_MAGIC, 5u, RP1_REQUIRED_CAPABILITIES, 1u),
+    "protocol-v5 firmware must be rejected");
+
+/// Return true only when the published firmware contract matches this host.
+bool contractCompatible(volatile rp1_ctrl_t* c) {
+    return contractFieldsCompatible(
+        c->magic, c->version, c->capabilities,
+        c->pdi_ipi_platform_id);
+}
+
+/// Diagnose an incompatible firmware contract before any probe BAR mutation.
+bool validateFirmwareContract(volatile rp1_ctrl_t* c) {
+    if (contractCompatible(c)) {
+        return true;
+    }
+    std::fprintf(
+        stderr,
+        "ERROR: incompatible RP1 firmware contract "
+        "(magic=0x%08x, version=%u, capabilities=0x%08x, "
+        "platform_id=0x%08x); expected protocol v%u and capabilities 0x%08x.\n",
+        c->magic, c->version, c->capabilities, c->pdi_ipi_platform_id,
+        static_cast<uint32_t>(RP1_PROTOCOL_VERSION),
+        static_cast<uint32_t>(RP1_REQUIRED_CAPABILITIES));
+    return false;
 }
 
 /// Minimum BAR length needed to reach the bring-up trace ring.
@@ -190,6 +508,7 @@ uint64_t requiredBarLen(uint64_t ctrlOffset) {
          + static_cast<uint64_t>(kBringupTraceSize) * sizeof(rp1_trace_entry_t);
 }
 
+/// Zero @p bytes through a volatile BAR mapping.
 void barZero(volatile void* dst, size_t bytes) {
     auto* p = static_cast<volatile uint8_t*>(dst);
     for (size_t i = 0; i < bytes; ++i) {
@@ -197,26 +516,36 @@ void barZero(volatile void* dst, size_t bytes) {
     }
 }
 
-void nodeSetHeader(volatile rp1_node_t* n, uint16_t opcode,
+/// Copy @p bytes into a volatile BAR mapping without dropping writes.
+void barWrite(volatile void* dst, const void* src, size_t bytes) {
+    auto* out = static_cast<volatile uint8_t*>(dst);
+    const auto* in = static_cast<const uint8_t*>(src);
+    for (size_t i = 0; i < bytes; ++i) {
+        out[i] = in[i];
+    }
+}
+
+/// Initialize the common header of one staged node packet.
+void nodeSetHeader(rp1_node_t* n, uint16_t opcode,
                    uint8_t awaitBucket, uint32_t awaitMask,
                    uint8_t setBucket, uint32_t setMask) {
-    n->opcode               = opcode;
-    n->flags                = 0;
+    rp1_node_set_opcode(n, opcode);
+    rp1_node_set_flags(n, 0u);
+    rp1_node_set_status(n, RP1_NODE_PENDING);
     n->barrier_await_mask   = awaitMask;
     n->barrier_set_mask     = setMask;
     n->barrier_await_bucket = awaitBucket;
     n->barrier_set_bucket   = setBucket;
-    n->status               = RP1_NODE_PENDING;
 }
 
 /// Program the control block's base-address fields for a graph of @p nodeCount nodes.
 void programCtrl(volatile rp1_ctrl_t* c, uint32_t nodeCount) {
     c->node_count        = nodeCount;
-    c->cq_size           = kBringupCqSize;
+    c->_reserved_cq_size = 0;
     c->node_base_lo      = static_cast<uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_NODE_ARRAY_OFFSET);
     c->node_base_hi      = 0;
-    c->cq_base_lo        = static_cast<uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_CQ_OFFSET);
-    c->cq_base_hi        = 0;
+    c->_reserved_cq_base_lo = 0;
+    c->_reserved_cq_base_hi = 0;
     c->arg_buf_base_lo   = static_cast<uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_ARG_BUF_OFFSET);
     c->arg_buf_base_hi   = 0;
     c->sig_array_base_lo = static_cast<uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_SIG_ARRAY_OFFSET);
@@ -225,7 +554,6 @@ void programCtrl(volatile rp1_ctrl_t* c, uint32_t nodeCount) {
     c->trace_base_lo     = static_cast<uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_TRACE_OFFSET);
     c->trace_base_hi     = 0;
     c->trace_size        = kBringupTraceSize;
-    c->trace_write_idx   = 0;
 }
 
 /// Refuse to submit unless the firmware is alive and idle.  Prints a
@@ -259,16 +587,37 @@ bool checkFirmwareReady(volatile rp1_ctrl_t* c) {
  */
 /// Poll graph_done_seq until it equals @p wantSeq. Returns 0 on success,
 /// -1 on timeout, -2 on a detected firmware hang (heartbeat stuck).
-int waitForSeq(volatile rp1_ctrl_t* c, uint32_t wantSeq) {
+int waitForSeq(vrtd::BarFile& barFile, size_t ctrlOffset, uint32_t wantSeq) {
     using clock = std::chrono::steady_clock;
     const auto deadline    = clock::now() + kPollTimeout;
-    uint32_t   lastHb      = c->heartbeat;
+    uint32_t lastHb;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read, ctrlOffset);
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+        lastHb = c->heartbeat;
+    }
     auto       lastHbTick  = clock::now();
 
-    while (c->graph_done_seq != wantSeq) {
+    while (true) {
+        uint32_t done;
+        uint32_t hb;
+        {
+            /*
+             * End each DMA-BUF read transaction before sleeping. Re-entering
+             * the bracket makes the next firmware publication visible.
+             */
+            auto base = barFile.getPtr<uint8_t>(
+                vrtd::BarFile::Direction::Read, ctrlOffset);
+            auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+            done = c->graph_done_seq;
+            hb = c->heartbeat;
+        }
+        if (done == wantSeq) {
+            return 0;
+        }
         const auto now = clock::now();
 
-        const uint32_t hb = c->heartbeat;
         if (hb != lastHb) {
             lastHb = hb;
             lastHbTick = now;
@@ -283,7 +632,7 @@ int waitForSeq(volatile rp1_ctrl_t* c, uint32_t wantSeq) {
 
         if (now > deadline) {
             std::fprintf(stderr, "TIMEOUT: graph_done_seq=%u (want %u)\n",
-                         c->graph_done_seq, wantSeq);
+                         done, wantSeq);
             return -1;
         }
         std::this_thread::sleep_for(kPollInterval);
@@ -331,7 +680,7 @@ vrtd::BarFile openRp1Bar(const Rp1Probe::Options& options,
 /*
  * dump is intentionally passive: snapshot the published contract, then sample
  * heartbeat over a stall window. It diagnoses compatibility and liveness
- * without changing sequence, CQ ownership, or graph storage.
+ * without changing sequence, graph result, or graph storage.
  */
 int Rp1Probe::dump(const Options& options) {
     const uint64_t ctrlOffset = parseUnsigned(options.ctrlOffsetText, "ctrl-offset");
@@ -339,20 +688,32 @@ int Rp1Probe::dump(const Options& options) {
     vrtd::Session session;
     vrtd::BarFile barFile = openRp1Bar(options, session, ctrlOffset, "debug rp1-dump");
 
-    auto base = barFile.getPtr<uint8_t>(vrtd::BarFile::Direction::Read, static_cast<size_t>(ctrlOffset));
-    auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+    bool compatible;
+    uint32_t hb1;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
 
-    std::printf("RP1 control block @ R5 0x%08lx (BAR%u + 0x%lx):\n",
-                static_cast<unsigned long>(RP1_CTRL_PHYS_ADDR),
-                options.bar, static_cast<unsigned long>(ctrlOffset));
-    printCtrl(c);
-    const bool compatible = contractCompatible(c);
-    std::printf("Protocol contract: %s\n",
-                compatible ? "compatible" : "INCOMPATIBLE");
-
-    const uint32_t hb1 = c->heartbeat;
+        std::printf("RP1 control block @ R5 0x%08lx (BAR%u + 0x%lx):\n",
+                    static_cast<unsigned long>(RP1_CTRL_PHYS_ADDR),
+                    options.bar, static_cast<unsigned long>(ctrlOffset));
+        printCtrl(c);
+        compatible = contractCompatible(c);
+        std::printf("Protocol contract: %s\n",
+                    compatible ? "compatible" : "INCOMPATIBLE");
+        hb1 = c->heartbeat;
+    }
     std::this_thread::sleep_for(kStallWindow);
-    const uint32_t hb2 = c->heartbeat;
+    uint32_t hb2;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+        hb2 = c->heartbeat;
+    }
     if (hb2 != hb1) {
         std::printf("Liveness: heartbeat advanced %u -> %u (running)\n", hb1, hb2);
     } else {
@@ -371,7 +732,7 @@ int Rp1Probe::dump(const Options& options) {
 /*
  * ping bypasses the graph runtime with one SIGNAL packet. It validates the BAR
  * layout, startup contract, doorbell ordering, scanner side effect, exact
- * sequence publication, and CQ evidence as one minimal transaction.
+ * sequence publication, and committed graph result as one minimal transaction.
  */
 int Rp1Probe::ping(const Options& options) {
     const uint64_t ctrlOffset = parseUnsigned(options.ctrlOffsetText, "ctrl-offset");
@@ -379,95 +740,115 @@ int Rp1Probe::ping(const Options& options) {
     vrtd::Session session;
     vrtd::BarFile barFile = openRp1Bar(options, session, ctrlOffset, "debug rp1-ping");
 
-    // Hold a single write session over the whole submit + poll sequence and
-    // reach every sub-region by offsetting from the control-block base.
-    auto base = barFile.getPtr<uint8_t>(vrtd::BarFile::Direction::Write, static_cast<size_t>(ctrlOffset));
-    volatile uint8_t* basePtr = base.get();
-    auto* c     = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
-    auto* nodes = reinterpret_cast<volatile rp1_node_t*>(basePtr + RP1_DEFAULT_NODE_ARRAY_OFFSET);
-    auto* cq    = reinterpret_cast<volatile rp1_cq_entry_t*>(basePtr + RP1_DEFAULT_CQ_OFFSET);
-    auto* sigs  = reinterpret_cast<volatile rp1_signal_slot_t*>(basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
-
     /*
-     * Phase 1: require idle READY firmware before claiming shared node, signal,
-     * and CQ storage; the probe cannot safely coexist with another graph.
+     * Phase 1: validate the full protocol and idle state in a read transaction.
+     * No pointer from this bracket may escape into the later write transaction.
      */
-    if (!checkFirmwareReady(c)) {
-        return 1;
+    uint32_t wantSeq;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+        if (!validateFirmwareContract(c) || !checkFirmwareReady(c)) {
+            return 1;
+        }
+        wantSeq = c->graph_done_seq + 1u;
     }
 
     /*
      * Phase 2: stage one SIGNAL node and clear its sentinel before publishing
      * a sequence change, so success cannot be inherited from an older run.
      */
-    barZero(&nodes[0], sizeof(rp1_node_t));
-    nodeSetHeader(&nodes[0], RP1_OP_SIGNAL, /*await*/ 0, 0x0, /*set*/ 0, 0x1);
-    nodes[0].payload.signal.target_slot = 0;
-    nodes[0].payload.signal.value       = kSignalMagic;
-    nodes[0].payload.signal.operation   = RP1_SIGOP_SET;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Write,
+            static_cast<size_t>(ctrlOffset));
+        volatile uint8_t* basePtr = base.get();
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
+        auto* nodes = reinterpret_cast<volatile rp1_node_t*>(
+            basePtr + RP1_DEFAULT_NODE_ARRAY_OFFSET);
+        auto* sigs = reinterpret_cast<volatile rp1_signal_slot_t*>(
+            basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
 
-    sigs[0].value            = 0;
-    sigs[0].last_writer_node = 0;
-    sigs[0].flags            = 0;
+        rp1_node_t node{};
+        nodeSetHeader(
+            &node, RP1_OP_SIGNAL, /*await*/ 0, 0x0,
+            /*set*/ 0, 0x1);
+        node.payload.signal.target_slot = 0;
+        node.payload.signal.value       = kSignalMagic;
+        node.payload.signal.operation   = RP1_SIGOP_SET;
+        barWrite(&nodes[0], &node, sizeof(node));
 
-    const uint32_t cqStart = c->cq_write_idx;
-    c->cq_read_idx = cqStart;
-    programCtrl(c, /*nodeCount*/ 1);
+        sigs[0].value            = 0;
+        sigs[0].last_writer_node = 0;
+        sigs[0].flags            = 0;
+        programCtrl(c, /*nodeCount*/ 1);
 
-    /*
-     * Phase 3: fences make all staged bytes visible before graph_seq, the sole
-     * firmware doorbell and the exact completion value the probe awaits.
-     */
-    const uint32_t wantSeq = c->graph_done_seq + 1;
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    c->graph_seq = wantSeq;
-    std::atomic_thread_fence(std::memory_order_seq_cst);
+        /*
+         * Fences make all staged bytes visible before graph_seq, the sole
+         * firmware doorbell and exact completion value.
+         */
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        c->graph_seq = wantSeq;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    }
 
     std::printf("rp1-ping: submitted seq=%u, polling...\n", wantSeq);
-    if (waitForSeq(c, wantSeq) != 0) {
-        printCtrl(c);
+    if (waitForSeq(
+            barFile, static_cast<size_t>(ctrlOffset), wantSeq) != 0) {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        printCtrl(reinterpret_cast<volatile rp1_ctrl_t*>(base.get()));
         return 1;
     }
 
     /*
-     * Phase 4: completion publishes the signal and one CQ record. Validate both
-     * before releasing the monotonic consumer cursor back to firmware.
+     * Phase 4: graph_done_seq releases both the sentinel side effect and the
+     * sequence-tagged result. Validate both before reporting probe success.
      */
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    const uint32_t observed = sigs[0].value;
-    if (observed != kSignalMagic) {
-        std::fprintf(stderr, "FAIL: signal slot 0 = 0x%08x, expected 0x%08x\n",
-                     observed, kSignalMagic);
-        printCtrl(c);
-        return 1;
-    }
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        volatile uint8_t* basePtr = base.get();
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
+        auto* sigs = reinterpret_cast<volatile rp1_signal_slot_t*>(
+            basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
 
-    const uint32_t cqEnd = c->cq_write_idx;
-    if (cqEnd - cqStart != 1u) {
-        std::fprintf(stderr,
-                     "FAIL: RP1 wrote %u CQ entries for one ping node\n",
-                     cqEnd - cqStart);
-        return 1;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        const GraphResultSnapshot result = snapshotResult(c);
+        if (!validateProbeResult(result, wantSeq, /*traceExpected=*/false) ||
+            c->rp1_state != RP1_STATE_READY) {
+            printCtrl(c);
+            return 1;
+        }
+        const uint32_t observed = sigs[0].value;
+        if (observed != kSignalMagic) {
+            std::fprintf(
+                stderr,
+                "FAIL: signal slot 0 = 0x%08x, expected 0x%08x\n",
+                observed, kSignalMagic);
+            printCtrl(c);
+            return 1;
+        }
+
+        std::printf("Graph result:\n");
+        printGraphResult(result);
+        std::printf("PASS: slot[0] = 0x%08x, result_seq=%u, outcome=%s, "
+                    "graph_ticks=%u, publish_ticks=%u, state=%s\n",
+                    observed, result.graphSeq, outcomeStr(result.outcome),
+                    result.graphElapsedTicks, result.publishElapsedTicks,
+                    stateStr(c->rp1_state));
     }
-    const volatile rp1_cq_entry_t& completion =
-        cq[cqStart % kBringupCqSize];
-    if (completion.node_index != 0u || completion.status != RP1_CQ_OK) {
-        std::fprintf(stderr,
-                     "FAIL: ping CQ node=%u status=%u detail=0x%08x\n",
-                     completion.node_index, completion.status,
-                     completion.error_detail);
-        return 1;
-    }
-    c->cq_read_idx = cqEnd;
-    std::printf("PASS: slot[0] = 0x%08x, cq_write_idx=%u, state=%s\n",
-                observed, c->cq_write_idx, stateStr(c->rp1_state));
     return 0;
 }
 
 /*
  * trace-ping repeats the sentinel transaction with tracing enabled, then reads
- * CQ and trace as rings. The two streams prove externally visible completion
- * and the firmware's internal event ordering.
+ * the committed result and trace ring. They prove externally visible graph
+ * completion and the firmware's internal event ordering.
  */
 int Rp1Probe::tracePing(const Options& options) {
     const uint64_t ctrlOffset = parseUnsigned(options.ctrlOffsetText, "ctrl-offset");
@@ -475,95 +856,133 @@ int Rp1Probe::tracePing(const Options& options) {
     vrtd::Session session;
     vrtd::BarFile barFile = openRp1Bar(options, session, ctrlOffset, "debug rp1-trace-ping");
 
-    auto base = barFile.getPtr<uint8_t>(vrtd::BarFile::Direction::Write, static_cast<size_t>(ctrlOffset));
-    volatile uint8_t* basePtr = base.get();
-    auto* c      = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
-    auto* nodes  = reinterpret_cast<volatile rp1_node_t*>(basePtr + RP1_DEFAULT_NODE_ARRAY_OFFSET);
-    auto* cq     = reinterpret_cast<volatile rp1_cq_entry_t*>(basePtr + RP1_DEFAULT_CQ_OFFSET);
-    auto* sigs   = reinterpret_cast<volatile rp1_signal_slot_t*>(basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
-    auto* traces = reinterpret_cast<volatile rp1_trace_entry_t*>(basePtr + RP1_DEFAULT_TRACE_OFFSET);
-
     /*
-     * Phase 1: claim the shared bring-up regions only from READY. A trace probe
-     * cannot safely merge records with an in-flight submission.
+     * Phase 1: reject an incompatible or busy firmware publication before
+     * opening any BAR write transaction.
      */
-    if (!checkFirmwareReady(c)) {
-        return 1;
+    uint32_t wantSeq;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(base.get());
+        if (!validateFirmwareContract(c) || !checkFirmwareReady(c)) {
+            return 1;
+        }
+        wantSeq = c->graph_done_seq + 1u;
     }
 
     /*
      * Phase 2: clear node, sentinel, and trace storage before enabling trace;
      * this makes every observed record attributable to the new sequence.
      */
-    barZero(&nodes[0], sizeof(rp1_node_t));
-    nodeSetHeader(&nodes[0], RP1_OP_SIGNAL, /*await*/ 0, 0x0, /*set*/ 0, 0x1);
-    nodes[0].payload.signal.target_slot = 0;
-    nodes[0].payload.signal.value       = kSignalMagic;
-    nodes[0].payload.signal.operation   = RP1_SIGOP_SET;
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Write,
+            static_cast<size_t>(ctrlOffset));
+        volatile uint8_t* basePtr = base.get();
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
+        auto* nodes = reinterpret_cast<volatile rp1_node_t*>(
+            basePtr + RP1_DEFAULT_NODE_ARRAY_OFFSET);
+        auto* sigs = reinterpret_cast<volatile rp1_signal_slot_t*>(
+            basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
+        auto* traces = reinterpret_cast<volatile rp1_trace_entry_t*>(
+            basePtr + RP1_DEFAULT_TRACE_OFFSET);
 
-    sigs[0].value            = 0;
-    sigs[0].last_writer_node = 0;
-    sigs[0].flags            = 0;
-    barZero(traces, kBringupTraceSize * sizeof(rp1_trace_entry_t));
+        rp1_node_t node{};
+        nodeSetHeader(
+            &node, RP1_OP_SIGNAL, /*await*/ 0, 0x0,
+            /*set*/ 0, 0x1);
+        node.payload.signal.target_slot = 0;
+        node.payload.signal.value       = kSignalMagic;
+        node.payload.signal.operation   = RP1_SIGOP_SET;
+        barWrite(&nodes[0], &node, sizeof(node));
 
-    programCtrl(c, /*nodeCount*/ 1);
-    c->trace_enable = 1;
+        sigs[0].value            = 0;
+        sigs[0].last_writer_node = 0;
+        sigs[0].flags            = 0;
+        barZero(traces, kBringupTraceSize * sizeof(rp1_trace_entry_t));
 
-    /*
-     * Phase 3: synchronize CQ ownership, publish the sequence doorbell, and
-     * wait exactly while heartbeat distinguishes timeout from a firmware hang.
-     */
-    const uint32_t cqStart = c->cq_write_idx;
-    c->cq_read_idx = cqStart;
-    const uint32_t wantSeq = c->graph_done_seq + 1;
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    c->graph_seq = wantSeq;
-    std::atomic_thread_fence(std::memory_order_seq_cst);
+        programCtrl(c, /*nodeCount*/ 1);
+        c->trace_enable = 1;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        c->graph_seq = wantSeq;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    }
 
     std::printf("rp1-trace-ping: submitted seq=%u, polling...\n", wantSeq);
-    if (waitForSeq(c, wantSeq) != 0) {
-        printCtrl(c);
+    if (waitForSeq(
+            barFile, static_cast<size_t>(ctrlOffset), wantSeq) != 0) {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        printCtrl(reinterpret_cast<volatile rp1_ctrl_t*>(base.get()));
         return 1;
     }
 
     /*
-     * Phase 4: validate the sentinel, drain CQ, then reconstruct the trace's
+     * Phase 4: validate the result and sentinel, then reconstruct the trace's
      * chronological suffix when its producer count has wrapped the ring.
      */
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    const uint32_t observed = sigs[0].value;
-    if (observed != kSignalMagic) {
-        std::fprintf(stderr, "FAIL: signal slot 0 = 0x%08x, expected 0x%08x\n",
-                     observed, kSignalMagic);
-        printCtrl(c);
-        return 1;
-    }
+    {
+        auto base = barFile.getPtr<uint8_t>(
+            vrtd::BarFile::Direction::Read,
+            static_cast<size_t>(ctrlOffset));
+        volatile uint8_t* basePtr = base.get();
+        auto* c = reinterpret_cast<volatile rp1_ctrl_t*>(basePtr);
+        auto* sigs = reinterpret_cast<volatile rp1_signal_slot_t*>(
+            basePtr + RP1_DEFAULT_SIG_ARRAY_OFFSET);
+        auto* traces = reinterpret_cast<volatile rp1_trace_entry_t*>(
+            basePtr + RP1_DEFAULT_TRACE_OFFSET);
 
-    const uint32_t cqEnd = c->cq_write_idx;
-    std::printf("PASS: slot[0] = 0x%08x, state=%s\n", observed, stateStr(c->rp1_state));
-    std::printf("CQ entries [%u, %u):\n", cqStart, cqEnd);
-    for (uint32_t i = cqStart; i < cqEnd; i++) {
-        const uint32_t idx = i % kBringupCqSize;
-        const auto& e = cq[idx];
-        std::printf("  cq[%u] node=%u status=%u detail=0x%08x timestamp=%u\n",
-                    idx, e.node_index, e.status, e.error_detail, e.timestamp);
-    }
-    c->cq_read_idx = cqEnd;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        const GraphResultSnapshot result = snapshotResult(c);
+        if (!validateProbeResult(result, wantSeq, /*traceExpected=*/true) ||
+            c->rp1_state != RP1_STATE_READY) {
+            printCtrl(c);
+            return 1;
+        }
+        const uint32_t observed = sigs[0].value;
+        if (observed != kSignalMagic) {
+            std::fprintf(
+                stderr,
+                "FAIL: signal slot 0 = 0x%08x, expected 0x%08x\n",
+                observed, kSignalMagic);
+            printCtrl(c);
+            return 1;
+        }
 
-    const uint32_t traceWritten = c->trace_write_idx;
-    const uint32_t traceCount = traceWritten > kBringupTraceSize
-                              ? kBringupTraceSize : traceWritten;
-    const uint32_t traceStart = traceWritten > kBringupTraceSize
-                              ? traceWritten % kBringupTraceSize : 0;
-    std::printf("Trace entries written=%u readable=%u%s:\n",
-                traceWritten, traceCount,
-                traceWritten > kBringupTraceSize ? " (overflow)" : "");
-    for (uint32_t i = 0; i < traceCount; i++) {
-        const uint32_t idx = (traceStart + i) % kBringupTraceSize;
-        const auto& e = traces[idx];
-        std::printf("  trace[%u] t=%u event=%s(%u) node=%u aux0=0x%08x aux1=0x%08x\n",
-                    idx, e.timestamp, traceEventStr(e.event), e.event,
-                    e.node_index, e.aux0, e.aux1);
+        if (result.traceWriteIndex != c->trace_write_idx) {
+            std::fprintf(
+                stderr,
+                "FAIL: result trace_write_idx=%u, control block reports %u\n",
+                result.traceWriteIndex, c->trace_write_idx);
+            return 1;
+        }
+        std::printf(
+            "PASS: slot[0] = 0x%08x, result_seq=%u, outcome=%s, state=%s\n",
+            observed, result.graphSeq, outcomeStr(result.outcome),
+            stateStr(c->rp1_state));
+        std::printf("Graph result:\n");
+        printGraphResult(result);
+
+        const uint32_t traceWritten = result.traceWriteIndex;
+        const uint32_t traceCount = traceWritten > kBringupTraceSize
+                                  ? kBringupTraceSize : traceWritten;
+        const uint32_t traceStart = traceWritten > kBringupTraceSize
+                                  ? traceWritten % kBringupTraceSize : 0;
+        std::printf("Trace entries written=%u readable=%u%s:\n",
+                    traceWritten, traceCount,
+                    traceWritten > kBringupTraceSize ? " (overflow)" : "");
+        for (uint32_t i = 0; i < traceCount; i++) {
+            const uint32_t idx = (traceStart + i) % kBringupTraceSize;
+            const auto& e = traces[idx];
+            std::printf(
+                "  trace[%u] t=%u event=%s(%u) node=%u "
+                "aux0=0x%08x aux1=0x%08x\n",
+                idx, e.timestamp, traceEventStr(e.event), e.event,
+                e.node_index, e.aux0, e.aux1);
+        }
     }
 
     return 0;

--- a/smi/src/smi.cpp
+++ b/smi/src/smi.cpp
@@ -328,7 +328,7 @@ static int smiMain(int argc, char **argv) {
     addRp1ProbeCommonOptions(rp1PingCommand);
 
     auto* rp1TracePingCommand = debugCommand->add_subcommand("rp1-trace-ping",
-        "Submit a one-node SIGNAL graph with RP1 tracing enabled and print CQ/trace entries");
+        "Submit a one-node SIGNAL graph and print its committed result and trace entries");
     addRp1ProbeCommonOptions(rp1TracePingCommand);
 
     CLI11_PARSE(app, argc, argv);

--- a/vrt/include/vrt/graph/device/fpga/rp1_bar_window.hpp
+++ b/vrt/include/vrt/graph/device/fpga/rp1_bar_window.hpp
@@ -148,7 +148,7 @@ class Rp1BarWindow {
         writeAt(0, &in, sizeof(in));
     }
 
-    /// Copy @p n consecutive 64-byte node packets to the node array at
+    /// Copy @p n consecutive 32-byte node packets to the node array at
     /// @c (RP1_DEFAULT_NODE_ARRAY_OFFSET + index * sizeof(rp1_node_t)).
     /// @p node_array_offset is the window-relative byte offset of the
     /// node array (defaults to @c RP1_DEFAULT_NODE_ARRAY_OFFSET).
@@ -171,9 +171,14 @@ class Rp1BarWindow {
     void readSignal(std::uint32_t slot, rp1_signal_slot_t& out,
                     std::uint32_t sig_array_offset = RP1_DEFAULT_SIG_ARRAY_OFFSET);
 
-    /// Read completion-queue entry @p idx.
-    void readCq(std::uint32_t idx, rp1_cq_entry_t& out,
-                std::uint32_t cq_offset = RP1_DEFAULT_CQ_OFFSET);
+    /**
+     * @brief Read the committed 64-byte graph-result record in one snapshot.
+     *
+     * Callers must first observe the matching @c graph_done_seq. Firmware
+     * publishes every result payload word and its commit magic before that
+     * sequence, so one bracketed read then captures a stable terminal record.
+     */
+    void readGraphResult(rp1_graph_result_t& out);
 
     /// Read trace-queue entry @p idx.
     void readTrace(std::uint32_t idx, rp1_trace_entry_t& out,
@@ -189,7 +194,6 @@ class Rp1BarWindow {
     std::uint32_t readMagic()        { return readU32(offsetof(rp1_ctrl_t, magic)); }
     std::uint32_t readGraphSeq()     { return readU32(offsetof(rp1_ctrl_t, graph_seq)); }
     std::uint32_t readGraphDoneSeq() { return readU32(offsetof(rp1_ctrl_t, graph_done_seq)); }
-    std::uint32_t readCqWriteIdx()   { return readU32(offsetof(rp1_ctrl_t, cq_write_idx)); }
     std::uint32_t readTraceWriteIdx(){ return readU32(offsetof(rp1_ctrl_t, trace_write_idx)); }
     std::uint32_t readState()        { return readU32(offsetof(rp1_ctrl_t, rp1_state)); }
     std::uint32_t readErrorCode()    { return readU32(offsetof(rp1_ctrl_t, rp1_error_code)); }
@@ -200,9 +204,6 @@ class Rp1BarWindow {
     }
     void writeNodeCount(std::uint32_t value) {
         writeU32(offsetof(rp1_ctrl_t, node_count), value);
-    }
-    void writeCqReadIdx(std::uint32_t value) {
-        writeU32(offsetof(rp1_ctrl_t, cq_read_idx), value);
     }
     void writeTraceEnable(std::uint32_t value) {
         writeU32(offsetof(rp1_ctrl_t, trace_enable), value);

--- a/vrt/include/vrt/graph/device/fpga/rp1_submitter.hpp
+++ b/vrt/include/vrt/graph/device/fpga/rp1_submitter.hpp
@@ -29,16 +29,13 @@
  *
  *   1. On first use, waits for the firmware to publish
  *      `magic == RP1_CTRL_MAGIC` and `rp1_state == READY`, then writes
- *      the control-block base addresses (node array, CQ, arg buffer,
- *      signal array) at the recommended `RP1_DEFAULT_*_OFFSET` layout.
+ *      the node, argument, signal, and trace base addresses at the
+ *      recommended `RP1_DEFAULT_*_OFFSET` layout.
  *   2. For each `submitAndWait()`:
  *        - Copies the node array, arg buffer, and signal clears into DDR.
- *        - Records the monotonic CQ cursor before incrementing `graph_seq`.
  *        - Memory-fences, bumps `graph_seq` by one, memory-fences again.
- *        - Polls by exact sequence equality and incrementally drains CQ so
- *          firmware can make progress through a full ring.
- *        - Surfaces ERROR/HALTED immediately with the complete terminal record.
- *   3. `drainCq()` returns the retained CQ evidence for final validation.
+ *        - Polls `graph_done_seq` by exact sequence equality.
+ *        - Reads and validates the committed protocol-v6 graph result.
  *
  * The submitter knows nothing about graphs, kernels, or VRT — it is a
  * mechanical adapter between a fully-realised RP1 graph image and the
@@ -57,6 +54,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -86,11 +84,6 @@ struct Rp1GraphImage {
     /// state left by an earlier graph.
     std::vector<std::uint32_t> clear_signal_slots;
 
-    /// Optional override of cq_size. Must be a power of 2 <= 4096. Zero means
-    /// "leave whatever was already programmed" (or use the submitter's
-    /// default on the first submission).
-    std::uint32_t cq_size_override = 0;
-
     /// Enable RP1 firmware trace-ring writes for this submission.
     bool trace_enable = false;
 
@@ -99,15 +92,125 @@ struct Rp1GraphImage {
 };
 
 /**
- * @brief Default CQ size for first submission (matches the `v80-smi debug
- *        rp1-ping` probe).
+ * @brief Append a complete SCALAR_WRITE operation as compact packets.
+ *
+ * Protocol v6 carries at most @c RP1_SCALAR_WRITE_MAX pairs per packet.
+ * This helper emits enough contiguous packets for every pair, applies
+ * @p awaitBucket / @p awaitMask to the whole sequence, and publishes
+ * @p setBucket / @p setMask only from the final packet. The flat RP1 scanner
+ * therefore performs every write before dependent work can activate.
+ *
+ * @throws std::logic_error for an empty list, a zero/unaligned address,
+ *         an invalid bucket, or a sequence that would exceed
+ *         @c RP1_MAX_NODES. The image is unchanged on error.
  */
-constexpr std::uint32_t kDefaultCqSize = 64u;
+void appendScalarWritePackets(
+    Rp1GraphImage& image,
+    const std::vector<rp1_write_pair_t>& writes,
+    std::uint8_t awaitBucket, std::uint32_t awaitMask,
+    std::uint8_t setBucket, std::uint32_t setMask);
 
 /**
  * @brief Default optional trace-ring size programmed by Rp1Submitter.
  */
 constexpr std::uint32_t kDefaultTraceSize = 256u;
+
+/**
+ * @brief Valid terminal outcomes returned by protocol-v6 firmware.
+ */
+enum class Rp1GraphOutcome : std::uint32_t {
+    /// Every reachable finite operation completed without a fatal error.
+    Success = RP1_GRAPH_RESULT_SUCCESS,
+    /// Firmware stopped activation after the first fatal graph error.
+    Failed = RP1_GRAPH_RESULT_FAILED,
+    /// An explicit @c RP1_OP_HALT terminated the graph.
+    Halted = RP1_GRAPH_RESULT_HALTED,
+};
+
+/**
+ * @brief Firmware's final knowledge of the programmed user image.
+ */
+enum class Rp1ImageState : std::uint32_t {
+    /// No image identity has been established by RP1.
+    None = RP1_IMAGE_STATE_NONE,
+    /// @c activeImageId names the image RP1 knows is installed.
+    Known = RP1_IMAGE_STATE_KNOWN,
+    /// A failed or timed-out reconfiguration made the image indeterminate.
+    Unknown = RP1_IMAGE_STATE_UNKNOWN,
+};
+
+/**
+ * @brief Terminal-node record carried by FAILED and HALTED results.
+ *
+ * HALTED uses a zero @c code and identifies its explicit HALT packet through
+ * @c node and @c opcode. FAILED uses the first-error-wins firmware record.
+ */
+struct Rp1TerminalError {
+    /// First terminal @c RP1_ERR_* code, or zero for explicit HALT.
+    std::uint32_t code = 0;
+    /// Failing or HALT node, or @c RP1_TERMINAL_ERROR_NODE_NONE.
+    std::uint32_t node = RP1_TERMINAL_ERROR_NODE_NONE;
+    /// Terminal opcode, or @c RP1_TERMINAL_OPCODE_NONE when unavailable.
+    std::uint32_t opcode = RP1_TERMINAL_OPCODE_NONE;
+    /// Error-specific primary detail.
+    std::uint32_t detail = 0;
+    /// Error-specific auxiliary detail.
+    std::uint32_t aux = 0;
+};
+
+/**
+ * @brief Counts recorded while firmware quiesces in-flight kernels.
+ */
+struct Rp1Quiescence {
+    /// Finite kernels that completed during terminal quiescence.
+    std::uint32_t finiteDone = 0;
+    /// Finite kernels that timed out during terminal quiescence.
+    std::uint32_t finiteTimeout = 0;
+    /// Infinite kernels that remain active after terminal publication.
+    std::uint32_t infinite = 0;
+};
+
+/**
+ * @brief Validated, sequence-tagged terminal result for one graph.
+ *
+ * This host-owned value contains no volatile BAR references and remains valid
+ * after another graph is submitted. FAILED and HALTED are determinate return
+ * values; transport/protocol corruption and host-side timeouts are exceptions.
+ */
+struct Rp1GraphResult {
+    /// Exact graph sequence accepted and completed by firmware.
+    std::uint32_t sequence = 0;
+    /// Terminal classification for the graph.
+    Rp1GraphOutcome outcome = Rp1GraphOutcome::Success;
+    /// Raw @c RP1_RESULT_* bit mask.
+    std::uint32_t flags = 0;
+    /// First terminal record for FAILED or HALTED; absent on SUCCESS.
+    std::optional<Rp1TerminalError> terminal;
+    /// Final known image id, or zero when @c imageState is not Known.
+    std::uint32_t activeImageId = 0;
+    /// Firmware's final image-identity state.
+    Rp1ImageState imageState = Rp1ImageState::None;
+    /// Number of successful operation executions, including loop repeats.
+    std::uint32_t completedOperations = 0;
+    /// PMU ticks spent executing graph work through GRAPH_DONE.
+    std::uint32_t graphElapsedTicks = 0;
+    /// PMU ticks through final trace flush and result preparation.
+    std::uint32_t publishElapsedTicks = 0;
+    /// Final monotonic trace producer cursor.
+    std::uint32_t traceWriteIndex = 0;
+    /// Decoded terminal quiescence counters.
+    Rp1Quiescence quiescence;
+
+    /// Return true only for @c Rp1GraphOutcome::Success.
+    bool succeeded() const noexcept {
+        return outcome == Rp1GraphOutcome::Success;
+    }
+
+    /// Return true when every bit in @p mask is present in @c flags.
+    bool hasFlags(std::uint32_t mask) const noexcept {
+        return (flags & mask) == mask;
+    }
+};
 
 /**
  * @brief Trace entries captured after an RP1 graph submission.
@@ -137,10 +240,17 @@ class Rp1TimeoutError : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+/**
+ * @brief Single-flight protocol-v6 graph submitter over one RP1 BAR window.
+ *
+ * The referenced window must outlive the submitter. A post-doorbell timeout or
+ * a terminal result reporting recovery-required or remaining infinite work
+ * permanently poisons the object; no later shared-state mutation is allowed.
+ */
 class Rp1Submitter {
    public:
-    explicit Rp1Submitter(Rp1BarWindow& window,
-                          std::uint32_t cq_size = kDefaultCqSize);
+    /// Bind one submitter to the exclusively owned RP1 BAR window @p window.
+    explicit Rp1Submitter(Rp1BarWindow& window);
 
     /**
      * @brief Wait for the firmware's READY signal and program the
@@ -173,38 +283,18 @@ class Rp1Submitter {
      *
      * Calls @c ensureReady() if it hasn't been called yet.
      *
+     * FAILED and HALTED are returned as determinate terminal results. The
+     * method throws only when host validation fails, BAR transport is corrupt,
+     * or @p timeout elapses without exact-sequence completion.
+     *
+     * @return A validated SUCCESS, FAILED, or HALTED result for this sequence.
      * @throws Rp1TimeoutError if @p timeout elapses without completion.
-     * @throws std::logic_error if @p image violates the protocol caps.
-     * @throws std::runtime_error if the firmware reports an error state.
+     * @throws std::logic_error if @p image violates the protocol contract.
+     * @throws std::runtime_error if firmware publication is inconsistent.
      */
-    void submitAndWait(const Rp1GraphImage& image,
-                       std::chrono::milliseconds timeout = kDefaultSubmitTimeout);
-
-    /**
-     * @brief Read the CQ entries written by the most recent
-     *        @c submitAndWait() invocation (excluding any silent nodes).
-     *
-     * Entries drained incrementally while the graph was running are retained
-     * here for final validation.
-     *
-     * @throws std::runtime_error if the CQ cursors are corrupt or any entry
-     *         reports an RP1 node error or timeout.
-     */
-    std::vector<rp1_cq_entry_t> drainCq();
-
-    /**
-     * @brief Drain CQ records without interpreting node status.
-     *
-     * This lets higher layers reconcile side effects that completed before a
-     * later node or transport failure. Ring/cursor corruption still throws.
-     */
-    std::vector<rp1_cq_entry_t> drainCqRaw();
-
-    /**
-     * @brief Validate statuses from a previously drained raw CQ batch.
-     */
-    static void validateCq(
-        const std::vector<rp1_cq_entry_t>& entries);
+    Rp1GraphResult submitAndWait(
+        const Rp1GraphImage& image,
+        std::chrono::milliseconds timeout = kDefaultSubmitTimeout);
 
     /**
      * @brief Read trace entries from the most recent @c submitAndWait().
@@ -229,48 +319,45 @@ class Rp1Submitter {
     }
 
     /**
-     * @brief True after an in-flight submission times out indeterminately.
+     * @brief True when the completed session cannot safely be reused.
      *
-     * A poisoned submitter rejects further BAR mutations and submissions.
-     * Callers must reset/recover the device and construct a new submitter.
+     * A timeout, recovery-required result, or remaining infinite work poisons
+     * the submitter. Callers must reset/recover the device and construct a new
+     * submitter before issuing another mutation.
      */
     bool poisoned() const noexcept {
         return poisoned_.load(std::memory_order_acquire);
     }
 
-    /**
-     * @brief CQ cursor at the latest submission/final drain boundary.
-     */
-    std::uint32_t lastCqStart() const noexcept { return last_cq_start_; }
-
    private:
+    /// Non-owning BAR accessor supplied at construction.
     Rp1BarWindow* window_;
-    std::uint32_t cq_size_;
+    /// True after the current firmware boot passed readiness validation.
     bool          ready_       = false;
+    /// Exact sequence written by the most recent accepted host submission.
     std::uint32_t last_graph_seq_ = 0;
-    std::uint32_t last_cq_start_  = 0;
+    /// Ring size used to decode the most recent optional trace capture.
     std::uint32_t last_trace_size_ = kDefaultTraceSize;
+    /// Host-local count advanced immediately after each graph doorbell.
     std::atomic_uint64_t submission_serial_{0};
     /*
-     * cq_cursor_ follows the monotonic firmware producer cursor; pending_cq_
-     * retains incrementally copied records until the caller consumes the graph.
-     */
-    std::uint32_t cq_cursor_ = 0;
-    std::vector<rp1_cq_entry_t> pending_cq_;
-    /*
-     * Poison closes an indeterminate post-doorbell session permanently;
+     * Poison closes an unsafe post-doorbell session permanently;
      * submission_active_ rejects only overlap and clears during stack unwind.
      */
     std::atomic_bool poisoned_{false};
     std::atomic_bool submission_active_{false};
 
+    /// Reject mutations after an unsafe post-doorbell terminal condition.
     void requireUsable() const;
+    /// Poll for the firmware's boot-contract commit magic.
     void waitForMagic(std::chrono::milliseconds timeout);
+    /// Poll for @p target while rejecting reset-only terminal firmware.
     void waitForState(std::uint32_t target, std::chrono::milliseconds timeout);
-    void waitForGraphDone(std::uint32_t want_seq, std::chrono::milliseconds timeout);
-    void drainAvailableCq();
-    [[noreturn]] void throwTerminalError(
-        std::uint32_t state, std::uint32_t graph_seq) const;
+    /// Wait for exact sequence completion and return its validated result.
+    Rp1GraphResult waitForGraphDone(
+        std::uint32_t want_seq, std::chrono::milliseconds timeout);
+    /// Snapshot and validate the committed result for @p want_seq.
+    Rp1GraphResult readGraphResult(std::uint32_t want_seq);
 };
 
 }  // namespace vrt::graph::fpga

--- a/vrt/include/vrt/graph/device/fpga_device.hpp
+++ b/vrt/include/vrt/graph/device/fpga_device.hpp
@@ -121,14 +121,12 @@ class FpgaDevice : public IDevice,
    public:
     FpgaDevice(std::string                       id,
                std::shared_ptr<fpga::Rp1BarWindow> window,
-               FpgaKernelLocationLookup           lookup,
-               std::uint32_t                      cq_size = fpga::kDefaultCqSize);
+               FpgaKernelLocationLookup           lookup);
 
     FpgaDevice(std::string                       id,
                std::shared_ptr<fpga::Rp1BarWindow> window,
                std::shared_ptr<fpga::FpgaVbinSpec> vbinSpec,
-               std::string                       initialImageId = "",
-               std::uint32_t                     cq_size = fpga::kDefaultCqSize);
+               std::string                       initialImageId = "");
 
     ~FpgaDevice() override;
 

--- a/vrt/src/graph/device/fpga/rp1_bar_window.cpp
+++ b/vrt/src/graph/device/fpga/rp1_bar_window.cpp
@@ -250,9 +250,8 @@ void Rp1BarWindow::readSignal(std::uint32_t slot, rp1_signal_slot_t& out,
            &out, sizeof(out));
 }
 
-void Rp1BarWindow::readCq(std::uint32_t idx, rp1_cq_entry_t& out,
-                          std::uint32_t cq_offset) {
-    readAt(cq_offset + idx * sizeof(rp1_cq_entry_t),
+void Rp1BarWindow::readGraphResult(rp1_graph_result_t& out) {
+    readAt(static_cast<std::uint32_t>(offsetof(rp1_ctrl_t, result)),
            &out, sizeof(out));
 }
 

--- a/vrt/src/graph/device/fpga/rp1_submitter.cpp
+++ b/vrt/src/graph/device/fpga/rp1_submitter.cpp
@@ -30,8 +30,18 @@ namespace vrt::graph::fpga {
 
 namespace {
 
-constexpr std::chrono::microseconds kPollInterval{1000};  // 1 ms
+/// Host polling cadence retained from the protocol-v4 submitter.
+constexpr std::chrono::microseconds kPollInterval{1000};
 
+/// Bytes available before the default signal-array region begins.
+constexpr std::size_t kDefaultArgBufferBytes =
+    RP1_DEFAULT_SIG_ARRAY_OFFSET - RP1_DEFAULT_ARG_BUF_OFFSET;
+
+/// Result flags that prove the device cannot be reused without recovery.
+constexpr std::uint32_t kPoisonFlags =
+    RP1_RESULT_RECOVERY_REQUIRED | RP1_RESULT_INFINITE_WORK_REMAINS;
+
+/// Return a stable diagnostic label for a raw firmware state.
 const char* stateName(std::uint32_t s) {
     switch (s) {
         case RP1_STATE_INIT:    return "INIT";
@@ -43,22 +53,35 @@ const char* stateName(std::uint32_t s) {
     }
 }
 
+/// Return true when @p v is a non-zero power of two.
 bool isPowerOfTwo(std::uint32_t v) noexcept {
     return v != 0 && (v & (v - 1)) == 0;
 }
 
-bool isValidCqSize(std::uint32_t size) noexcept {
-    return isPowerOfTwo(size) && size <= RP1_MAX_CQ_ENTRIES;
-}
-
+/// Return true when @p op is a protocol-defined condition operation.
 bool isValidCondition(std::uint16_t op) noexcept {
     return op <= RP1_COP_AND_Z;
+}
+
+/**
+ * @brief Return whether one phase-1 DMA endpoint fits the 32-bit DDR model.
+ *
+ * Phase 1 supports only word-aligned, low-word addresses. A zero-byte transfer
+ * is valid; non-empty ranges may end at the top of the 32-bit address space
+ * but must not wrap past it.
+ */
+bool isValidPhase1DmaRange(std::uint32_t lo, std::uint32_t hi,
+                           std::uint32_t bytes) noexcept {
+    constexpr std::uint64_t addressSpaceSize =
+        std::uint64_t{1} << 32;
+    return hi == 0u && ((lo | bytes) & 3u) == 0u &&
+           static_cast<std::uint64_t>(lo) + bytes <= addressSpaceSize;
 }
 
 /*
  * Validation is deliberately complete before the doorbell can move. Check the
  * shared header first, then opcode-specific slots and ranges, and reject
- * undefined packets or PDI loads that suppress durable completion evidence.
+ * undefined packets before staged bytes can become firmware-owned.
  */
 void validateImage(const Rp1GraphImage& image) {
     const auto bad = [](std::size_t index, const std::string& reason) {
@@ -70,19 +93,73 @@ void validateImage(const Rp1GraphImage& image) {
         return slot < RP1_MAX_SIGNALS;
     };
 
+    if (image.arg_buf.size() >
+        kDefaultArgBufferBytes / sizeof(std::uint32_t)) {
+        throw std::logic_error(
+            "Rp1Submitter: argument buffer exceeds the default " +
+            std::to_string(kDefaultArgBufferBytes) + "-byte region");
+    }
+
     for (std::size_t i = 0; i < image.nodes.size(); ++i) {
         const rp1_node_t& node = image.nodes[i];
+        const std::uint16_t opcode = rp1_node_get_opcode(&node);
+        const std::uint16_t flags = rp1_node_get_flags(&node);
+        if ((rp1_node_get_control(&node) & RP1_NODE_RESERVED_MASK) != 0u) {
+            bad(i, "packed control reserved bits are non-zero");
+        }
+        if (rp1_node_get_status(&node) != RP1_NODE_PENDING) {
+            bad(i, "initial status is not PENDING");
+        }
+        if ((flags & ~RP1_FLAG_INFINITE) != 0u ||
+            ((flags & RP1_FLAG_INFINITE) != 0u &&
+             opcode != RP1_OP_KERNEL_DISPATCH)) {
+            bad(i, "flags are invalid for the opcode");
+        }
         if (node.barrier_await_bucket >= RP1_MAX_BUCKETS ||
             node.barrier_set_bucket >= RP1_MAX_BUCKETS) {
             bad(i, "barrier bucket out of range");
         }
-        switch (node.opcode) {
+        switch (opcode) {
             case RP1_OP_NOP:
-            case RP1_OP_SCALAR_WRITE:
-            case RP1_OP_DMA_COPY:
-            case RP1_OP_DMA_FILL:
             case RP1_OP_HALT:
                 break;
+            case RP1_OP_SCALAR_WRITE: {
+                bool terminated = false;
+                for (const rp1_write_pair_t& write :
+                     node.payload.scalar_write.writes) {
+                    if (write.addr == 0u) {
+                        terminated = true;
+                    } else if (terminated || (write.addr & 3u) != 0u) {
+                        bad(i, "SCALAR_WRITE pair sequence is invalid");
+                    }
+                }
+                break;
+            }
+            case RP1_OP_DMA_COPY: {
+                const auto& dma = node.payload.dma_copy;
+                const std::uint32_t packed =
+                    dma.length_types;
+                const std::uint32_t length =
+                    rp1_dma_get_length(packed);
+                if (rp1_dma_get_src_type(packed) != 0u ||
+                    rp1_dma_get_dst_type(packed) != 0u ||
+                    !isValidPhase1DmaRange(
+                        dma.src_addr_lo, dma.src_addr_hi, length) ||
+                    !isValidPhase1DmaRange(
+                        dma.dst_addr_lo, dma.dst_addr_hi, length)) {
+                    bad(i, "DMA_COPY address, length, or memory type is invalid");
+                }
+                break;
+            }
+            case RP1_OP_DMA_FILL: {
+                const auto& dma = node.payload.dma_fill;
+                if (dma.dst_type != 0u ||
+                    !isValidPhase1DmaRange(
+                        dma.dst_addr_lo, dma.dst_addr_hi, dma.length)) {
+                    bad(i, "DMA_FILL address, length, or memory type is invalid");
+                }
+                break;
+            }
             case RP1_OP_SIGNAL:
                 if (!validSlot(node.payload.signal.target_slot)) {
                     bad(i, "SIGNAL target slot out of range");
@@ -117,15 +194,13 @@ void validateImage(const Rp1GraphImage& image) {
                         sizeof(rp1_kernel_arg_t);
                 if (kernel.kernel_base_addr == 0 ||
                     (kernel.arg_buffer_offset & 7u) != 0u ||
+                    kernel.ctrl_flags != 0u ||
                     argEnd > image.arg_buf.size() * sizeof(std::uint32_t)) {
                     bad(i, "KERNEL_DISPATCH argument range is invalid");
                 }
                 break;
             }
             case RP1_OP_PDI_LOAD:
-                if ((node.flags & RP1_FLAG_SILENT) != 0u) {
-                    bad(i, "PDI_LOAD must retain CQ evidence");
-                }
                 break;
             case RP1_OP_LOOP: {
                 const auto& loop = node.payload.loop;
@@ -161,6 +236,8 @@ void validateImage(const Rp1GraphImage& image) {
             }
             case RP1_OP_RERUN:
                 if (node.payload.rerun.target_node >= image.nodes.size() ||
+                    (node.payload.rerun.rerun_flags &
+                     ~RP1_RERUN_CLEAR_STATE) != 0u ||
                     (((node.payload.rerun.rerun_flags &
                        RP1_RERUN_CLEAR_STATE) != 0u) &&
                      node.payload.rerun.loop_id >= RP1_MAX_LOOPS)) {
@@ -168,7 +245,7 @@ void validateImage(const Rp1GraphImage& image) {
                 }
                 break;
             default:
-                bad(i, "opcode is not defined by protocol v4");
+                bad(i, "opcode is not defined by protocol v6");
         }
     }
 }
@@ -197,7 +274,7 @@ void requireFirmwareContract(Rp1BarWindow& window) {
         RP1_REQUIRED_CAPABILITIES & ~capabilities;
     if (missing != 0u) {
         throw std::runtime_error(
-            "Rp1Submitter: RP1 firmware is missing required protocol-v4 "
+            "Rp1Submitter: RP1 firmware is missing required protocol-v6 "
             "capabilities (firmware mask=" +
             std::to_string(capabilities) + ", required mask=" +
             std::to_string(RP1_REQUIRED_CAPABILITIES) + ", missing mask=" +
@@ -214,22 +291,71 @@ void requireFirmwareContract(Rp1BarWindow& window) {
 
 }  // namespace
 
-Rp1Submitter::Rp1Submitter(Rp1BarWindow& window, std::uint32_t cq_size)
-    : window_(&window), cq_size_(cq_size) {
-    if (!isValidCqSize(cq_size_)) {
-        throw std::invalid_argument(
-            "Rp1Submitter: cq_size must be a power of 2 in [1, " +
-            std::to_string(RP1_MAX_CQ_ENTRIES) + "], got " +
-            std::to_string(cq_size_));
+void appendScalarWritePackets(
+    Rp1GraphImage& image,
+    const std::vector<rp1_write_pair_t>& writes,
+    std::uint8_t awaitBucket, std::uint32_t awaitMask,
+    std::uint8_t setBucket, std::uint32_t setMask) {
+    if (writes.empty()) {
+        throw std::logic_error(
+            "appendScalarWritePackets: write list is empty");
+    }
+    if (awaitBucket >= RP1_MAX_BUCKETS ||
+        setBucket >= RP1_MAX_BUCKETS) {
+        throw std::logic_error(
+            "appendScalarWritePackets: barrier bucket is out of range");
+    }
+    for (const rp1_write_pair_t& write : writes) {
+        if (write.addr == 0u || (write.addr & 3u) != 0u) {
+            throw std::logic_error(
+                "appendScalarWritePackets: address is zero or unaligned");
+        }
+    }
+
+    const std::size_t packetCount =
+        writes.size() / RP1_SCALAR_WRITE_MAX +
+        (writes.size() % RP1_SCALAR_WRITE_MAX != 0u ? 1u : 0u);
+    if (image.nodes.size() > RP1_MAX_NODES ||
+        packetCount > RP1_MAX_NODES - image.nodes.size()) {
+        throw std::logic_error(
+            "appendScalarWritePackets: image exceeds RP1_MAX_NODES");
+    }
+
+    /*
+     * Every packet shares the original await. Only the final packet publishes
+     * completion, so contiguous flat-scanner order cannot expose a partial
+     * register-write sequence to dependent nodes.
+     */
+    image.nodes.reserve(image.nodes.size() + packetCount);
+    for (std::size_t first = 0; first < writes.size();
+         first += RP1_SCALAR_WRITE_MAX) {
+        rp1_node_t node{};
+        rp1_node_set_opcode(&node, RP1_OP_SCALAR_WRITE);
+        rp1_node_set_flags(&node, 0u);
+        rp1_node_set_status(&node, RP1_NODE_PENDING);
+        node.barrier_await_bucket = awaitBucket;
+        node.barrier_await_mask = awaitMask;
+        const bool final =
+            first + RP1_SCALAR_WRITE_MAX >= writes.size();
+        node.barrier_set_bucket = final ? setBucket : 0u;
+        node.barrier_set_mask = final ? setMask : 0u;
+        for (std::size_t i = 0;
+             i < RP1_SCALAR_WRITE_MAX && first + i < writes.size();
+             ++i) {
+            node.payload.scalar_write.writes[i] = writes[first + i];
+        }
+        image.nodes.push_back(node);
     }
 }
+
+Rp1Submitter::Rp1Submitter(Rp1BarWindow& window) : window_(&window) {}
 
 void Rp1Submitter::requireUsable() const {
     if (poisoned()) {
         throw std::runtime_error(
-            "Rp1Submitter: device is poisoned after an indeterminate "
-            "submission timeout; reset/recover the device and construct "
-            "a new runtime device before submitting again");
+            "Rp1Submitter: device is poisoned after an unsafe terminal "
+            "submission; reset/recover the device and construct a new "
+            "runtime device before submitting again");
     }
 }
 
@@ -260,22 +386,18 @@ void Rp1Submitter::ensureReady(std::chrono::milliseconds timeout) {
     // publication fields are visible.
     requireFirmwareContract(*window_);
 
-    // Program the recommended base addresses + cq_size by writing
-    // host-owned fields individually.  We must NOT bulk-write the 4 KB
-    // control block here: the firmware concurrently updates its own
-    // fields (heartbeat, rp1_state, graph_done_seq, cq_write_idx,
-    // rp1_current_node, rp1_error_code), so a read-modify-write of the
-    // whole block would clobber whatever RP1 changed between our read
-    // and write.  Individual 32-bit writes only touch host-owned slots.
-    window_->writeU32(offsetof(rp1_ctrl_t, cq_size), cq_size_);
+    /*
+     * Program host-owned words individually. A bulk control-block write would
+     * race firmware-owned heartbeat, state, sequence, result, and diagnostics.
+     * Former CQ configuration words are zero-only protocol-v6 reservations.
+     */
+    window_->writeU32(offsetof(rp1_ctrl_t, _reserved_cq_size), 0u);
     window_->writeU32(offsetof(rp1_ctrl_t, node_base_lo),
                        static_cast<std::uint32_t>(
                            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_NODE_ARRAY_OFFSET));
     window_->writeU32(offsetof(rp1_ctrl_t, node_base_hi),  0);
-    window_->writeU32(offsetof(rp1_ctrl_t, cq_base_lo),
-                       static_cast<std::uint32_t>(
-                           RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_CQ_OFFSET));
-    window_->writeU32(offsetof(rp1_ctrl_t, cq_base_hi),    0);
+    window_->writeU32(offsetof(rp1_ctrl_t, _reserved_cq_base_lo), 0u);
+    window_->writeU32(offsetof(rp1_ctrl_t, _reserved_cq_base_hi), 0u);
     window_->writeU32(offsetof(rp1_ctrl_t, arg_buf_base_lo),
                        static_cast<std::uint32_t>(
                            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_ARG_BUF_OFFSET));
@@ -291,29 +413,19 @@ void Rp1Submitter::ensureReady(std::chrono::milliseconds timeout) {
     window_->writeTraceEnable(0);
     last_trace_size_ = kDefaultTraceSize;
 
-    // Synchronize the host-owned CQ consumer cursor to the producer's current
-    // position. Other sequence/state fields remain firmware-owned.
-    cq_cursor_ = window_->readCqWriteIdx();
-    window_->writeCqReadIdx(cq_cursor_);
-    pending_cq_.clear();
-
     std::atomic_thread_fence(std::memory_order_seq_cst);
-
-    // Seed last_cq_start_ so callers that immediately drainCq() see an
-    // empty range.
-    last_cq_start_ = cq_cursor_;
     last_graph_seq_ = window_->readGraphSeq();
 
     ready_ = true;
 }
 
 /*
- * A submission has five ordered phases: claim and validate, establish READY,
- * retire prior CQ evidence, stage the image, then publish graph_seq and wait.
- * Only publication transfers ownership of the staged bytes to RP1.
+ * A submission has four ordered phases: claim and validate, establish READY,
+ * stage the image, then publish graph_seq and wait. Only publication transfers
+ * ownership of the staged bytes to RP1.
  */
-void Rp1Submitter::submitAndWait(const Rp1GraphImage& image,
-                                  std::chrono::milliseconds timeout) {
+Rp1GraphResult Rp1Submitter::submitAndWait(
+    const Rp1GraphImage& image, std::chrono::milliseconds timeout) {
     requireUsable();
     bool expected = false;
     if (!submission_active_.compare_exchange_strong(
@@ -322,8 +434,11 @@ void Rp1Submitter::submitAndWait(const Rp1GraphImage& image,
         throw std::runtime_error(
             "Rp1Submitter: a graph submission is already active");
     }
+    /// Clear the single-flight claim during every stack-unwind path.
     struct ActiveSubmission {
+        /// Submitter flag exclusively owned by this scope guard.
         std::atomic_bool& active;
+        /// Release the single-flight claim after result or exception.
         ~ActiveSubmission() {
             active.store(false, std::memory_order_release);
         }
@@ -349,35 +464,33 @@ void Rp1Submitter::submitAndWait(const Rp1GraphImage& image,
                 " exceeds RP1_MAX_SIGNALS (" + std::to_string(RP1_MAX_SIGNALS) + ")");
         }
     }
+    const std::uint32_t trace_size =
+        image.trace_size_override != 0 ?
+            image.trace_size_override : kDefaultTraceSize;
+    if (!isPowerOfTwo(trace_size) ||
+        trace_size > RP1_MAX_TRACE_ENTRIES) {
+        throw std::invalid_argument(
+            "Rp1Submitter: trace_size must be a power of 2 in [1, " +
+            std::to_string(RP1_MAX_TRACE_ENTRIES) + "], got " +
+            std::to_string(trace_size));
+    }
 
     /*
      * Phase 2: establish the firmware contract and reject terminal or busy
      * state before this submission takes ownership of shared storage.
      */
-    if (!ready_) {
-        ensureReady(kDefaultReadyTimeout);
-    }
+    ensureReady(kDefaultReadyTimeout);
     const std::uint32_t preflightState = window_->readState();
     if (preflightState != RP1_STATE_READY) {
-        if (preflightState == RP1_STATE_ERROR ||
-            preflightState == RP1_STATE_HALTED) {
-            throwTerminalError(preflightState, window_->readGraphSeq());
-        }
         throw std::runtime_error(
             "Rp1Submitter: firmware is not READY before submission "
             "(state=" + std::string(stateName(preflightState)) + ")");
     }
 
     /*
-     * Phase 3: retire old CQ records, then stage arguments, signals, nodes,
-     * and host-owned configuration while firmware still sees the old sequence.
+     * Phase 3: stage arguments, signals, nodes, and host-owned configuration
+     * while firmware still sees the old sequence.
      */
-    drainAvailableCq();
-    // CQ records carry no graph sequence. Retain evidence for exactly this
-    // submission so an earlier image can never be interpreted as the next one.
-    pending_cq_.clear();
-    last_cq_start_ = cq_cursor_;
-
     // Stage args first so the kernel-dispatch packets reference valid
     // memory the moment graph_seq advances.
     if (!image.arg_buf.empty()) {
@@ -393,37 +506,13 @@ void Rp1Submitter::submitAndWait(const Rp1GraphImage& image,
     // Stage the node array.
     window_->writeNodes(image.nodes.data(), image.nodes.size());
 
-    // Read pre-submission cq cursor + current graph_seq so the caller
-    // can drain just this graph's CQ entries.
-    last_cq_start_ = cq_cursor_;
     const std::uint32_t prev_seq = window_->readGraphSeq();
     const std::uint32_t want_seq = prev_seq + 1u;
 
-    // Program node_count and (optionally) cq_size *before* bumping
-    // graph_seq.  RP1's flat scanner reads node_count when it observes
-    // graph_seq advancing, so this must be visible first.
+    // Program node_count before bumping graph_seq. RP1 snapshots it only after
+    // observing the new sequence, so the count must be visible first.
     window_->writeNodeCount(static_cast<std::uint32_t>(image.nodes.size()));
-    if (image.cq_size_override != 0) {
-        if (!isValidCqSize(image.cq_size_override)) {
-            throw std::invalid_argument(
-                "Rp1Submitter: cq_size_override must be a power of 2 in [1, " +
-                std::to_string(RP1_MAX_CQ_ENTRIES) + "], got " +
-                std::to_string(image.cq_size_override));
-        }
-        // Persist for subsequent submissions too.
-        cq_size_ = image.cq_size_override;
-        window_->writeU32(offsetof(rp1_ctrl_t, cq_size), cq_size_);
-    }
 
-    const std::uint32_t trace_size =
-        image.trace_size_override != 0 ? image.trace_size_override : kDefaultTraceSize;
-    if (!isPowerOfTwo(trace_size) ||
-        trace_size > RP1_MAX_TRACE_ENTRIES) {
-        throw std::invalid_argument(
-            "Rp1Submitter: trace_size must be a power of 2 in [1, " +
-            std::to_string(RP1_MAX_TRACE_ENTRIES) + "], got " +
-            std::to_string(trace_size));
-    }
     window_->writeTraceBase(static_cast<std::uint32_t>(
                                 RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_TRACE_OFFSET),
                             0);
@@ -443,39 +532,32 @@ void Rp1Submitter::submitAndWait(const Rp1GraphImage& image,
     ++submission_serial_;
 
     /*
-     * Phase 5: drain while waiting so a full CQ cannot stall firmware, then
-     * translate the terminal publication into the host-visible result.
+     * Completion: exact sequence equality releases the committed graph result.
+     * A timeout after the doorbell is indeterminate and permanently poisons
+     * this submitter so no later image can overwrite firmware-owned storage.
      */
     try {
-        waitForGraphDone(want_seq, timeout);
+        return waitForGraphDone(want_seq, timeout);
     } catch (const Rp1TimeoutError&) {
-        /*
-         * The doorbell is irreversible: RP1 may still consume the image or
-         * publish CQ after timeout. Poisoning prevents a second image racing it.
-         */
+        // The doorbell is irreversible: RP1 may still consume the staged image.
         poisoned_.store(true, std::memory_order_release);
         throw;
-    }
-
-    // After completion, surface explicit firmware-side errors so the
-    // caller doesn't have to remember to inspect rp1_state.
-    const std::uint32_t state = window_->readState();
-    if (state == RP1_STATE_ERROR || state == RP1_STATE_HALTED) {
-        throwTerminalError(state, want_seq);
     }
 }
 
 void Rp1Submitter::clearSignalSlots(const std::vector<std::uint32_t>& slots) {
     requireUsable();
-    if (!ready_) {
-        ensureReady(kDefaultReadyTimeout);
-    }
     for (std::uint32_t slot : slots) {
         if (slot >= RP1_MAX_SIGNALS) {
             throw std::logic_error(
                 "Rp1Submitter: signal slot " + std::to_string(slot) +
                 " exceeds RP1_MAX_SIGNALS (" + std::to_string(RP1_MAX_SIGNALS) + ")");
         }
+    }
+    if (!ready_) {
+        ensureReady(kDefaultReadyTimeout);
+    }
+    for (std::uint32_t slot : slots) {
         window_->clearSignal(slot);
     }
 }
@@ -490,63 +572,6 @@ std::uint32_t Rp1Submitter::readSignalValue(std::uint32_t slot) const {
     rp1_signal_slot_t value{};
     window_->readSignal(slot, value);
     return value.value;
-}
-
-std::vector<rp1_cq_entry_t> Rp1Submitter::drainCq() {
-    std::vector<rp1_cq_entry_t> out = drainCqRaw();
-    validateCq(out);
-    return out;
-}
-
-std::vector<rp1_cq_entry_t> Rp1Submitter::drainCqRaw() {
-    drainAvailableCq();
-    std::vector<rp1_cq_entry_t> out;
-    out.swap(pending_cq_);
-    last_cq_start_ = cq_cursor_;
-    return out;
-}
-
-/*
- * Monotonic uint32_t subtraction remains valid across wrap while delta does
- * not exceed the ring; the power-of-two mask then selects physical slots.
- * Copy before advancing read_idx so firmware cannot overwrite unretained
- * evidence. Draining in the wait loop also relieves producer backpressure.
- */
-void Rp1Submitter::drainAvailableCq() {
-    const std::uint32_t end = window_->readCqWriteIdx();
-    const std::uint32_t delta = end - cq_cursor_;
-    if (delta > cq_size_) {
-        throw std::runtime_error(
-            "Rp1Submitter::drainCq: corrupt completion queue cursors (" +
-            std::to_string(delta) + " entries for a " +
-            std::to_string(cq_size_) + "-entry ring)");
-    }
-
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    pending_cq_.reserve(pending_cq_.size() + delta);
-    for (std::uint32_t i = 0; i < delta; ++i) {
-        const std::uint32_t idx = (cq_cursor_ + i) & (cq_size_ - 1u);
-        rp1_cq_entry_t entry{};
-        window_->readCq(idx, entry);
-        pending_cq_.push_back(entry);
-    }
-    std::atomic_thread_fence(std::memory_order_seq_cst);
-    window_->writeCqReadIdx(end);
-    cq_cursor_ = end;
-}
-
-void Rp1Submitter::validateCq(
-    const std::vector<rp1_cq_entry_t>& entries) {
-    for (const rp1_cq_entry_t& entry : entries) {
-        if (entry.status == RP1_CQ_OK) continue;
-        const char* status =
-            entry.status == RP1_CQ_TIMEOUT ? "timeout" : "error";
-        throw std::runtime_error(
-            "Rp1Submitter: node " +
-            std::to_string(entry.node_index) + " reported " + status +
-            " (status=" + std::to_string(entry.status) +
-            ", detail=" + std::to_string(entry.error_detail) + ")");
-    }
 }
 
 Rp1TraceCapture Rp1Submitter::drainTrace() {
@@ -599,7 +624,10 @@ void Rp1Submitter::waitForState(std::uint32_t target,
         const std::uint32_t s = window_->readState();
         if (s == target) return;
         if (s == RP1_STATE_ERROR || s == RP1_STATE_HALTED) {
-            throwTerminalError(s, window_->readGraphSeq());
+            throw std::runtime_error(
+                "Rp1Submitter: firmware entered terminal state " +
+                std::string(stateName(s)) +
+                " before becoming READY; reset/recover the device");
         }
         if (std::chrono::steady_clock::now() > deadline) {
             throw Rp1TimeoutError(
@@ -611,33 +639,26 @@ void Rp1Submitter::waitForState(std::uint32_t target,
 }
 
 /*
- * Each poll first frees CQ space, then handles terminal, exact completion, or
- * timeout. Completion gets a final drain and state recheck because firmware
- * publishes CQ and errors before graph_done_seq, but BAR reads are separate.
+ * graph_done_seq is the sole release point for a terminal publication.
+ * Firmware deliberately writes result magic and terminal state first, so
+ * neither field may short-circuit this exact-sequence wait.
  */
-void Rp1Submitter::waitForGraphDone(std::uint32_t want_seq,
-                                     std::chrono::milliseconds timeout) {
+Rp1GraphResult Rp1Submitter::waitForGraphDone(
+    std::uint32_t want_seq, std::chrono::milliseconds timeout) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (true) {
-        drainAvailableCq();
-        std::uint32_t state = window_->readState();
-        if (state == RP1_STATE_ERROR || state == RP1_STATE_HALTED) {
-            throwTerminalError(state, want_seq);
-        }
         const std::uint32_t done = window_->readGraphDoneSeq();
         if (done == want_seq) {
-            drainAvailableCq();
-            state = window_->readState();
-            if (state == RP1_STATE_ERROR || state == RP1_STATE_HALTED) {
-                throwTerminalError(state, want_seq);
-            }
-            return;
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            return readGraphResult(want_seq);
         }
         if (std::chrono::steady_clock::now() > deadline) {
-            const std::uint32_t cur     = window_->readU32(
-                                              offsetof(rp1_ctrl_t, rp1_current_node));
-            const std::uint32_t err     = window_->readErrorCode();
-            const std::uint32_t cq_idx  = window_->readCqWriteIdx();
+            const std::uint32_t state = window_->readState();
+            const std::uint32_t cur = window_->readU32(
+                offsetof(rp1_ctrl_t, rp1_current_node));
+            const std::uint32_t err = window_->readErrorCode();
+            rp1_graph_result_t result{};
+            window_->readGraphResult(result);
             throw Rp1TimeoutError(
                 "Rp1Submitter: timed out waiting for graph_done_seq=" +
                 std::to_string(want_seq) +
@@ -645,36 +666,160 @@ void Rp1Submitter::waitForGraphDone(std::uint32_t want_seq,
                 ", state=" + stateName(state) +
                 ", current_node=" + std::to_string(cur) +
                 ", error_code=" + std::to_string(err) +
-                ", cq_write_idx=" + std::to_string(cq_idx) + ")");
+                ", result_magic=" + std::to_string(result.magic) +
+                ", result_seq=" + std::to_string(result.graph_seq) +
+                ", result_outcome=" + std::to_string(result.outcome) + ")");
         }
         std::this_thread::sleep_for(kPollInterval);
     }
 }
 
 /*
- * Terminal state publishes the first-error-wins record after quiescence.
- * Read every field only after observing that state so diagnostics describe
- * the accepted graph rather than a partially written failure.
+ * Convert the stable wire record only after validating every discriminant.
+ * State/outcome agreement catches a reordered or torn terminal publication;
+ * image-id agreement prevents higher layers from trusting a malformed image.
  */
-void Rp1Submitter::throwTerminalError(
-    std::uint32_t state, std::uint32_t graph_seq) const {
-    const std::uint32_t code = window_->readErrorCode();
-    const std::uint32_t node =
-        window_->readU32(offsetof(rp1_ctrl_t, terminal_error_node));
-    const std::uint32_t detail =
-        window_->readU32(offsetof(rp1_ctrl_t, terminal_error_detail));
-    const std::uint32_t aux =
-        window_->readU32(offsetof(rp1_ctrl_t, terminal_error_aux));
-    throw std::runtime_error(
-        std::string("Rp1Submitter: firmware reported terminal state ") +
-        stateName(state) + " for graph seq " + std::to_string(graph_seq) +
-        " (error_code=" + std::to_string(code) +
-        ", base_error=" + std::to_string(code & RP1_ERR_CODE_MASK) +
-        ", recovery_required=" +
-        std::to_string((code & RP1_ERR_RECOVERY_REQUIRED) != 0u) +
-        ", node=" + std::to_string(node) +
-        ", detail=" + std::to_string(detail) +
-        ", aux=" + std::to_string(aux) + ")");
+Rp1GraphResult Rp1Submitter::readGraphResult(
+    std::uint32_t want_seq) {
+    rp1_graph_result_t wire{};
+    window_->readGraphResult(wire);
+    const std::uint32_t state = window_->readState();
+
+    const auto corrupt = [want_seq](const std::string& reason) {
+        throw std::runtime_error(
+            "Rp1Submitter: corrupt graph result for sequence " +
+            std::to_string(want_seq) + ": " + reason);
+    };
+    if (wire.magic != RP1_GRAPH_RESULT_MAGIC) {
+        corrupt("magic=" + std::to_string(wire.magic) +
+                ", expected=" + std::to_string(RP1_GRAPH_RESULT_MAGIC));
+    }
+    if (wire.graph_seq != want_seq) {
+        corrupt("result sequence=" + std::to_string(wire.graph_seq) +
+                ", expected=" + std::to_string(want_seq));
+    }
+    /*
+     * A committed hazardous result is enough to close the session even when
+     * another field is corrupt. Firmware may still own staged addresses.
+     */
+    if ((wire.flags & kPoisonFlags) != 0u) {
+        poisoned_.store(true, std::memory_order_release);
+    }
+    const std::uint32_t finiteDone =
+        (wire.quiescence >> RP1_QUIESCE_FINITE_DONE_SHIFT) &
+        RP1_QUIESCE_COUNT_MASK;
+    const std::uint32_t finiteTimeout =
+        (wire.quiescence >> RP1_QUIESCE_FINITE_TIMEOUT_SHIFT) &
+        RP1_QUIESCE_COUNT_MASK;
+    const std::uint32_t infinite =
+        (wire.quiescence >> RP1_QUIESCE_INFINITE_SHIFT) &
+        RP1_QUIESCE_COUNT_MASK;
+    if (finiteTimeout != 0u || infinite != 0u) {
+        /*
+         * Counters are direct evidence that firmware may retain access even
+         * when a corrupt result omitted the matching hazard flags.
+         */
+        poisoned_.store(true, std::memory_order_release);
+    }
+    if (finiteTimeout != 0u &&
+        (wire.flags & RP1_RESULT_RECOVERY_REQUIRED) == 0u) {
+        corrupt("finite timeout quiescence lacks recovery-required flag");
+    }
+    if (infinite != 0u &&
+        (wire.flags & (RP1_RESULT_RECOVERY_REQUIRED |
+                       RP1_RESULT_INFINITE_WORK_REMAINS)) !=
+            (RP1_RESULT_RECOVERY_REQUIRED |
+             RP1_RESULT_INFINITE_WORK_REMAINS)) {
+        corrupt("infinite quiescence lacks recovery/infinite flags");
+    }
+
+    Rp1GraphOutcome outcome = Rp1GraphOutcome::Success;
+    std::uint32_t expectedState = RP1_STATE_READY;
+    switch (wire.outcome) {
+        case RP1_GRAPH_RESULT_SUCCESS:
+            outcome = Rp1GraphOutcome::Success;
+            expectedState = RP1_STATE_READY;
+            if (wire.error_code != 0u) {
+                corrupt("SUCCESS carries error_code=" +
+                        std::to_string(wire.error_code));
+            }
+            if ((wire.flags &
+                 (RP1_RESULT_RECOVERY_REQUIRED |
+                  RP1_RESULT_EFFECTS_MAY_BE_PARTIAL)) != 0u) {
+                corrupt("SUCCESS carries terminal-only flags=" +
+                        std::to_string(wire.flags));
+            }
+            break;
+        case RP1_GRAPH_RESULT_FAILED:
+            outcome = Rp1GraphOutcome::Failed;
+            expectedState = RP1_STATE_ERROR;
+            if (wire.error_code == 0u) {
+                corrupt("FAILED carries no terminal error code");
+            }
+            break;
+        case RP1_GRAPH_RESULT_HALTED:
+            outcome = Rp1GraphOutcome::Halted;
+            expectedState = RP1_STATE_HALTED;
+            if (wire.error_code != 0u ||
+                wire.terminal_opcode != RP1_OP_HALT) {
+                corrupt("HALTED terminal record is inconsistent");
+            }
+            break;
+        default:
+            corrupt("outcome=" + std::to_string(wire.outcome) +
+                    " is not terminal");
+    }
+    if (state != expectedState) {
+        corrupt("state=" + std::string(stateName(state)) +
+                " does not match outcome=" +
+                std::to_string(wire.outcome));
+    }
+
+    Rp1ImageState imageState = Rp1ImageState::None;
+    switch (wire.image_state) {
+        case RP1_IMAGE_STATE_NONE:
+            imageState = Rp1ImageState::None;
+            break;
+        case RP1_IMAGE_STATE_KNOWN:
+            imageState = Rp1ImageState::Known;
+            break;
+        case RP1_IMAGE_STATE_UNKNOWN:
+            imageState = Rp1ImageState::Unknown;
+            break;
+        default:
+            corrupt("image_state=" + std::to_string(wire.image_state) +
+                    " is invalid");
+    }
+    if ((imageState == Rp1ImageState::Known) !=
+        (wire.active_image_id != 0u)) {
+        corrupt("active_image_id=" +
+                std::to_string(wire.active_image_id) +
+                " disagrees with image_state=" +
+                std::to_string(wire.image_state));
+    }
+
+    Rp1GraphResult result;
+    result.sequence = wire.graph_seq;
+    result.outcome = outcome;
+    result.flags = wire.flags;
+    if (outcome != Rp1GraphOutcome::Success) {
+        result.terminal = Rp1TerminalError{
+            wire.error_code,
+            wire.terminal_node,
+            wire.terminal_opcode,
+            wire.error_detail,
+            wire.error_aux};
+    }
+    result.activeImageId = wire.active_image_id;
+    result.imageState = imageState;
+    result.completedOperations = wire.completed_operations;
+    result.graphElapsedTicks = wire.graph_elapsed_ticks;
+    result.publishElapsedTicks = wire.publish_elapsed_ticks;
+    result.traceWriteIndex = wire.trace_write_idx;
+    result.quiescence.finiteDone = finiteDone;
+    result.quiescence.finiteTimeout = finiteTimeout;
+    result.quiescence.infinite = infinite;
+    return result;
 }
 
 }  // namespace vrt::graph::fpga

--- a/vrt/src/graph/device/fpga_device.cpp
+++ b/vrt/src/graph/device/fpga_device.cpp
@@ -69,13 +69,58 @@ constexpr std::uint32_t kKernelBitsPerBucket  = 31u;
 constexpr std::uint32_t kArgBufferWords =
     (RP1_DEFAULT_SIG_ARRAY_OFFSET - RP1_DEFAULT_ARG_BUF_OFFSET) / sizeof(std::uint32_t);
 
+/// Initialize one zeroed packet's packed control word for host submission.
+void initializeNode(rp1_node_t& node, rp1_opcode_t opcode) noexcept {
+    rp1_node_set_opcode(&node, opcode);
+    rp1_node_set_flags(&node, 0u);
+    rp1_node_set_status(&node, RP1_NODE_PENDING);
+}
+
+/// Narrow @p slot to the protocol-v6 signal field or reject it before packing.
+std::uint8_t checkedSignalSlot(std::uint32_t slot, const char* owner) {
+    if (slot >= RP1_MAX_SIGNALS) {
+        throw std::logic_error(
+            std::string("FpgaDevice: ") + owner +
+            " signal slot exceeds RP1_MAX_SIGNALS");
+    }
+    return static_cast<std::uint8_t>(slot);
+}
+
+/// Narrow @p operation to the protocol-v6 SIGNAL field after range validation.
+std::uint8_t checkedSignalOperation(std::uint32_t operation) {
+    if (operation > RP1_SIGOP_AND) {
+        throw std::logic_error(
+            "FpgaDevice: SIGNAL operation is not defined by RP1");
+    }
+    return static_cast<std::uint8_t>(operation);
+}
+
+/// Narrow @p operation to the protocol-v6 condition field after validation.
+std::uint8_t checkedConditionOperation(std::uint32_t operation) {
+    if (operation > RP1_COP_AND_Z) {
+        throw std::logic_error(
+            "FpgaDevice: condition operation is not defined by RP1");
+    }
+    return static_cast<std::uint8_t>(operation);
+}
+
+/// Narrow @p index to a protocol-v6 node index before packet publication.
+std::uint16_t checkedNodeIndex(std::size_t index, const char* owner) {
+    if (index >= RP1_MAX_NODES) {
+        throw std::logic_error(
+            std::string("FpgaDevice: ") + owner +
+            " node index exceeds RP1_MAX_NODES");
+    }
+    return static_cast<std::uint16_t>(index);
+}
+
 constexpr std::uint32_t alignUp(std::uint32_t value, std::uint32_t alignment) {
     return (value + alignment - 1u) & ~(alignment - 1u);
 }
 
 constexpr std::uint32_t kBufferArenaStart =
     alignUp(RP1_DEFAULT_TRACE_OFFSET +
-                fpga::kDefaultTraceSize * sizeof(rp1_trace_entry_t),
+                RP1_MAX_TRACE_ENTRIES * sizeof(rp1_trace_entry_t),
             4096u);
 
 std::mutex& rp1DiagnosticMutex() {
@@ -1301,18 +1346,23 @@ class FpgaDevicePlan : public IBackendExecutable {
 
     void finalize() override { ensureDirectImage(); }
 
+    /// Return the diagnostic label for an RP1 wire opcode.
     static const char* opcodeName(std::uint16_t op) {
         switch (op) {
             case RP1_OP_WAIT:            return "WAIT";
             case RP1_OP_SIGNAL:          return "SIGNAL";
+            case RP1_OP_SCALAR_WRITE:    return "SCALAR_WRITE";
             case RP1_OP_SCALAR_READ:     return "SCALAR_READ";
             case RP1_OP_SCALAR_COPY:     return "SCALAR_COPY";
             case RP1_OP_KERNEL_DISPATCH: return "KERNEL_DISPATCH";
             case RP1_OP_DMA_COPY:        return "DMA_COPY";
+            case RP1_OP_DMA_FILL:        return "DMA_FILL";
             case RP1_OP_PDI_LOAD:        return "PDI_LOAD";
             case RP1_OP_LOOP:            return "LOOP";
             case RP1_OP_COND:            return "COND";
             case RP1_OP_RERUN:           return "RERUN";
+            case RP1_OP_HALT:            return "HALT";
+            case RP1_OP_NOP:             return "NOP";
             default:                     return "?";
         }
     }
@@ -1321,36 +1371,55 @@ class FpgaDevicePlan : public IBackendExecutable {
         std::cerr << "[rp1-dump] " << image.nodes.size() << " nodes\n";
         for (std::size_t i = 0; i < image.nodes.size(); ++i) {
             const rp1_node_t& n = image.nodes[i];
-            std::cerr << "[rp1-dump] #" << i << " " << opcodeName(n.opcode)
+            const std::uint16_t opcode = rp1_node_get_opcode(&n);
+            std::cerr << "[rp1-dump] #" << i << " " << opcodeName(opcode)
                       << " await(b" << int(n.barrier_await_bucket) << ":0x"
                       << std::hex << n.barrier_await_mask << std::dec << ")"
                       << " set(b" << int(n.barrier_set_bucket) << ":0x"
                       << std::hex << n.barrier_set_mask << std::dec << ")";
-            if (n.opcode == RP1_OP_WAIT) {
-                std::cerr << " wait[sig=" << n.payload.wait.condition_signal
-                          << " op=" << n.payload.wait.condition_op
+            if (opcode == RP1_OP_WAIT) {
+                std::cerr << " wait[sig="
+                          << static_cast<unsigned>(
+                                 n.payload.wait.condition_signal)
+                          << " op="
+                          << static_cast<unsigned>(
+                                 n.payload.wait.condition_op)
                           << " val=" << n.payload.wait.condition_value << "]";
-            } else if (n.opcode == RP1_OP_SIGNAL) {
-                std::cerr << " sig[slot=" << n.payload.signal.target_slot
-                          << " op=" << n.payload.signal.operation
+            } else if (opcode == RP1_OP_SIGNAL) {
+                std::cerr << " sig[slot="
+                          << static_cast<unsigned>(
+                                 n.payload.signal.target_slot)
+                          << " op="
+                          << static_cast<unsigned>(
+                                 n.payload.signal.operation)
                           << " val=" << n.payload.signal.value << "]";
-            } else if (n.opcode == RP1_OP_LOOP) {
+            } else if (opcode == RP1_OP_LOOP) {
                 std::cerr << " loop[body=" << n.payload.loop.body_start << ".."
                           << n.payload.loop.body_end
                           << " maxIter=" << n.payload.loop.max_iterations
-                          << " condSig=" << n.payload.loop.condition_signal
+                          << " condSig="
+                          << static_cast<unsigned>(
+                                 n.payload.loop.condition_signal)
                           << " condVal=" << n.payload.loop.condition_value
-                          << " condOp=" << n.payload.loop.condition_op
+                          << " condOp="
+                          << static_cast<unsigned>(
+                                 n.payload.loop.condition_op)
                           << " clearB=" << int(n.payload.loop.bucket_clear_start) << ".."
                           << int(n.payload.loop.bucket_clear_end) << "]";
-            } else if (n.opcode == RP1_OP_PDI_LOAD) {
+            } else if (opcode == RP1_OP_PDI_LOAD) {
                 std::cerr << " pdi[img=" << n.payload.pdi_load.image_id << "]";
-            } else if (n.opcode == RP1_OP_KERNEL_DISPATCH) {
+            } else if (opcode == RP1_OP_KERNEL_DISPATCH) {
                 std::cerr << " kd[img=" << n.payload.kernel_dispatch.expected_image_id << "]";
-            } else if (n.opcode == RP1_OP_SCALAR_COPY) {
-                std::cerr << " scopy[srcSlot=" << n.payload.scalar_copy.source_slot << "]";
-            } else if (n.opcode == RP1_OP_SCALAR_READ) {
-                std::cerr << " sread[slot=" << n.payload.scalar_read.target_slot << "]";
+            } else if (opcode == RP1_OP_SCALAR_COPY) {
+                std::cerr << " scopy[srcSlot="
+                          << static_cast<unsigned>(
+                                 n.payload.scalar_copy.source_slot)
+                          << "]";
+            } else if (opcode == RP1_OP_SCALAR_READ) {
+                std::cerr << " sread[slot="
+                          << static_cast<unsigned>(
+                                 n.payload.scalar_read.target_slot)
+                          << "]";
             }
             std::cerr << "\n";
         }
@@ -1360,7 +1429,7 @@ class FpgaDevicePlan : public IBackendExecutable {
     static void dumpResolvedKernelArgs(const fpga::Rp1GraphImage& image) {
         for (std::size_t nodeIndex = 0; nodeIndex < image.nodes.size(); ++nodeIndex) {
             const rp1_node_t& node = image.nodes[nodeIndex];
-            if (node.opcode != RP1_OP_KERNEL_DISPATCH) continue;
+            if (rp1_node_get_opcode(&node) != RP1_OP_KERNEL_DISPATCH) continue;
             const auto& dispatch = node.payload.kernel_dispatch;
             std::size_t cursor =
                 dispatch.arg_buffer_offset / sizeof(std::uint32_t);
@@ -1392,6 +1461,8 @@ class FpgaDevicePlan : public IBackendExecutable {
             case RP1_TRACE_PDI_LOAD:       return "PDI_LOAD";
             case RP1_TRACE_IMAGE_MISMATCH: return "IMAGE_MISMATCH";
             case RP1_TRACE_GRAPH_DONE:     return "GRAPH_DONE";
+            case RP1_TRACE_FLUSH_START:    return "TRACE_FLUSH_START";
+            case RP1_TRACE_FLUSH_END:      return "TRACE_FLUSH_END";
         }
         return "UNKNOWN";
     }
@@ -1413,34 +1484,60 @@ class FpgaDevicePlan : public IBackendExecutable {
         }
     }
 
-    static void dumpCq(const fpga::Rp1GraphImage& image,
-                       const std::vector<rp1_cq_entry_t>& completions) {
-        std::lock_guard<std::mutex> lock(rp1DiagnosticMutex());
-        auto statusName = [](std::uint32_t status) -> const char* {
-            switch (status) {
-                case RP1_CQ_OK:      return "OK";
-                case RP1_CQ_ERROR:   return "ERROR";
-                case RP1_CQ_TIMEOUT: return "TIMEOUT";
-                default:             return "UNKNOWN";
-            }
-        };
-
-        std::cerr << "[rp1-cq] entries=" << completions.size() << "\n";
-        for (std::size_t i = 0; i < completions.size(); ++i) {
-            const rp1_cq_entry_t& completion = completions[i];
-            const char* opcode =
-                completion.node_index < image.nodes.size()
-                    ? opcodeName(image.nodes[completion.node_index].opcode)
-                    : "OUT_OF_RANGE";
-            std::cerr << "  cq[" << i << "]"
-                      << " node=" << completion.node_index
-                      << " opcode=" << opcode
-                      << " status=" << statusName(completion.status)
-                      << "(" << completion.status << ")"
-                      << " detail=0x" << std::hex << completion.error_detail
-                      << std::dec
-                      << " timestamp=" << completion.timestamp << "\n";
+    /// Return the diagnostic name for a validated terminal outcome.
+    static const char* outcomeName(fpga::Rp1GraphOutcome outcome) {
+        switch (outcome) {
+            case fpga::Rp1GraphOutcome::Success: return "SUCCESS";
+            case fpga::Rp1GraphOutcome::Failed:  return "FAILED";
+            case fpga::Rp1GraphOutcome::Halted:  return "HALTED";
         }
+        return "UNKNOWN";
+    }
+
+    /// Return the diagnostic name for a validated firmware image state.
+    static const char* imageStateName(fpga::Rp1ImageState state) {
+        switch (state) {
+            case fpga::Rp1ImageState::None:    return "NONE";
+            case fpga::Rp1ImageState::Known:   return "KNOWN";
+            case fpga::Rp1ImageState::Unknown: return "UNKNOWN";
+        }
+        return "INVALID";
+    }
+
+    /*
+     * Emit the complete sequence-tagged terminal record without consulting
+     * mutable control words. This replaces per-node CQ diagnostics.
+     */
+    static void dumpGraphResult(const fpga::Rp1GraphResult& result) {
+        std::lock_guard<std::mutex> lock(rp1DiagnosticMutex());
+        std::cerr << "[rp1-result]"
+                  << " seq=" << result.sequence
+                  << " outcome=" << outcomeName(result.outcome)
+                  << "(" << static_cast<std::uint32_t>(result.outcome) << ")"
+                  << " flags=0x" << std::hex << result.flags << std::dec
+                  << " image=" << imageStateName(result.imageState)
+                  << "(" << static_cast<std::uint32_t>(result.imageState)
+                  << "):" << result.activeImageId
+                  << " completed=" << result.completedOperations
+                  << " graph_ticks=" << result.graphElapsedTicks
+                  << " publish_ticks=" << result.publishElapsedTicks
+                  << " trace_write_idx=" << result.traceWriteIndex
+                  << " quiescence=" << result.quiescence.finiteDone << "/"
+                  << result.quiescence.finiteTimeout << "/"
+                  << result.quiescence.infinite;
+        if (result.terminal) {
+            std::cerr << " terminal={code=" << result.terminal->code
+                      << ",node=" << result.terminal->node
+                      << ",opcode=" << opcodeName(
+                             static_cast<std::uint16_t>(
+                                 result.terminal->opcode))
+                      << "(" << result.terminal->opcode << ")"
+                      << ",detail=0x" << std::hex
+                      << result.terminal->detail
+                      << ",aux=0x" << result.terminal->aux
+                      << std::dec << "}";
+        }
+        std::cerr << "\n";
     }
 
     static void clearHandshakeSlots(fpga::Rp1GraphImage& image) {
@@ -1451,18 +1548,19 @@ class FpgaDevicePlan : public IBackendExecutable {
          */
         std::set<std::uint32_t> carried;
         for (const rp1_node_t& n : image.nodes) {
-            if (n.opcode == RP1_OP_SCALAR_COPY) {
+            if (rp1_node_get_opcode(&n) == RP1_OP_SCALAR_COPY) {
                 carried.insert(n.payload.scalar_copy.source_slot);
             }
         }
 
         std::set<std::uint32_t> toClear;
         for (const rp1_node_t& n : image.nodes) {
-            if (n.opcode == RP1_OP_LOOP) {
+            const std::uint16_t opcode = rp1_node_get_opcode(&n);
+            if (opcode == RP1_OP_LOOP) {
                 toClear.insert(n.payload.loop.condition_signal);
-            } else if (n.opcode == RP1_OP_SIGNAL) {
+            } else if (opcode == RP1_OP_SIGNAL) {
                 toClear.insert(n.payload.signal.target_slot);
-            } else if (n.opcode == RP1_OP_WAIT) {
+            } else if (opcode == RP1_OP_WAIT) {
                 toClear.insert(n.payload.wait.condition_signal);
             }
         }
@@ -1506,9 +1604,10 @@ class FpgaDevicePlan : public IBackendExecutable {
     }
 
     /*
-     * Launch resolves every host-dependent field before submission, then drains
-     * completion evidence even when submission reports an error.  Image state
-     * is reconciled before errors are rethrown; sentinel success is checked last.
+     * Launch resolves every host-dependent field before submission. A returned
+     * terminal result reconciles image state before failure is surfaced, while
+     * an indeterminate post-doorbell exception conservatively forgets any image
+     * a PDI node may have changed. Sentinel success is checked last.
      */
     void launch() override {
         ensureDirectImage();
@@ -1525,7 +1624,6 @@ class FpgaDevicePlan : public IBackendExecutable {
                  * must precede aliases; aliases must precede address allocation
                  * so every deferred pointer resolves to its canonical backing.
                  */
-                lastCq_.clear();
                 resolveDeferredScalars();
                 resolveDeferredLoopTripCounts();
                 stageDeferredPdis();
@@ -1548,73 +1646,45 @@ class FpgaDevicePlan : public IBackendExecutable {
                 if (std::getenv("VRT_RP1_TRACE")) submitImage.trace_enable = true;
                 const std::uint64_t submissionBefore =
                     submitter_->submissionSerial();
-                std::exception_ptr submitError;
+                fpga::Rp1GraphResult result;
                 try {
-                    submitter_->submitAndWait(
+                    result = submitter_->submitAndWait(
                         submitImage, timeout_);
                 } catch (...) {
-                    submitError = std::current_exception();
-                }
-                const bool submitted =
-                    submitter_->submissionSerial() !=
-                    submissionBefore;
-
-                /*
-                 * Once RP1 accepted the image, CQ evidence is needed even when
-                 * submitAndWait failed.  PDI side effects are reconciled from
-                 * that evidence before transport or firmware errors escape.
-                 */
-                std::exception_ptr drainError;
-                if (submitted) {
-                    try {
-                        lastCq_ = submitter_->drainCqRaw();
-                    } catch (...) {
-                        drainError = std::current_exception();
+                    /*
+                     * No committed result exists for a host timeout or corrupt
+                     * transport. If RP1 accepted a graph containing PDI_LOAD,
+                     * its final image cannot be inferred safely.
+                     */
+                    if (submitter_->submissionSerial() !=
+                            submissionBefore &&
+                        imageContainsPdiLoad()) {
+                        device_->markActiveImageUnknown();
                     }
+                    throw;
                 }
-                reconcileImageSideEffects(
-                    lastCq_, submitted, submitError,
-                    !drainError);
-                if (std::getenv("VRT_RP1_CQ")) {
-                    dumpCq(image_, lastCq_);
-                }
-
+                reconcileImageState(result);
                 /*
-                 * Validate indices before status so diagnostics never index
-                 * outside the submitted image.  Preserve error precedence:
-                 * submission, CQ drain, then firmware completion status.
+                 * Recovery-required and infinite-work results retain every
+                 * execution lease and launch pin before any failure or success
+                 * path can release storage still reachable by firmware.
                  */
-                std::exception_ptr cqError;
-                if (!drainError) {
-                    try {
-                        for (const rp1_cq_entry_t& completion :
-                             lastCq_) {
-                            if (completion.node_index >=
-                                image_.nodes.size()) {
-                                throw std::runtime_error(
-                                    "FpgaDevicePlan: completion "
-                                    "references out-of-range node " +
-                                    std::to_string(
-                                        completion.node_index));
-                            }
-                        }
-                        fpga::Rp1Submitter::validateCq(lastCq_);
-                    } catch (...) {
-                        cqError = std::current_exception();
-                    }
+                if (submitter_->poisoned()) {
+                    device_->poisonExecution();
                 }
-                if (submitError) {
-                    std::rethrow_exception(submitError);
+                if (std::getenv("VRT_RP1_RESULT")) {
+                    dumpGraphResult(result);
                 }
-                if (drainError) {
-                    std::rethrow_exception(drainError);
+                if (submitImage.trace_enable) {
+                    dumpTrace(submitter_->drainTrace());
                 }
-                if (cqError) {
-                    std::rethrow_exception(cqError);
+                if (!result.succeeded()) {
+                    throw std::runtime_error(
+                        graphFailureMessage(result));
                 }
 
                 /*
-                 * A clean CQ is not sufficient: the trailing sentinel proves
+                 * SUCCESS alone is not sufficient: the trailing sentinel proves
                  * every graph leaf joined and the final SIGNAL actually ran.
                  */
                 const std::uint32_t sentinel =
@@ -1627,7 +1697,6 @@ class FpgaDevicePlan : public IBackendExecutable {
                         std::to_string(sentinelValue_) + ", actual=" +
                         std::to_string(sentinel) + ")");
                 }
-                if (submitImage.trace_enable) dumpTrace(submitter_->drainTrace());
             } catch (...) {
                 /*
                  * A submitter timeout with unknown hardware state poisons the
@@ -1673,7 +1742,6 @@ class FpgaDevicePlan : public IBackendExecutable {
         }
     }
 
-    const std::vector<rp1_cq_entry_t>& lastCq() const noexcept { return lastCq_; }
     std::uint32_t sentinelSlot()  const noexcept { return sentinelSlot_; }
     std::uint32_t sentinelValue() const noexcept { return sentinelValue_; }
     const fpga::Rp1GraphImage& image() const noexcept { return image_; }
@@ -1805,57 +1873,106 @@ class FpgaDevicePlan : public IBackendExecutable {
         }
     }
 
-    static bool isTimeoutError(
-        const std::exception_ptr& error) {
-        if (!error) return false;
-        try {
-            std::rethrow_exception(error);
-        } catch (const fpga::Rp1TimeoutError&) {
-            return true;
-        } catch (...) {
-            return false;
-        }
+    /// Return true when the reusable image can change the programmed PL image.
+    bool imageContainsPdiLoad() const {
+        return std::any_of(
+            image_.nodes.begin(), image_.nodes.end(),
+            [](const rp1_node_t& node) {
+                return rp1_node_get_opcode(&node) == RP1_OP_PDI_LOAD;
+            });
     }
 
     /*
-     * PDI_LOAD changes host image state only when its CQ entry proves success.
-     * A failed PDI makes the image unknown; incomplete CQ evidence or a timeout
-     * does likewise because later dispatch guards must not trust stale state.
+     * Resolve the firmware's stable numeric image id through the same sorted
+     * vbin map used by imageNumericId(). A result id outside that map is corrupt,
+     * because dispatch guards could otherwise trust the wrong user image.
      */
-    void reconcileImageSideEffects(
-        const std::vector<rp1_cq_entry_t>& completions,
-        bool submitted, const std::exception_ptr& submitError,
-        bool evidenceComplete) {
-        if (!device_ || !submitted || pdiImagesByNode_.empty()) {
-            return;
+    std::optional<std::string> imageName(
+        std::uint32_t numericId) const {
+        if (!device_ || !device_->vbinSpec_ || numericId == 0u) {
+            return std::nullopt;
         }
-        bool terminalEvidence = false;
-        bool transportIndeterminate = !evidenceComplete;
-        for (const rp1_cq_entry_t& completion : completions) {
-            if (completion.node_index >= image_.nodes.size()) {
-                transportIndeterminate = true;
-                continue;
-            }
-            if (completion.status != RP1_CQ_OK) {
-                terminalEvidence = true;
-            }
-            auto pdi = pdiImagesByNode_.find(
-                completion.node_index);
-            if (pdi == pdiImagesByNode_.end()) continue;
-            if (completion.status == RP1_CQ_OK) {
-                device_->setActiveImage(pdi->second);
-            } else {
+        std::uint32_t candidate = 1u;
+        for (const auto& [name, spec] : device_->vbinSpec_->images()) {
+            (void)spec;
+            if (candidate == numericId) return name;
+            ++candidate;
+        }
+        return std::nullopt;
+    }
+
+    /*
+     * The terminal result is authoritative for image identity even when a later
+     * node failed. Reconcile it before throwing so the next compilation either
+     * selects the installed image or rejects an unknown state safely.
+     */
+    void reconcileImageState(
+        const fpga::Rp1GraphResult& result) {
+        switch (result.imageState) {
+            case fpga::Rp1ImageState::None:
+                /*
+                 * Lookup-path and externally programmed images have no RP1 id.
+                 * A successful graph without PDI_LOAD therefore preserves the
+                 * host's existing image selection; a PDI or failure cannot.
+                 */
+                if (imageContainsPdiLoad() ||
+                    !result.succeeded()) {
+                    device_->markActiveImageUnknown();
+                }
+                return;
+            case fpga::Rp1ImageState::Unknown:
                 device_->markActiveImageUnknown();
-            }
+                return;
+            case fpga::Rp1ImageState::Known:
+                break;
         }
-        if (submitError &&
-            (isTimeoutError(submitError) ||
-             !terminalEvidence)) {
-            transportIndeterminate = true;
-        }
-        if (transportIndeterminate) {
+        const auto name = imageName(result.activeImageId);
+        if (!name) {
             device_->markActiveImageUnknown();
+            throw std::runtime_error(
+                "FpgaDevicePlan: RP1 graph result names unknown active "
+                "image id " + std::to_string(result.activeImageId));
         }
+        device_->setActiveImage(*name);
+    }
+
+    /// Format all terminal evidence needed to diagnose a determinate failure.
+    static std::string graphFailureMessage(
+        const fpga::Rp1GraphResult& result) {
+        std::string message =
+            "FpgaDevicePlan: RP1 graph seq " +
+            std::to_string(result.sequence) + " returned " +
+            outcomeName(result.outcome) +
+            " (flags=" + std::to_string(result.flags) +
+            ", completed_operations=" +
+            std::to_string(result.completedOperations) +
+            ", image_state=" + imageStateName(result.imageState) +
+            ", active_image_id=" +
+            std::to_string(result.activeImageId) +
+            ", graph_elapsed_ticks=" +
+            std::to_string(result.graphElapsedTicks) +
+            ", publish_elapsed_ticks=" +
+            std::to_string(result.publishElapsedTicks) +
+            ", trace_write_idx=" +
+            std::to_string(result.traceWriteIndex) +
+            ", quiescence=" +
+            std::to_string(result.quiescence.finiteDone) + "/" +
+            std::to_string(result.quiescence.finiteTimeout) + "/" +
+            std::to_string(result.quiescence.infinite);
+        if (result.terminal) {
+            message +=
+                ", error_code=" +
+                std::to_string(result.terminal->code) +
+                ", terminal_node=" +
+                std::to_string(result.terminal->node) +
+                ", terminal_opcode=" +
+                std::to_string(result.terminal->opcode) +
+                ", error_detail=" +
+                std::to_string(result.terminal->detail) +
+                ", error_aux=" +
+                std::to_string(result.terminal->aux);
+        }
+        return message + ")";
     }
 
     /*
@@ -1930,12 +2047,12 @@ class FpgaDevicePlan : public IBackendExecutable {
                     "' must be in the range 0..UINT32_MAX");
             }
             if (d.nodeIndex >= image_.nodes.size() ||
-                image_.nodes[d.nodeIndex].opcode != RP1_OP_LOOP) {
+                rp1_node_get_opcode(&image_.nodes[d.nodeIndex]) != RP1_OP_LOOP) {
                 throw std::logic_error(
                     "FpgaDevicePlan: deferred trip count points at a non-LOOP node");
             }
             if (d.gateNodeIndex >= image_.nodes.size() ||
-                image_.nodes[d.gateNodeIndex].opcode != RP1_OP_COND) {
+                rp1_node_get_opcode(&image_.nodes[d.gateNodeIndex]) != RP1_OP_COND) {
                 throw std::logic_error(
                     "FpgaDevicePlan: deferred trip count points at a non-COND body gate");
             }
@@ -1944,15 +2061,17 @@ class FpgaDevicePlan : public IBackendExecutable {
                 value == 0 ? 1u : static_cast<std::uint32_t>(value);
             loop.condition_value = fpga::kNeverValue;
             loop.condition_op =
-                value == 0
-                    ? fpga::invertRp1Op(fpga::kNeverOp)
-                    : fpga::kNeverOp;
+                checkedConditionOperation(
+                    value == 0
+                        ? fpga::invertRp1Op(fpga::kNeverOp)
+                        : fpga::kNeverOp);
             auto& gate =
                 image_.nodes[d.gateNodeIndex].payload.cond;
             gate.condition_op =
-                fpga::invertRp1Op(
-                    static_cast<rp1_condop_t>(
-                        loop.condition_op));
+                checkedConditionOperation(
+                    fpga::invertRp1Op(
+                        static_cast<rp1_condop_t>(
+                            loop.condition_op)));
         }
     }
 
@@ -2147,7 +2266,7 @@ class FpgaDevicePlan : public IBackendExecutable {
                     key, std::move(staged)).first;
             }
             if (d.nodeIndex >= image_.nodes.size() ||
-                image_.nodes[d.nodeIndex].opcode != RP1_OP_PDI_LOAD) {
+                rp1_node_get_opcode(&image_.nodes[d.nodeIndex]) != RP1_OP_PDI_LOAD) {
                 throw std::logic_error(
                     "FpgaDevicePlan: deferred PDI fixup points at a non-PDI_LOAD node");
             }
@@ -2439,9 +2558,7 @@ class FpgaDevicePlan : public IBackendExecutable {
             static_cast<std::uint32_t>(image.arg_buf.size()) * sizeof(std::uint32_t);
         const std::uint32_t argCount = packKernelArgs(image, k, skipInputScalars);
         rp1_node_t pkt{};
-        pkt.status               = RP1_NODE_PENDING;
-        pkt.opcode               = RP1_OP_KERNEL_DISPATCH;
-        pkt.flags                = RP1_FLAG_HALT_ON_ERROR;
+        initializeNode(pkt, RP1_OP_KERNEL_DISPATCH);
         pkt.barrier_await_bucket = awBucket;
         pkt.barrier_await_mask   = awMask;
         pkt.barrier_set_bucket   = setBucket;
@@ -2464,9 +2581,7 @@ class FpgaDevicePlan : public IBackendExecutable {
                                     std::uint8_t awBucket, std::uint32_t awMask,
                                     std::uint8_t setBucket, std::uint32_t setMask) {
         rp1_node_t pkt{};
-        pkt.status               = RP1_NODE_PENDING;
-        pkt.opcode               = RP1_OP_PDI_LOAD;
-        pkt.flags                = RP1_FLAG_HALT_ON_ERROR;
+        initializeNode(pkt, RP1_OP_PDI_LOAD);
         pkt.barrier_await_bucket = awBucket;
         pkt.barrier_await_mask   = awMask;
         pkt.barrier_set_bucket   = setBucket;
@@ -2479,7 +2594,6 @@ class FpgaDevicePlan : public IBackendExecutable {
         image.nodes.push_back(pkt);
         const std::size_t idx = image.nodes.size() - 1;
         deferredPdis_.push_back(DeferredPdi{idx, r.imageId, r.pdiPath});
-        pdiImagesByNode_[idx] = r.imageId;
         return idx;
     }
 
@@ -2546,13 +2660,14 @@ class FpgaDevicePlan : public IBackendExecutable {
                     const std::uint32_t cmask = nodeBitOf(cpos);
 
                     rp1_node_t cp{};
-                    cp.opcode = RP1_OP_SCALAR_COPY;
-                    cp.status = RP1_NODE_PENDING;
+                    initializeNode(cp, RP1_OP_SCALAR_COPY);
                     cp.barrier_await_bucket = copyAwBucket;
                     cp.barrier_await_mask = copyAwMask;
                     cp.barrier_set_bucket = cbucket;
                     cp.barrier_set_mask = cmask;
-                    cp.payload.scalar_copy.source_slot = readyIt->second.slot;
+                    cp.payload.scalar_copy.source_slot =
+                        checkedSignalSlot(
+                            readyIt->second.slot, "SCALAR_COPY");
                     cp.payload.scalar_copy.dest_addr =
                         loc->r5_base_addr + inputOffsets->at(sp.name);
                     image.nodes.push_back(cp);
@@ -2588,14 +2703,14 @@ class FpgaDevicePlan : public IBackendExecutable {
                     const FpgaKernelLocation loc = device_->resolveKernelLocation(k->kernel);
                     const std::uint32_t off = device_->outputScalarRegOffset(k->kernel, sp.name);
                     rp1_node_t sr{};
-                    sr.opcode = RP1_OP_SCALAR_READ;
-                    sr.status = RP1_NODE_PENDING;
+                    initializeNode(sr, RP1_OP_SCALAR_READ);
                     sr.barrier_await_bucket = lastBucket;
                     sr.barrier_await_mask = lastMask;
                     sr.barrier_set_bucket = rbucket;
                     sr.barrier_set_mask = rmask;
                     sr.payload.scalar_read.source_addr = loc.r5_base_addr + off;
-                    sr.payload.scalar_read.target_slot = slot;
+                    sr.payload.scalar_read.target_slot =
+                        checkedSignalSlot(slot, "SCALAR_READ");
                     image.nodes.push_back(sr);
                     if (bindIt != k->ioMap.outputScalars().end()) {
                         scalarSlots_[key] = slot;
@@ -2613,27 +2728,29 @@ class FpgaDevicePlan : public IBackendExecutable {
                 emitReprogramPacket(image, *r, awBucket, awMask, setBucket, setMask);
             } else if (const auto* sg = std::get_if<Rp1SignalCommand>(&n)) {
                 rp1_node_t pkt{};
-                pkt.opcode = RP1_OP_SIGNAL;
-                pkt.status = RP1_NODE_PENDING;
+                initializeNode(pkt, RP1_OP_SIGNAL);
                 pkt.barrier_await_bucket = awBucket;
                 pkt.barrier_await_mask = awMask;
                 pkt.barrier_set_bucket = setBucket;
                 pkt.barrier_set_mask = setMask;
-                pkt.payload.signal.target_slot = sg->slot;
+                pkt.payload.signal.target_slot =
+                    checkedSignalSlot(sg->slot, "SIGNAL");
                 pkt.payload.signal.value = sg->value;
-                pkt.payload.signal.operation = sg->operation;
+                pkt.payload.signal.operation =
+                    checkedSignalOperation(sg->operation);
                 image.nodes.push_back(pkt);
             } else if (const auto* wt = std::get_if<Rp1WaitCommand>(&n)) {
                 rp1_node_t pkt{};
-                pkt.opcode = RP1_OP_WAIT;
-                pkt.status = RP1_NODE_PENDING;
+                initializeNode(pkt, RP1_OP_WAIT);
                 pkt.barrier_await_bucket = awBucket;
                 pkt.barrier_await_mask = awMask;
                 pkt.barrier_set_bucket = setBucket;
                 pkt.barrier_set_mask = setMask;
-                pkt.payload.wait.condition_signal = wt->slot;
+                pkt.payload.wait.condition_signal =
+                    checkedSignalSlot(wt->slot, "WAIT");
                 pkt.payload.wait.condition_value = wt->value;
-                pkt.payload.wait.condition_op = wt->conditionOp;
+                pkt.payload.wait.condition_op =
+                    checkedConditionOperation(wt->conditionOp);
                 image.nodes.push_back(pkt);
             } else {
                 throw std::logic_error(
@@ -2727,7 +2844,7 @@ class FpgaDevicePlan : public IBackendExecutable {
 
         /*
          * A direct await is possible only within one bucket.  For a multi-
-         * bucket join, emit one silent collector per source bucket and recurse
+         * bucket join, emit one collector per source bucket and recurse
          * until the resulting bits share a bucket.
          */
         auto resolveAwait =
@@ -2750,9 +2867,7 @@ class FpgaDevicePlan : public IBackendExecutable {
             std::uint32_t j = 0;
             for (const auto& [bucket, bits] : groups) {
                 rp1_node_t agg{};
-                agg.opcode = RP1_OP_NOP;
-                agg.flags = RP1_FLAG_SILENT;
-                agg.status = RP1_NODE_PENDING;
+                initializeNode(agg, RP1_OP_NOP);
                 agg.barrier_await_bucket = bucket;
                 agg.barrier_await_mask = bits;
                 agg.barrier_set_bucket = cb;
@@ -2786,15 +2901,16 @@ class FpgaDevicePlan : public IBackendExecutable {
         for (const rp1_node_t& agg : aggregators) image.nodes.push_back(agg);
 
         rp1_node_t sentinel{};
-        sentinel.opcode = RP1_OP_SIGNAL;
-        sentinel.status = RP1_NODE_PENDING;
+        initializeNode(sentinel, RP1_OP_SIGNAL);
         sentinel.barrier_await_bucket = sentBucket;
         sentinel.barrier_await_mask = sentMask;
         sentinel.barrier_set_bucket = kSentinelBucket;
         sentinel.barrier_set_mask = kSentinelBit;
-        sentinel.payload.signal.target_slot = sentinelSlot_;
+        sentinel.payload.signal.target_slot =
+            checkedSignalSlot(sentinelSlot_, "sentinel SIGNAL");
         sentinel.payload.signal.value = sentinelValue_;
-        sentinel.payload.signal.operation = RP1_SIGOP_SET;
+        sentinel.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(sentinel);
         image.clear_signal_slots.push_back(sentinelSlot_);
         clearHandshakeSlots(image);
@@ -2822,15 +2938,16 @@ class FpgaDevicePlan : public IBackendExecutable {
             }
         }
         rp1_node_t sentinel{};
-        sentinel.opcode = RP1_OP_SIGNAL;
-        sentinel.status = RP1_NODE_PENDING;
+        initializeNode(sentinel, RP1_OP_SIGNAL);
         sentinel.barrier_await_bucket = kSentinelBucket;
         sentinel.barrier_await_mask = sentinelMask;
         sentinel.barrier_set_bucket = kSentinelBucket;
         sentinel.barrier_set_mask = kSentinelBit;
-        sentinel.payload.signal.target_slot = sentinelSlot_;
+        sentinel.payload.signal.target_slot =
+            checkedSignalSlot(sentinelSlot_, "sentinel SIGNAL");
         sentinel.payload.signal.value = sentinelValue_;
-        sentinel.payload.signal.operation = RP1_SIGOP_SET;
+        sentinel.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(sentinel);
         image.clear_signal_slots.push_back(sentinelSlot_);
         clearHandshakeSlots(image);
@@ -2915,14 +3032,14 @@ class FpgaDevicePlan : public IBackendExecutable {
                     const std::uint32_t off = device_->outputScalarRegOffset(k->kernel, sp.name);
                     const std::uint32_t rbit = allocMainBit();
                     rp1_node_t sr{};
-                    sr.opcode               = RP1_OP_SCALAR_READ;
-                    sr.status               = RP1_NODE_PENDING;
+                    initializeNode(sr, RP1_OP_SCALAR_READ);
                     sr.barrier_await_bucket = 0;
                     sr.barrier_await_mask   = lastBit;
                     sr.barrier_set_bucket   = 0;
                     sr.barrier_set_mask     = rbit;
                     sr.payload.scalar_read.source_addr = loc.r5_base_addr + off;
-                    sr.payload.scalar_read.target_slot = slot;
+                    sr.payload.scalar_read.target_slot =
+                        checkedSignalSlot(slot, "SCALAR_READ");
                     image.nodes.push_back(sr);
                     if (bindIt != k->ioMap.outputScalars().end()) {
                         scalarSlots_[key] = slot;
@@ -2947,30 +3064,32 @@ class FpgaDevicePlan : public IBackendExecutable {
                 const std::uint32_t aw  = awaitMaskFor(sg->dependsOn);
                 const std::uint32_t bit = allocMainBit();
                 rp1_node_t pkt{};
-                pkt.opcode               = RP1_OP_SIGNAL;
-                pkt.status               = RP1_NODE_PENDING;
+                initializeNode(pkt, RP1_OP_SIGNAL);
                 pkt.barrier_await_bucket = 0;
                 pkt.barrier_await_mask   = aw;
                 pkt.barrier_set_bucket   = 0;
                 pkt.barrier_set_mask     = bit;
-                pkt.payload.signal.target_slot = sg->slot;
+                pkt.payload.signal.target_slot =
+                    checkedSignalSlot(sg->slot, "SIGNAL");
                 pkt.payload.signal.value       = sg->value;
-                pkt.payload.signal.operation   = sg->operation;
+                pkt.payload.signal.operation   =
+                    checkedSignalOperation(sg->operation);
                 image.nodes.push_back(pkt);
                 mainBit[sg->id] = bit;
             } else if (const auto* wt = std::get_if<Rp1WaitCommand>(&node)) {
                 const std::uint32_t aw  = awaitMaskFor(wt->dependsOn);
                 const std::uint32_t bit = allocMainBit();
                 rp1_node_t pkt{};
-                pkt.opcode               = RP1_OP_WAIT;
-                pkt.status               = RP1_NODE_PENDING;
+                initializeNode(pkt, RP1_OP_WAIT);
                 pkt.barrier_await_bucket = 0;
                 pkt.barrier_await_mask   = aw;
                 pkt.barrier_set_bucket   = 0;
                 pkt.barrier_set_mask     = bit;
-                pkt.payload.wait.condition_signal = wt->slot;
+                pkt.payload.wait.condition_signal =
+                    checkedSignalSlot(wt->slot, "WAIT");
                 pkt.payload.wait.condition_value  = wt->value;
-                pkt.payload.wait.condition_op     = wt->conditionOp;
+                pkt.payload.wait.condition_op     =
+                    checkedConditionOperation(wt->conditionOp);
                 image.nodes.push_back(pkt);
                 mainBit[wt->id] = bit;
             } else if (std::holds_alternative<Rp1BoundaryCommand>(node)) {
@@ -3049,9 +3168,7 @@ class FpgaDevicePlan : public IBackendExecutable {
             for (const auto& [bucket, mask] : groups) {
                 BarrierRef c = allocBit();
                 rp1_node_t pkt{};
-                pkt.opcode = RP1_OP_NOP;
-                pkt.flags = RP1_FLAG_SILENT;
-                pkt.status = RP1_NODE_PENDING;
+                initializeNode(pkt, RP1_OP_NOP);
                 pkt.barrier_await_bucket = bucket;
                 pkt.barrier_await_mask = mask;
                 pkt.barrier_set_bucket = c.bucket;
@@ -3254,14 +3371,14 @@ class FpgaDevicePlan : public IBackendExecutable {
             const BarrierRef done =
                 domain.define(kernel.id + ".scopy." + port.name);
             rp1_node_t packet{};
-            packet.opcode = RP1_OP_SCALAR_COPY;
-            packet.status = RP1_NODE_PENDING;
+            initializeNode(packet, RP1_OP_SCALAR_COPY);
             packet.barrier_await_bucket = await.bucket;
             packet.barrier_await_mask = await.mask;
             packet.barrier_set_bucket = done.bucket;
             packet.barrier_set_mask = done.mask;
             packet.payload.scalar_copy.source_slot =
-                carriedSlot(imported->second);
+                checkedSignalSlot(
+                    carriedSlot(imported->second), "SCALAR_COPY");
             packet.payload.scalar_copy.dest_addr =
                 location.r5_base_addr + offsets.at(port.name);
             image.nodes.push_back(packet);
@@ -3297,8 +3414,7 @@ class FpgaDevicePlan : public IBackendExecutable {
             const BarrierRef readDone =
                 domain.define(kernel.id + ".sread." + port.name);
             rp1_node_t packet{};
-            packet.opcode = RP1_OP_SCALAR_READ;
-            packet.status = RP1_NODE_PENDING;
+            initializeNode(packet, RP1_OP_SCALAR_READ);
             packet.barrier_await_bucket = lastDone.bucket;
             packet.barrier_await_mask = lastDone.mask;
             packet.barrier_set_bucket = readDone.bucket;
@@ -3307,7 +3423,8 @@ class FpgaDevicePlan : public IBackendExecutable {
                 location.r5_base_addr +
                 device_->outputScalarRegOffset(
                     kernel.kernel, port.name);
-            packet.payload.scalar_read.target_slot = slot;
+            packet.payload.scalar_read.target_slot =
+                checkedSignalSlot(slot, "SCALAR_READ");
             image.nodes.push_back(packet);
             if (!localKey.empty()) scalarSlots_[localKey] = slot;
             lastDone = readDone;
@@ -3346,15 +3463,16 @@ class FpgaDevicePlan : public IBackendExecutable {
             domain.awaitFor(domain.refsFor(signal.dependsOn));
         const BarrierRef done = domain.define(signal.id);
         rp1_node_t packet{};
-        packet.opcode = RP1_OP_SIGNAL;
-        packet.status = RP1_NODE_PENDING;
+        initializeNode(packet, RP1_OP_SIGNAL);
         packet.barrier_await_bucket = await.bucket;
         packet.barrier_await_mask = await.mask;
         packet.barrier_set_bucket = done.bucket;
         packet.barrier_set_mask = done.mask;
-        packet.payload.signal.target_slot = signal.slot;
+        packet.payload.signal.target_slot =
+            checkedSignalSlot(signal.slot, "SIGNAL");
         packet.payload.signal.value = signal.value;
-        packet.payload.signal.operation = signal.operation;
+        packet.payload.signal.operation =
+            checkedSignalOperation(signal.operation);
         image.nodes.push_back(packet);
     }
 
@@ -3365,15 +3483,16 @@ class FpgaDevicePlan : public IBackendExecutable {
             domain.awaitFor(domain.refsFor(wait.dependsOn));
         const BarrierRef done = domain.define(wait.id);
         rp1_node_t packet{};
-        packet.opcode = RP1_OP_WAIT;
-        packet.status = RP1_NODE_PENDING;
+        initializeNode(packet, RP1_OP_WAIT);
         packet.barrier_await_bucket = await.bucket;
         packet.barrier_await_mask = await.mask;
         packet.barrier_set_bucket = done.bucket;
         packet.barrier_set_mask = done.mask;
-        packet.payload.wait.condition_signal = wait.slot;
+        packet.payload.wait.condition_signal =
+            checkedSignalSlot(wait.slot, "WAIT");
         packet.payload.wait.condition_value = wait.value;
-        packet.payload.wait.condition_op = wait.conditionOp;
+        packet.payload.wait.condition_op =
+            checkedConditionOperation(wait.conditionOp);
         image.nodes.push_back(packet);
     }
 
@@ -3392,44 +3511,44 @@ class FpgaDevicePlan : public IBackendExecutable {
 
         const std::uint32_t waited = allocMainBit();
         rp1_node_t wait{};
-        wait.opcode = RP1_OP_WAIT;
-        wait.status = RP1_NODE_PENDING;
+        initializeNode(wait, RP1_OP_WAIT);
         wait.barrier_await_bucket = 0;
         wait.barrier_await_mask = loopAwait;
         wait.barrier_set_bucket = 0;
         wait.barrier_set_mask = waited;
         wait.payload.wait.condition_signal =
-            loop.broadcastReadySlot;
-        wait.payload.wait.condition_op = RP1_COP_AND_NZ;
+            checkedSignalSlot(loop.broadcastReadySlot, "WAIT");
+        wait.payload.wait.condition_op =
+            checkedConditionOperation(RP1_COP_AND_NZ);
         wait.payload.wait.condition_value = 1;
         image.nodes.push_back(wait);
 
         const std::uint32_t cleared = allocMainBit();
         rp1_node_t clear{};
-        clear.opcode = RP1_OP_SIGNAL;
-        clear.status = RP1_NODE_PENDING;
+        initializeNode(clear, RP1_OP_SIGNAL);
         clear.barrier_await_bucket = 0;
         clear.barrier_await_mask = waited;
         clear.barrier_set_bucket = 0;
         clear.barrier_set_mask = cleared;
         clear.payload.signal.target_slot =
-            loop.broadcastReadySlot;
+            checkedSignalSlot(loop.broadcastReadySlot, "SIGNAL");
         clear.payload.signal.value = 0;
-        clear.payload.signal.operation = RP1_SIGOP_SET;
+        clear.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(clear);
 
         const std::uint32_t acknowledged = allocMainBit();
         rp1_node_t acknowledge{};
-        acknowledge.opcode = RP1_OP_SIGNAL;
-        acknowledge.status = RP1_NODE_PENDING;
+        initializeNode(acknowledge, RP1_OP_SIGNAL);
         acknowledge.barrier_await_bucket = 0;
         acknowledge.barrier_await_mask = cleared;
         acknowledge.barrier_set_bucket = 0;
         acknowledge.barrier_set_mask = acknowledged;
         acknowledge.payload.signal.target_slot =
-            loop.broadcastAckSlot;
+            checkedSignalSlot(loop.broadcastAckSlot, "SIGNAL");
         acknowledge.payload.signal.value = 1;
-        acknowledge.payload.signal.operation = RP1_SIGOP_SET;
+        acknowledge.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(acknowledge);
         return acknowledged;
     }
@@ -3448,46 +3567,46 @@ class FpgaDevicePlan : public IBackendExecutable {
         const BarrierRef waited =
             domain.define(loop.id + ".broadcast_wait");
         rp1_node_t wait{};
-        wait.opcode = RP1_OP_WAIT;
-        wait.status = RP1_NODE_PENDING;
+        initializeNode(wait, RP1_OP_WAIT);
         wait.barrier_await_bucket = bodyLeaves.bucket;
         wait.barrier_await_mask = bodyLeaves.mask;
         wait.barrier_set_bucket = waited.bucket;
         wait.barrier_set_mask = waited.mask;
         wait.payload.wait.condition_signal =
-            loop.broadcastReadySlot;
-        wait.payload.wait.condition_op = RP1_COP_AND_NZ;
+            checkedSignalSlot(loop.broadcastReadySlot, "WAIT");
+        wait.payload.wait.condition_op =
+            checkedConditionOperation(RP1_COP_AND_NZ);
         wait.payload.wait.condition_value = 1;
         image.nodes.push_back(wait);
 
         const BarrierRef cleared =
             domain.define(loop.id + ".broadcast_clear");
         rp1_node_t clear{};
-        clear.opcode = RP1_OP_SIGNAL;
-        clear.status = RP1_NODE_PENDING;
+        initializeNode(clear, RP1_OP_SIGNAL);
         clear.barrier_await_bucket = waited.bucket;
         clear.barrier_await_mask = waited.mask;
         clear.barrier_set_bucket = cleared.bucket;
         clear.barrier_set_mask = cleared.mask;
         clear.payload.signal.target_slot =
-            loop.broadcastReadySlot;
+            checkedSignalSlot(loop.broadcastReadySlot, "SIGNAL");
         clear.payload.signal.value = 0;
-        clear.payload.signal.operation = RP1_SIGOP_SET;
+        clear.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(clear);
 
         const BarrierRef acknowledged =
             domain.define(loop.id + ".broadcast_ack");
         rp1_node_t acknowledge{};
-        acknowledge.opcode = RP1_OP_SIGNAL;
-        acknowledge.status = RP1_NODE_PENDING;
+        initializeNode(acknowledge, RP1_OP_SIGNAL);
         acknowledge.barrier_await_bucket = cleared.bucket;
         acknowledge.barrier_await_mask = cleared.mask;
         acknowledge.barrier_set_bucket = acknowledged.bucket;
         acknowledge.barrier_set_mask = acknowledged.mask;
         acknowledge.payload.signal.target_slot =
-            loop.broadcastAckSlot;
+            checkedSignalSlot(loop.broadcastAckSlot, "SIGNAL");
         acknowledge.payload.signal.value = 1;
-        acknowledge.payload.signal.operation = RP1_SIGOP_SET;
+        acknowledge.payload.signal.operation =
+            checkedSignalOperation(RP1_SIGOP_SET);
         image.nodes.push_back(acknowledge);
         return acknowledged;
     }
@@ -3504,18 +3623,20 @@ class FpgaDevicePlan : public IBackendExecutable {
         fpga::LoopIdAllocator& loopIds) {
         auto& payload = image.nodes[loopIndex].payload.loop;
         payload.body_start =
-            static_cast<std::uint32_t>(loopIndex + 1);
+            checkedNodeIndex(loopIndex + 1, "LOOP body start");
         payload.body_end =
-            static_cast<std::uint32_t>(rerunIndex);
+            checkedNodeIndex(rerunIndex, "LOOP body end");
         if (loop.broadcastRole == Rp1SplitRole::Follower) {
             // RP1 uses zero for predicate-governed duration. The authority's
             // broadcast is the only termination source; a local cap would let
             // the follower leave the shared handshake prematurely.
             payload.max_iterations = 0;
             payload.condition_signal =
-                loop.conditionBroadcastSlot;
+                checkedSignalSlot(
+                    loop.conditionBroadcastSlot, "LOOP");
             payload.condition_value = 1;
-            payload.condition_op = RP1_COP_AND_NZ;
+            payload.condition_op =
+                checkedConditionOperation(RP1_COP_AND_NZ);
         } else if (whileLoop) {
             const fpga::Rp1Compare condition =
                 fpga::mapRp1Condition(*loop.condition);
@@ -3528,15 +3649,18 @@ class FpgaDevicePlan : public IBackendExecutable {
                     "produced by the body");
             }
             payload.max_iterations = 0;
-            payload.condition_signal = slot->second;
+            payload.condition_signal =
+                checkedSignalSlot(slot->second, "LOOP");
             payload.condition_value = condition.value;
             payload.condition_op =
-                fpga::invertRp1Op(condition.op);
+                checkedConditionOperation(
+                    fpga::invertRp1Op(condition.op));
         } else {
             payload.max_iterations = 1;
             payload.condition_signal = 0;
             payload.condition_value = fpga::kNeverValue;
-            payload.condition_op = fpga::kNeverOp;
+            payload.condition_op =
+                checkedConditionOperation(fpga::kNeverOp);
         }
         payload.bucket_clear_start = domain.clearStart();
         payload.bucket_clear_end = domain.clearEnd();
@@ -3594,8 +3718,7 @@ class FpgaDevicePlan : public IBackendExecutable {
 
         // LOOP packet (body_start/end backpatched after the body is emitted).
         rp1_node_t loopPkt{};
-        loopPkt.opcode               = RP1_OP_LOOP;
-        loopPkt.status               = RP1_NODE_PENDING;
+        initializeNode(loopPkt, RP1_OP_LOOP);
         loopPkt.barrier_await_bucket = 0;
         loopPkt.barrier_await_mask   = initialLoopAwait;
         loopPkt.barrier_set_bucket   = 0;
@@ -3603,8 +3726,7 @@ class FpgaDevicePlan : public IBackendExecutable {
         const std::size_t loopIdx = image.nodes.size();
         image.nodes.push_back(loopPkt);
         rp1_node_t gate{};
-        gate.opcode = RP1_OP_COND;
-        gate.status = RP1_NODE_PENDING;
+        initializeNode(gate, RP1_OP_COND);
         gate.barrier_set_bucket = 0;
         gate.barrier_set_mask = 0;
         gate.payload.cond.body_start = 1;
@@ -3696,13 +3818,13 @@ class FpgaDevicePlan : public IBackendExecutable {
 
         const BarrierRef rerunBit = bodyDomain.define(loop.id + ".rerun");
         rp1_node_t rerun{};
-        rerun.opcode               = RP1_OP_RERUN;
-        rerun.status               = RP1_NODE_PENDING;
+        initializeNode(rerun, RP1_OP_RERUN);
         rerun.barrier_await_bucket = bodyLeaves.bucket;
         rerun.barrier_await_mask   = bodyLeaves.mask;
         rerun.barrier_set_bucket   = rerunBit.bucket;
         rerun.barrier_set_mask     = rerunBit.mask;
-        rerun.payload.rerun.target_node = static_cast<std::uint32_t>(loopIdx);
+        rerun.payload.rerun.target_node =
+            checkedNodeIndex(loopIdx, "RERUN target");
         const std::size_t rerunIdx = image.nodes.size();
         image.nodes.push_back(rerun);
 
@@ -3722,9 +3844,10 @@ class FpgaDevicePlan : public IBackendExecutable {
         gatePayload.condition_value =
             loopPayload.condition_value;
         gatePayload.condition_op =
-            fpga::invertRp1Op(
-                static_cast<rp1_condop_t>(
-                    loopPayload.condition_op));
+            checkedConditionOperation(
+                fpga::invertRp1Op(
+                    static_cast<rp1_condop_t>(
+                        loopPayload.condition_op)));
         mainBit[loop.id] = exitBit;
     }
 
@@ -3794,15 +3917,16 @@ class FpgaDevicePlan : public IBackendExecutable {
             }
 
             rp1_node_t cnode{};
-            cnode.opcode               = RP1_OP_COND;
-            cnode.status               = RP1_NODE_PENDING;
+            initializeNode(cnode, RP1_OP_COND);
             cnode.barrier_await_bucket = 0;
             cnode.barrier_await_mask   = condAwait;
             cnode.barrier_set_bucket   = 0;
             cnode.barrier_set_mask     = 0;
-            cnode.payload.cond.condition_signal   = condSlot;
+            cnode.payload.cond.condition_signal   =
+                checkedSignalSlot(condSlot, "COND");
             cnode.payload.cond.condition_value    = c.value;
-            cnode.payload.cond.condition_op       = op;
+            cnode.payload.cond.condition_op       =
+                checkedConditionOperation(op);
             cnode.payload.cond.body_start         = 1;  // empty range (start > end):
             cnode.payload.cond.body_end           = 0;  // COND is a pure boolean
             cnode.payload.cond.bucket_clear_start = 1;
@@ -3873,8 +3997,7 @@ class FpgaDevicePlan : public IBackendExecutable {
              */
             const BarrierRef leaves = branchDomain.mutableLeafAwait();
             rp1_node_t join{};
-            join.opcode               = RP1_OP_NOP;
-            join.status               = RP1_NODE_PENDING;
+            initializeNode(join, RP1_OP_NOP);
             join.barrier_await_bucket = leaves.bucket;
             join.barrier_await_mask   = leaves.mask;
             join.barrier_set_bucket   = 0;
@@ -3899,7 +4022,6 @@ class FpgaDevicePlan : public IBackendExecutable {
     std::vector<DeferredScalar>                                deferred_;
     std::vector<DeferredLoopTripCount>                         deferredTripCounts_;
     std::vector<DeferredPdi>                                   deferredPdis_;
-    std::map<std::size_t, std::string>                         pdiImagesByNode_;
     std::vector<DeferredBufferAddress>                         deferredBufferAddresses_;
     std::vector<DeferredBufferAlias>                           deferredBufferAliases_;
     std::shared_ptr<BackendRuntimeState>                       runtimeState_;
@@ -3909,7 +4031,6 @@ class FpgaDevicePlan : public IBackendExecutable {
     std::chrono::milliseconds                                  timeout_;
     std::thread                                                worker_;
     std::exception_ptr                                         workerEx_;
-    std::vector<rp1_cq_entry_t>                                lastCq_;
     bool                                                       signalsPrepared_ = false;
     std::map<std::string, BackendScalarId>                      boundScalarSlots_;
     std::set<std::uint32_t>                                     ownedSignalSlots_;
@@ -3944,8 +4065,7 @@ class FpgaDevicePlan : public IBackendExecutable {
  */
 FpgaDevice::FpgaDevice(std::string                       id,
                         std::shared_ptr<fpga::Rp1BarWindow> window,
-                        FpgaKernelLocationLookup           lookup,
-                        std::uint32_t                      cq_size)
+                        FpgaKernelLocationLookup           lookup)
     : id_(std::move(id)),
       window_(std::move(window)),
       lookup_(std::move(lookup)),
@@ -3957,7 +4077,7 @@ FpgaDevice::FpgaDevice(std::string                       id,
         throw std::invalid_argument("FpgaDevice: kernel-location lookup must not be null");
     }
     scalarSlotAlloc_.reserve(sentinelSlot_);
-    submitter_ = std::make_shared<fpga::Rp1Submitter>(*window_, cq_size);
+    submitter_ = std::make_shared<fpga::Rp1Submitter>(*window_);
 }
 
 /*
@@ -3968,8 +4088,7 @@ FpgaDevice::FpgaDevice(std::string                       id,
 FpgaDevice::FpgaDevice(std::string                       id,
                        std::shared_ptr<fpga::Rp1BarWindow> window,
                        std::shared_ptr<fpga::FpgaVbinSpec> vbinSpec,
-                       std::string                       initialImageId,
-                       std::uint32_t                     cq_size)
+                       std::string                       initialImageId)
     : id_(std::move(id)),
       window_(std::move(window)),
       vbinSpec_(std::move(vbinSpec)),
@@ -3990,7 +4109,7 @@ FpgaDevice::FpgaDevice(std::string                       id,
             "FpgaDevice: initial image '" + activeImageId_ + "' is not in the vbin spec");
     }
     scalarSlotAlloc_.reserve(sentinelSlot_);
-    submitter_ = std::make_shared<fpga::Rp1Submitter>(*window_, cq_size);
+    submitter_ = std::make_shared<fpga::Rp1Submitter>(*window_);
 }
 
 FpgaDevice::~FpgaDevice() = default;
@@ -4000,14 +4119,14 @@ void FpgaDevice::requireExecutionUsable(
     if (executionPoisoned()) {
         throw std::runtime_error(
             std::string(method) +
-            ": device is poisoned after an indeterminate RP1 timeout; "
+            ": device is poisoned after an unsafe RP1 terminal result; "
             "reset/recover the device and create a new FpgaDevice");
     }
 }
 
 /*
- * Poison once and retain the entire device through process exit.  An
- * indeterminate timeout means RP1 may still dereference device-owned buffers;
+ * Poison once and retain the entire device through process exit. An unsafe
+ * terminal result means RP1 may still dereference device-owned buffers;
  * failure to establish quarantine is therefore fatal, not recoverable cleanup.
  */
 void FpgaDevice::poisonExecution() noexcept {

--- a/vrt/tests/fpga_device_test.cpp
+++ b/vrt/tests/fpga_device_test.cpp
@@ -30,7 +30,7 @@
  *
  *  - The sentinel slot gets the expected magic written once the graph
  *    finishes (the trailing-SIGNAL completion contract).
- *  - The CQ contains one entry per kernel + the sentinel signal node.
+ *  - One committed graph result describes terminal and image state.
  *  - Barrier masks and arg packing are correct for the diamond DAG.
  *  - Non-kernel Rp1Command variants (e.g. CompiledBridgeOpNode that
  *    the compiler splices for cross-device buffers) cause compileProgram
@@ -45,8 +45,10 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <future>
 #include <memory>
 #include <optional>
 #include <set>
@@ -107,8 +109,6 @@ struct DdrView {
     rp1_ctrl_t&        ctrl()      { return *reinterpret_cast<rp1_ctrl_t*>(base + kWindowOff); }
     rp1_node_t*        nodes()     { return reinterpret_cast<rp1_node_t*>(
                                          base + kWindowOff + RP1_DEFAULT_NODE_ARRAY_OFFSET); }
-    rp1_cq_entry_t*    cq()        { return reinterpret_cast<rp1_cq_entry_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_CQ_OFFSET); }
     std::uint32_t*     args()      { return reinterpret_cast<std::uint32_t*>(
                                          base + kWindowOff + RP1_DEFAULT_ARG_BUF_OFFSET); }
     rp1_signal_slot_t* signals()   { return reinterpret_cast<rp1_signal_slot_t*>(
@@ -129,7 +129,7 @@ struct DdrView {
 const rp1_node_t* findDispatch(DdrView ddr, std::uint32_t r5Address) {
     for (std::uint32_t i = 0; i < ddr.ctrl().node_count; ++i) {
         const rp1_node_t& node = ddr.nodes()[i];
-        if (node.opcode == RP1_OP_KERNEL_DISPATCH &&
+        if (rp1_node_get_opcode(&node) == RP1_OP_KERNEL_DISPATCH &&
             node.payload.kernel_dispatch.kernel_base_addr == r5Address) {
             return &node;
         }
@@ -137,25 +137,88 @@ const rp1_node_t* findDispatch(DdrView ddr, std::uint32_t r5Address) {
     return nullptr;
 }
 
+/**
+ * @brief Publish one committed terminal result in protocol-v6 order.
+ *
+ * The fake writes payload, commit magic, terminal state, then graph_done_seq.
+ * This mirrors the release contract consumed by Rp1Submitter.
+ */
+void publishFakeGraphResult(
+    DdrView ddr, std::uint32_t sequence, std::uint32_t outcome,
+    std::uint32_t errorCode, std::uint32_t terminalNode,
+    std::uint32_t terminalOpcode, std::uint32_t completedOperations,
+    std::uint32_t activeImageId, std::uint32_t imageState,
+    std::uint32_t extraFlags = 0u) {
+    rp1_ctrl_t& ctrl = ddr.ctrl();
+    rp1_graph_result_t& result = ctrl.result;
+    result.magic = 0u;
+    result.graph_seq = sequence;
+    result.outcome = outcome;
+    result.flags = extraFlags |
+        (outcome == RP1_GRAPH_RESULT_SUCCESS
+             ? 0u
+             : RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+                   RP1_RESULT_UNREACHED_NODES);
+    result.error_code = errorCode;
+    result.terminal_node = terminalNode;
+    result.terminal_opcode = terminalOpcode;
+    result.error_detail = errorCode;
+    result.error_aux = 0u;
+    result.active_image_id = activeImageId;
+    result.image_state = imageState;
+    result.completed_operations = completedOperations;
+    result.graph_elapsed_ticks = 100u;
+    result.publish_elapsed_ticks = 120u;
+    result.trace_write_idx = ctrl.trace_write_idx;
+    result.quiescence = 0u;
+    ctrl.rp1_error_code = errorCode;
+    ctrl.terminal_error_node = terminalNode;
+    ctrl.terminal_error_detail = errorCode;
+    ctrl.terminal_error_aux = 0u;
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    result.magic = RP1_GRAPH_RESULT_MAGIC;
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    ctrl.rp1_state =
+        outcome == RP1_GRAPH_RESULT_FAILED
+            ? RP1_STATE_ERROR
+            : outcome == RP1_GRAPH_RESULT_HALTED
+                  ? RP1_STATE_HALTED
+                  : RP1_STATE_READY;
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    ctrl.graph_done_seq = sequence;
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+
+/**
+ * @brief Minimal fail-fast RP1 model for FpgaDevicePlan lifecycle tests.
+ *
+ * The optional failure callback selects one fatal node. Successful PDI_LOAD
+ * operations update persistent image state, while a failed PDI_LOAD publishes
+ * UNKNOWN so host-side reconciliation can be tested after terminal failure.
+ */
 class FakeRp1 {
    public:
-    using CompletionFn = std::function<
-        std::optional<std::pair<std::uint32_t, std::uint32_t>>(
+    /// Return a fatal @c RP1_ERR_* code for a selected node, or no failure.
+    using FailureFn = std::function<
+        std::optional<std::uint32_t>(
             std::uint32_t, const rp1_node_t&)>;
 
+    /// Start a publisher that may fail one node selected by @p failure.
     explicit FakeRp1(
         DdrView ddr, bool writeSignals = true,
-        CompletionFn completion = {})
+        FailureFn failure = {}, std::uint32_t resultFlags = 0u)
         : ddr_(ddr), writeSignals_(writeSignals),
-          completion_(std::move(completion)) {
+          failure_(std::move(failure)), resultFlags_(resultFlags) {
         thread_ = std::thread([this] { run(); });
     }
+    /// Stop the worker before the caller releases its backing mapping.
     ~FakeRp1() {
         stop_.store(true, std::memory_order_relaxed);
         if (thread_.joinable()) thread_.join();
     }
 
    private:
+    /// Evaluate one protocol condition against a shared signal value.
     static bool conditionSatisfied(
         std::uint32_t signal, std::uint16_t operation,
         std::uint32_t value) {
@@ -172,32 +235,43 @@ class FakeRp1 {
         return false;
     }
 
+    /// Watch graph_seq and publish one terminal result per accepted graph.
     void run() {
         while (!stop_.load(std::memory_order_relaxed)) {
             auto& c = ddr_.ctrl();
             if (c.graph_seq != c.graph_done_seq) {
+                const std::uint32_t sequence = c.graph_seq;
                 c.rp1_state = RP1_STATE_RUNNING;
+                terminalNode_ = RP1_TERMINAL_ERROR_NODE_NONE;
+                terminalOpcode_ = RP1_TERMINAL_OPCODE_NONE;
+                terminalCode_ = 0u;
+                completedOperations_ = 0u;
                 const bool failed = processGraph();
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                c.rp1_state =
-                    failed ? RP1_STATE_ERROR
-                           : RP1_STATE_READY;
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                c.graph_done_seq = c.graph_seq;
-                std::atomic_thread_fence(std::memory_order_seq_cst);
+                publishFakeGraphResult(
+                    ddr_, sequence,
+                    failed ? RP1_GRAPH_RESULT_FAILED
+                           : RP1_GRAPH_RESULT_SUCCESS,
+                    terminalCode_, terminalNode_, terminalOpcode_,
+                    completedOperations_, activeImageId_,
+                    activeImageState_,
+                    resultFlags_ |
+                        (terminalCode_ == RP1_ERR_PDI_TIMEOUT
+                             ? RP1_RESULT_RECOVERY_REQUIRED
+                             : 0u));
             }
             c.heartbeat = c.heartbeat + 1;
             std::this_thread::sleep_for(std::chrono::microseconds(200));
         }
     }
 
+    /// Execute immediate node effects and stop at the first selected failure.
     bool processGraph() {
         auto& c = ddr_.ctrl();
-        const std::uint32_t count   = c.node_count;
-        const std::uint32_t cq_size = c.cq_size;
+        const std::uint32_t count = c.node_count;
         for (std::uint32_t i = 0; i < count; ++i) {
-            rp1_node_t& n = ddr_.nodes()[i];
-            if (n.opcode == RP1_OP_WAIT) {
+            const rp1_node_t& n = ddr_.nodes()[i];
+            const std::uint16_t opcode = rp1_node_get_opcode(&n);
+            if (opcode == RP1_OP_WAIT) {
                 const auto deadline =
                     std::chrono::steady_clock::now() +
                     std::chrono::seconds(2);
@@ -207,14 +281,16 @@ class FakeRp1 {
                     wait.condition_op, wait.condition_value)) {
                     if (std::chrono::steady_clock::now() >
                         deadline) {
-                        c.rp1_error_code = RP1_ERR_KERNEL_TIMEOUT;
+                        terminalCode_ = RP1_ERR_KERNEL_TIMEOUT;
+                        terminalNode_ = i;
+                        terminalOpcode_ = opcode;
                         return true;
                     }
                     std::this_thread::sleep_for(
                         std::chrono::microseconds(50));
                 }
             }
-            if (n.opcode == RP1_OP_KERNEL_DISPATCH) {
+            if (opcode == RP1_OP_KERNEL_DISPATCH) {
                 const auto& kd = n.payload.kernel_dispatch;
                 if (kd.arg_count >= 5) {
                     // Protocol v2: the argument buffer is an array of
@@ -239,54 +315,58 @@ class FakeRp1 {
                     }
                 }
             }
-            if (n.opcode == RP1_OP_SIGNAL && writeSignals_) {
+            const std::optional<std::uint32_t> failure =
+                failure_ ? failure_(i, n) : std::nullopt;
+            if (failure) {
+                terminalCode_ = *failure;
+                terminalNode_ = i;
+                terminalOpcode_ = opcode;
+                if (opcode == RP1_OP_PDI_LOAD) {
+                    activeImageId_ = 0u;
+                    activeImageState_ = RP1_IMAGE_STATE_UNKNOWN;
+                }
+                return true;
+            }
+            if (opcode == RP1_OP_PDI_LOAD) {
+                activeImageId_ = n.payload.pdi_load.image_id;
+                activeImageState_ =
+                    activeImageId_ == 0u
+                        ? RP1_IMAGE_STATE_NONE
+                        : RP1_IMAGE_STATE_KNOWN;
+            }
+            if (opcode == RP1_OP_SIGNAL && writeSignals_) {
                 const auto& pl = n.payload.signal;
                 ddr_.signals()[pl.target_slot].value = pl.value;
                 ddr_.signals()[pl.target_slot].last_writer_node = i;
             }
-            const auto completion =
-                completion_
-                    ? completion_(i, n)
-                    : std::optional<std::pair<
-                          std::uint32_t, std::uint32_t>>(
-                          std::make_pair(
-                              static_cast<std::uint32_t>(
-                                  RP1_CQ_OK),
-                              0u));
-            if ((n.flags & RP1_FLAG_SILENT) == 0u &&
-                completion) {
-                while (!stop_.load(std::memory_order_relaxed) &&
-                       c.cq_write_idx - c.cq_read_idx == cq_size) {
-                    std::this_thread::sleep_for(
-                        std::chrono::microseconds(50));
-                }
-                if (stop_.load(std::memory_order_relaxed))
-                    return true;
-                const std::uint32_t idx = c.cq_write_idx & (cq_size - 1u);
-                rp1_cq_entry_t& e = ddr_.cq()[idx];
-                e.node_index   = i;
-                e.status       = completion->first;
-                e.error_detail = completion->second;
-                e.timestamp    = 0;
-                ++c.cq_write_idx;
-            }
-            n.status = RP1_NODE_DONE;
-            if (completion &&
-                completion->first != RP1_CQ_OK) {
-                c.rp1_error_code = completion->second;
-                c.terminal_error_node = i;
-                c.terminal_error_detail = completion->second;
-                c.terminal_error_aux = 0u;
-                return true;
-            }
+            ++completedOperations_;
         }
         return false;
     }
 
+    /// Shared fake-DDR view; non-owning.
     DdrView           ddr_;
+    /// Whether SIGNAL operations update the shared array.
     bool              writeSignals_;
-    CompletionFn      completion_;
+    /// Optional fatal-node selector.
+    FailureFn         failure_;
+    /// Extra terminal flags published for every fake result.
+    std::uint32_t     resultFlags_ = 0u;
+    /// Cooperative worker-stop flag.
     std::atomic<bool> stop_{false};
+    /// Persistent numeric image id known by the fake firmware.
+    std::uint32_t     activeImageId_ = 0u;
+    /// Persistent @c RP1_IMAGE_STATE_* classification.
+    std::uint32_t     activeImageState_ = RP1_IMAGE_STATE_NONE;
+    /// First terminal @c RP1_ERR_* code for the current graph.
+    std::uint32_t     terminalCode_ = 0u;
+    /// First terminal node for the current graph.
+    std::uint32_t     terminalNode_ = RP1_TERMINAL_ERROR_NODE_NONE;
+    /// Opcode at @c terminalNode_.
+    std::uint32_t     terminalOpcode_ = RP1_TERMINAL_OPCODE_NONE;
+    /// Successful operation executions before terminal publication.
+    std::uint32_t     completedOperations_ = 0u;
+    /// Background firmware-emulation thread.
     std::thread       thread_;
 };
 
@@ -319,7 +399,22 @@ class FaithfulRp1 {
         return it == dispatchCount_.end() ? 0u : it->second;
     }
 
+    /// Return the number of node arrays snapshotted at graph acceptance.
+    std::uint32_t acceptedGraphs() const noexcept {
+        return acceptedGraphs_.load(std::memory_order_acquire);
+    }
+
    private:
+    /**
+     * @brief Terminal facts derived from one snapshotted scanner execution.
+     */
+    struct ExecutionSummary {
+        /// Successful operation executions, including repeated nodes.
+        std::uint32_t completedOperations = 0u;
+        /// Result flags derived from final local node status.
+        std::uint32_t flags = 0u;
+    };
+
     static bool cmp(std::uint32_t sig, std::uint16_t op, std::uint32_t val) {
         switch (op) {
             case RP1_COP_EQ:     return sig == val;
@@ -336,31 +431,38 @@ class FaithfulRp1 {
         while (!stop_.load(std::memory_order_relaxed)) {
             auto& c = ddr_.ctrl();
             if (c.graph_seq != c.graph_done_seq) {
+                const std::uint32_t sequence = c.graph_seq;
                 c.rp1_state = RP1_STATE_RUNNING;
-                processGraph();
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                c.rp1_state      = RP1_STATE_READY;
-                c.graph_done_seq = c.graph_seq;
-                std::atomic_thread_fence(std::memory_order_seq_cst);
+                const ExecutionSummary summary = processGraph();
+                publishFakeGraphResult(
+                    ddr_, sequence, RP1_GRAPH_RESULT_SUCCESS,
+                    0u, RP1_TERMINAL_ERROR_NODE_NONE,
+                    RP1_TERMINAL_OPCODE_NONE, summary.completedOperations,
+                    activeImageId_, activeImageState_, summary.flags);
             }
             c.heartbeat = c.heartbeat + 1;
             std::this_thread::sleep_for(std::chrono::microseconds(100));
         }
     }
 
-    void processGraph() {
+    ExecutionSummary processGraph() {
         auto& c = ddr_.ctrl();
         const std::uint32_t count = c.node_count;
-        rp1_node_t* nodes = ddr_.nodes();
+        std::vector<rp1_node_t> acceptedNodes(
+            ddr_.nodes(), ddr_.nodes() + count);
+        rp1_node_t* nodes = acceptedNodes.data();
         rp1_signal_slot_t* sigs = signals_;
+        acceptedGraphs_.fetch_add(1u, std::memory_order_release);
 
         std::vector<std::uint8_t> status(count, RP1_NODE_PENDING);
         std::vector<std::uint32_t> barriers(RP1_MAX_BUCKETS, 0);
         std::vector<std::uint32_t> loopIters(RP1_MAX_LOOPS, 0);
+        ExecutionSummary summary;
 
         auto setDone = [&](std::uint32_t i) {
             status[i] = RP1_NODE_DONE;
             barriers[nodes[i].barrier_set_bucket] |= nodes[i].barrier_set_mask;
+            ++summary.completedOperations;
         };
 
         for (std::uint64_t guard = 0; guard < 10'000'000ull; ++guard) {
@@ -372,7 +474,7 @@ class FaithfulRp1 {
                     n.barrier_await_mask) {
                     continue;
                 }
-                switch (n.opcode) {
+                switch (rp1_node_get_opcode(&n)) {
                     case RP1_OP_KERNEL_DISPATCH: {
                         std::lock_guard<std::mutex> lk(mtx_);
                         dispatchCount_[n.payload.kernel_dispatch.kernel_base_addr]++;
@@ -445,6 +547,7 @@ class FaithfulRp1 {
                             for (std::uint32_t nn = lp.body_start; nn <= lp.body_end; ++nn)
                                 status[nn] = RP1_NODE_PENDING;
                             status[i] = RP1_NODE_DONE;  // no barrier on continue
+                            ++summary.completedOperations;
                         }
                         progress = true;
                         break;
@@ -471,7 +574,16 @@ class FaithfulRp1 {
                         progress = true;
                         break;
                     }
-                    default:  // NOP / PDI_LOAD / SCALAR_* -> immediate
+                    case RP1_OP_PDI_LOAD:
+                        activeImageId_ = n.payload.pdi_load.image_id;
+                        activeImageState_ =
+                            activeImageId_ == 0u
+                                ? RP1_IMAGE_STATE_NONE
+                                : RP1_IMAGE_STATE_KNOWN;
+                        setDone(i);
+                        progress = true;
+                        break;
+                    default:  // NOP / SCALAR_* -> immediate
                         setDone(i);
                         progress = true;
                         break;
@@ -496,6 +608,15 @@ class FaithfulRp1 {
                 std::this_thread::sleep_for(std::chrono::microseconds(50));
             }
         }
+        for (std::uint8_t finalStatus : status) {
+            if (finalStatus == RP1_NODE_PENDING ||
+                finalStatus == RP1_NODE_DISPATCHED ||
+                finalStatus == RP1_NODE_WAITING) {
+                summary.flags |= RP1_RESULT_UNREACHED_NODES;
+                break;
+            }
+        }
+        return summary;
     }
 
     DdrView                                ddr_;
@@ -505,6 +626,13 @@ class FaithfulRp1 {
     std::mutex                             mtx_;
     std::map<std::uint32_t, std::uint32_t> dispatchCount_;
     std::map<std::uint32_t, std::uint32_t> scalarReadCount_;
+    /// Accepted snapshots published for deterministic mutation tests.
+    std::atomic<std::uint32_t>              acceptedGraphs_{0u};
+    /// Persistent numeric image id after successful PDI_LOAD operations.
+    std::uint32_t                          activeImageId_ = 0u;
+    /// Persistent @c RP1_IMAGE_STATE_* classification.
+    std::uint32_t                          activeImageState_ =
+        RP1_IMAGE_STATE_NONE;
 
    public:
     std::uint32_t scalarCopyTo(std::uint32_t addr) {
@@ -522,8 +650,11 @@ void primeAsReady(DdrView ddr) {
     c.version      = RP1_PROTOCOL_VERSION;
     c.capabilities = RP1_REQUIRED_CAPABILITIES;
     c.pdi_ipi_platform_id = 0x51454D55u;
+    c.graph_seq     = 0u;
+    c.graph_done_seq = 0u;
     c.rp1_state    = RP1_STATE_READY;
     c.heartbeat    = 1;
+    c.result.magic = 0u;
     c.magic        = RP1_CTRL_MAGIC;
 }
 
@@ -596,6 +727,70 @@ class FpgaDeviceFixture : public ::testing::Test {
     std::shared_ptr<fpga::Rp1BarWindow> window_;
     std::unique_ptr<FakeRp1>            rp1_;
 };
+
+TEST(FaithfulRp1Test, SnapshotsAcceptedNodesAndDerivesUnreachedFlag) {
+    std::vector<std::byte> backing(kBarSize, std::byte{0});
+    DdrView ddr{backing.data()};
+    primeAsReady(ddr);
+    fpga::Rp1BarWindow window(
+        backing.data(), backing.size(), kWindowOff);
+    fpga::Rp1Submitter submitter(window);
+    FaithfulRp1 rp1(ddr);
+
+    fpga::Rp1GraphImage image;
+    image.nodes.resize(3u);
+    rp1_node_t& wait = image.nodes[0];
+    rp1_node_set_opcode(&wait, RP1_OP_WAIT);
+    rp1_node_set_status(&wait, RP1_NODE_PENDING);
+    wait.barrier_set_mask = 0x1u;
+    wait.payload.wait.condition_signal = 3u;
+    wait.payload.wait.condition_op = RP1_COP_EQ;
+    wait.payload.wait.condition_value = 1u;
+
+    rp1_node_t& signal = image.nodes[1];
+    rp1_node_set_opcode(&signal, RP1_OP_SIGNAL);
+    rp1_node_set_status(&signal, RP1_NODE_PENDING);
+    signal.barrier_await_mask = 0x1u;
+    signal.payload.signal.target_slot = 4u;
+    signal.payload.signal.operation = RP1_SIGOP_SET;
+    signal.payload.signal.value = 0x11112222u;
+
+    rp1_node_t& unreachable = image.nodes[2];
+    rp1_node_set_opcode(&unreachable, RP1_OP_NOP);
+    rp1_node_set_status(&unreachable, RP1_NODE_PENDING);
+    unreachable.barrier_await_mask = 0x2u;
+
+    auto resultFuture = std::async(std::launch::async, [&] {
+        return submitter.submitAndWait(
+            image, std::chrono::milliseconds(1000));
+    });
+    const auto acceptedDeadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (rp1.acceptedGraphs() == 0u &&
+           std::chrono::steady_clock::now() < acceptedDeadline) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    const bool accepted = rp1.acceptedGraphs() == 1u;
+
+    /*
+     * Mutation after the acceptance counter cannot race the fake's snapshot.
+     * Releasing the original WAIT then proves execution uses only that copy.
+     */
+    ddr.nodes()[1].payload.signal.target_slot = 5u;
+    ddr.nodes()[1].payload.signal.value = 0x33334444u;
+    ddr.signals()[3].value = 1u;
+
+    ASSERT_TRUE(accepted);
+    ASSERT_EQ(
+        resultFuture.wait_for(std::chrono::milliseconds(500)),
+        std::future_status::ready);
+    const auto result = resultFuture.get();
+    EXPECT_TRUE(result.succeeded());
+    EXPECT_TRUE(result.hasFlags(RP1_RESULT_UNREACHED_NODES));
+    EXPECT_EQ(result.completedOperations, 2u);
+    EXPECT_EQ(ddr.signals()[4].value, 0x11112222u);
+    EXPECT_EQ(ddr.signals()[5].value, 0u);
+}
 
 }  // namespace
 
@@ -672,6 +867,10 @@ TEST_F(FpgaDeviceFixture, BarBackedBufferArenaDoesNotOverlapTraceRing) {
     ddr_.traces()[0].node_index = 7u;
     ddr_.traces()[0].aux0 = 0x55667788u;
     ddr_.traces()[0].aux1 = 0x99aabbccu;
+    ddr_.traces()[RP1_MAX_TRACE_ENTRIES - 1u].timestamp =
+        0x22334455u;
+    ddr_.traces()[RP1_MAX_TRACE_ENTRIES - 1u].event =
+        RP1_TRACE_FLUSH_END;
 
     const std::uint8_t bytes[32] = {};
     dev.setInputBuffer("scratch", bytes, sizeof(bytes));
@@ -681,6 +880,12 @@ TEST_F(FpgaDeviceFixture, BarBackedBufferArenaDoesNotOverlapTraceRing) {
     EXPECT_EQ(ddr_.traces()[0].node_index, 7u);
     EXPECT_EQ(ddr_.traces()[0].aux0, 0x55667788u);
     EXPECT_EQ(ddr_.traces()[0].aux1, 0x99aabbccu);
+    EXPECT_EQ(
+        ddr_.traces()[RP1_MAX_TRACE_ENTRIES - 1u].timestamp,
+        0x22334455u);
+    EXPECT_EQ(
+        ddr_.traces()[RP1_MAX_TRACE_ENTRIES - 1u].event,
+        static_cast<std::uint16_t>(RP1_TRACE_FLUSH_END));
 }
 
 TEST_F(FpgaDeviceFixture, ImageNumericIdIsStableOneBasedAndZeroForUnguarded) {
@@ -705,7 +910,7 @@ TEST_F(FpgaDeviceFixture, ImageNumericIdIsStableOneBasedAndZeroForUnguarded) {
     EXPECT_EQ(dev.imageNumericId(""), 0u);
 }
 
-TEST_F(FpgaDeviceFixture, CqDiagnosticReportsRetainedCompletions) {
+TEST_F(FpgaDeviceFixture, GraphResultDiagnosticReportsTerminalSnapshot) {
     auto dev = std::make_shared<FpgaDevice>(
         "fpga:0", window_, makeDiamondLookup());
 
@@ -720,15 +925,15 @@ TEST_F(FpgaDeviceFixture, CqDiagnosticReportsRetainedCompletions) {
     auto plan = dev->compileProgram(program);
     ASSERT_NE(plan, nullptr);
 
-    ScopedEnv cqTrace("VRT_RP1_CQ", std::string("1"));
+    ScopedEnv resultTrace("VRT_RP1_RESULT", std::string("1"));
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(plan->launch());
     EXPECT_NO_THROW(plan->wait());
     const std::string diagnostics = testing::internal::GetCapturedStderr();
 
-    EXPECT_NE(diagnostics.find("[rp1-cq] entries="), std::string::npos);
+    EXPECT_NE(diagnostics.find("[rp1-result] seq=1"), std::string::npos);
     EXPECT_NE(
-        diagnostics.find("opcode=KERNEL_DISPATCH status=OK(0)"),
+        diagnostics.find("outcome=SUCCESS(1)"),
         std::string::npos);
 }
 
@@ -1029,7 +1234,7 @@ TEST_F(FpgaDeviceFixture, CpuWaitConsumesPerIterationFpgaPublication) {
     std::size_t consumedEvents = 0;
     for (std::uint32_t i = 0; i < ddr_.ctrl().node_count; ++i) {
         const rp1_node_t& node = ddr_.nodes()[i];
-        if (node.opcode != RP1_OP_SIGNAL ||
+        if (rp1_node_get_opcode(&node) != RP1_OP_SIGNAL ||
             node.payload.signal.value != 1u ||
             node.payload.signal.target_slot ==
                 kDefaultSentinelSlot) {
@@ -1272,11 +1477,11 @@ TEST_F(FpgaDeviceFixture, AutonomousLoopPublishesCarriedOutputToCpu) {
     const rp1_node_t* zeroLoop = std::find_if(
         ddr_.nodes(), ddr_.nodes() + ddr_.ctrl().node_count,
         [](const rp1_node_t& node) {
-            return node.opcode == RP1_OP_LOOP;
+            return rp1_node_get_opcode(&node) == RP1_OP_LOOP;
         });
     ASSERT_NE(zeroLoop, ddr_.nodes() + ddr_.ctrl().node_count);
     EXPECT_EQ(zeroLoop->payload.loop.condition_op, RP1_COP_AND_Z);
-    ASSERT_EQ((zeroLoop + 1)->opcode, RP1_OP_COND);
+    ASSERT_EQ(rp1_node_get_opcode(zeroLoop + 1), RP1_OP_COND);
     EXPECT_EQ(
         (zeroLoop + 1)->payload.cond.condition_op,
         RP1_COP_AND_NZ);
@@ -1293,7 +1498,7 @@ TEST_F(FpgaDeviceFixture, AutonomousLoopPublishesCarriedOutputToCpu) {
     }
     std::optional<std::uint32_t> loopIndex;
     for (std::uint32_t i = 0; i < ddr_.ctrl().node_count; ++i) {
-        if (ddr_.nodes()[i].opcode == RP1_OP_LOOP) {
+        if (rp1_node_get_opcode(&ddr_.nodes()[i]) == RP1_OP_LOOP) {
             loopIndex = i;
             break;
         }
@@ -1302,7 +1507,7 @@ TEST_F(FpgaDeviceFixture, AutonomousLoopPublishesCarriedOutputToCpu) {
     EXPECT_TRUE(std::any_of(
         ddr_.nodes(), ddr_.nodes() + ddr_.ctrl().node_count,
         [&](const rp1_node_t& node) {
-            return node.opcode == RP1_OP_RERUN &&
+            return rp1_node_get_opcode(&node) == RP1_OP_RERUN &&
                    node.payload.rerun.target_node == *loopIndex;
         }))
         << "RERUN must target the scheduled LOOP even when it is nonzero";
@@ -1455,7 +1660,7 @@ TEST_F(FpgaDeviceFixture, InoutBufferPacksOnePointerAndAliasesOutput) {
     ASSERT_NO_THROW(plan->launch());
     ASSERT_NO_THROW(plan->wait());
 
-    ASSERT_EQ(ddr_.nodes()[0].opcode, RP1_OP_KERNEL_DISPATCH);
+    ASSERT_EQ(rp1_node_get_opcode(&ddr_.nodes()[0]), RP1_OP_KERNEL_DISPATCH);
     const rp1_node_t* dispatch = findDispatch(ddr_, kKernelA_R5);
     ASSERT_NE(dispatch, nullptr);
     EXPECT_EQ(dispatch->payload.kernel_dispatch.arg_count, 2u);
@@ -1551,13 +1756,13 @@ TEST_F(FpgaDeviceFixture, ReprogramNodeLowersToPdiLoad) {
     ASSERT_NO_THROW(plan->launch());
     ASSERT_NO_THROW(plan->wait());
 
-    EXPECT_EQ(ddr_.nodes()[0].opcode, RP1_OP_PDI_LOAD);
+    EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[0]), RP1_OP_PDI_LOAD);
     EXPECT_EQ(ddr_.nodes()[0].payload.pdi_load.timeout_cycles, 12345u);
     const std::uint64_t pdiAddr =
         static_cast<std::uint64_t>(ddr_.nodes()[0].payload.pdi_load.pdi_addr_lo) |
         (static_cast<std::uint64_t>(ddr_.nodes()[0].payload.pdi_load.pdi_addr_hi) << 32);
     EXPECT_GE(pdiAddr, static_cast<std::uint64_t>(RP1_CTRL_PHYS_ADDR));
-    EXPECT_EQ(ddr_.nodes()[1].opcode, RP1_OP_SIGNAL);
+    EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[1]), RP1_OP_SIGNAL);
     EXPECT_EQ(ddr_.signals()[kDefaultSentinelSlot].value, kDefaultSentinelValue);
 
     std::filesystem::remove_all(tmpDir);
@@ -1569,15 +1774,11 @@ TEST_F(FpgaDeviceFixture,
     rp1_ = std::make_unique<FakeRp1>(
         ddr_, true,
         [](std::uint32_t, const rp1_node_t& node)
-            -> std::optional<
-                std::pair<std::uint32_t, std::uint32_t>> {
-            if (node.opcode == RP1_OP_KERNEL_DISPATCH) {
-                return std::make_pair(
-                    static_cast<std::uint32_t>(RP1_CQ_ERROR),
-                    0x55u);
+            -> std::optional<std::uint32_t> {
+            if (rp1_node_get_opcode(&node) == RP1_OP_KERNEL_DISPATCH) {
+                return 0x55u;
             }
-            return std::make_pair(
-                static_cast<std::uint32_t>(RP1_CQ_OK), 0u);
+            return std::nullopt;
         });
     auto dev = std::make_shared<FpgaDevice>(
         "fpga:0", window_, makeImageRuntimeSpec(),
@@ -1601,7 +1802,17 @@ TEST_F(FpgaDeviceFixture,
 
     auto plan = dev->compileProgram(program);
     plan->launch();
-    EXPECT_THROW(plan->wait(), std::runtime_error);
+    try {
+        plan->wait();
+        FAIL() << "expected determinate graph failure";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(message.find("returned FAILED"), std::string::npos);
+        EXPECT_NE(message.find("error_code=85"), std::string::npos);
+        EXPECT_NE(message.find("image_state=KNOWN"), std::string::npos);
+        EXPECT_EQ(message.find("lifecycle sentinel"), std::string::npos)
+            << "failure must be surfaced before success-only sentinel validation";
+    }
     plan.reset();
 
     fpga::Rp1GraphImage projected;
@@ -1620,16 +1831,51 @@ TEST_F(FpgaDeviceFixture, FailedPdiMakesActiveImageUnknown) {
     rp1_ = std::make_unique<FakeRp1>(
         ddr_, true,
         [](std::uint32_t, const rp1_node_t& node)
-            -> std::optional<
-                std::pair<std::uint32_t, std::uint32_t>> {
-            if (node.opcode == RP1_OP_PDI_LOAD) {
-                return std::make_pair(
-                    static_cast<std::uint32_t>(RP1_CQ_ERROR),
-                    static_cast<std::uint32_t>(
-                        RP1_ERR_PDI_FAILED));
+            -> std::optional<std::uint32_t> {
+            if (rp1_node_get_opcode(&node) == RP1_OP_PDI_LOAD) {
+                return RP1_ERR_PDI_FAILED;
             }
-            return std::make_pair(
-                static_cast<std::uint32_t>(RP1_CQ_OK), 0u);
+            return std::nullopt;
+        });
+    auto dev = std::make_shared<FpgaDevice>(
+        "fpga:0", window_, makeImageRuntimeSpec(),
+        "imageA");
+
+    Rp1QueueProgram program;
+    program.device = DeviceId("fpga:0");
+    Rp1ReprogramCommand load;
+    load.id = "load_b";
+    load.deviceId = "fpga:0";
+    load.imageId = "imageB";
+    program.commands.emplace_back(load);
+
+    auto plan = dev->compileProgram(program);
+    plan->launch();
+    try {
+        plan->wait();
+        FAIL() << "expected PDI failure";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(message.find("error_code=5"), std::string::npos);
+        EXPECT_NE(message.find("image_state=UNKNOWN"), std::string::npos);
+    }
+    plan.reset();
+
+    EXPECT_THROW(
+        dev->projectProgram(makeImplicitImageProgram()),
+        std::runtime_error);
+}
+
+TEST_F(FpgaDeviceFixture, PdiRecoveryResultPoisonsDeviceReuse) {
+    rp1_.reset();
+    rp1_ = std::make_unique<FakeRp1>(
+        ddr_, true,
+        [](std::uint32_t, const rp1_node_t& node)
+            -> std::optional<std::uint32_t> {
+            if (rp1_node_get_opcode(&node) == RP1_OP_PDI_LOAD) {
+                return RP1_ERR_PDI_TIMEOUT;
+            }
+            return std::nullopt;
         });
     auto dev = std::make_shared<FpgaDevice>(
         "fpga:0", window_, makeImageRuntimeSpec(),
@@ -1646,11 +1892,33 @@ TEST_F(FpgaDeviceFixture, FailedPdiMakesActiveImageUnknown) {
     auto plan = dev->compileProgram(program);
     plan->launch();
     EXPECT_THROW(plan->wait(), std::runtime_error);
+    EXPECT_TRUE(dev->executionPoisoned());
+    EXPECT_TRUE(dev->submitter()->poisoned());
     plan.reset();
 
     EXPECT_THROW(
-        dev->projectProgram(makeImplicitImageProgram()),
+        dev->leaseResources({RendezvousId(0)}, {}),
         std::runtime_error);
+}
+
+TEST_F(FpgaDeviceFixture, InfiniteWorkResultPoisonsDeviceReuse) {
+    rp1_.reset();
+    rp1_ = std::make_unique<FakeRp1>(
+        ddr_, true, FakeRp1::FailureFn{},
+        RP1_RESULT_INFINITE_WORK_REMAINS);
+    auto dev = std::make_shared<FpgaDevice>(
+        "fpga:0", window_, makeImageRuntimeSpec(),
+        "imageA");
+    const Rp1QueueProgram program = makeImplicitImageProgram();
+
+    auto plan = dev->compileProgram(program);
+    plan->launch();
+    EXPECT_NO_THROW(plan->wait());
+    EXPECT_TRUE(dev->executionPoisoned());
+    EXPECT_TRUE(dev->submitter()->poisoned());
+    plan.reset();
+
+    EXPECT_THROW(dev->compileProgram(program), std::runtime_error);
 }
 
 TEST_F(FpgaDeviceFixture,
@@ -1692,55 +1960,6 @@ TEST_F(FpgaDeviceFixture,
     dev.reset();
     EXPECT_FALSE(quarantinedDevice.expired())
         << "poison quarantine must retain the device and its DMA/PDI pins";
-}
-
-TEST_F(FpgaDeviceFixture,
-       ImageReconciliationIgnoresPdiWithoutCqEvidence) {
-    const auto spec = makeImageRuntimeSpec();
-    const std::uint32_t imageAId = 1u;
-    rp1_.reset();
-    rp1_ = std::make_unique<FakeRp1>(
-        ddr_, true,
-        [imageAId](
-            std::uint32_t, const rp1_node_t& node)
-            -> std::optional<
-                std::pair<std::uint32_t, std::uint32_t>> {
-            if (node.opcode == RP1_OP_PDI_LOAD &&
-                node.payload.pdi_load.image_id == imageAId) {
-                return std::nullopt;
-            }
-            return std::make_pair(
-                static_cast<std::uint32_t>(RP1_CQ_OK), 0u);
-        });
-    auto dev = std::make_shared<FpgaDevice>(
-        "fpga:0", window_, spec, std::string{});
-
-    Rp1QueueProgram program;
-    program.device = DeviceId("fpga:0");
-    Rp1ReprogramCommand loadB;
-    loadB.id = "load_b";
-    loadB.deviceId = "fpga:0";
-    loadB.imageId = "imageB";
-    program.commands.emplace_back(loadB);
-    Rp1ReprogramCommand skippedA;
-    skippedA.id = "skipped_a";
-    skippedA.deviceId = "fpga:0";
-    skippedA.imageId = "imageA";
-    skippedA.dependsOn = {loadB.id};
-    program.commands.emplace_back(skippedA);
-
-    auto plan = dev->compileProgram(program);
-    ASSERT_NO_THROW(plan->launch());
-    ASSERT_NO_THROW(plan->wait());
-    plan.reset();
-
-    const fpga::Rp1GraphImage projected =
-        dev->projectProgram(makeImplicitImageProgram());
-    ASSERT_FALSE(projected.nodes.empty());
-    EXPECT_EQ(
-        projected.nodes.front()
-            .payload.kernel_dispatch.kernel_base_addr,
-        kKernelB_R5);
 }
 
 TEST_F(FpgaDeviceFixture,
@@ -1864,8 +2083,9 @@ TEST_F(FpgaDeviceFixture, DiamondGraphCompletesAndSentinelFires) {
     ASSERT_NO_THROW(g.compile().run());
 
     EXPECT_EQ(ddr_.signals()[kDefaultSentinelSlot].value, kDefaultSentinelValue);
-    // 4 kernels + 1 sentinel signal = 5 CQ entries.
-    EXPECT_EQ(ddr_.ctrl().cq_write_idx, 5u);
+    EXPECT_EQ(ddr_.ctrl().result.outcome,
+              static_cast<std::uint32_t>(RP1_GRAPH_RESULT_SUCCESS));
+    EXPECT_EQ(ddr_.ctrl().result.completed_operations, 5u);
 }
 
 TEST_F(FpgaDeviceFixture, MissingLifecycleSentinelRejectsCompletion) {
@@ -1907,7 +2127,7 @@ TEST_F(FpgaDeviceFixture, DiamondBarrierMasksAreCorrect) {
     // The compiler may reorder topologically; locate nodes by R5 addr.
     auto find = [&](std::uint32_t r5) -> const rp1_node_t* {
         for (std::size_t i = 0; i < 4; ++i) {
-            if (n[i].opcode == RP1_OP_KERNEL_DISPATCH &&
+            if (rp1_node_get_opcode(&n[i]) == RP1_OP_KERNEL_DISPATCH &&
                 n[i].payload.kernel_dispatch.kernel_base_addr == r5) {
                 return &n[i];
             }
@@ -1923,10 +2143,10 @@ TEST_F(FpgaDeviceFixture, DiamondBarrierMasksAreCorrect) {
     ASSERT_NE(nc, nullptr);
     ASSERT_NE(nd, nullptr);
 
-    EXPECT_NE(na->flags & RP1_FLAG_HALT_ON_ERROR, 0u);
-    EXPECT_NE(nb->flags & RP1_FLAG_HALT_ON_ERROR, 0u);
-    EXPECT_NE(nc->flags & RP1_FLAG_HALT_ON_ERROR, 0u);
-    EXPECT_NE(nd->flags & RP1_FLAG_HALT_ON_ERROR, 0u);
+    EXPECT_EQ(rp1_node_get_flags(na), 0u);
+    EXPECT_EQ(rp1_node_get_flags(nb), 0u);
+    EXPECT_EQ(rp1_node_get_flags(nc), 0u);
+    EXPECT_EQ(rp1_node_get_flags(nd), 0u);
     EXPECT_EQ(na->barrier_await_mask, 0u);
     EXPECT_EQ(nb->barrier_await_mask, na->barrier_set_mask);
     EXPECT_EQ(nc->barrier_await_mask, na->barrier_set_mask);
@@ -1934,7 +2154,7 @@ TEST_F(FpgaDeviceFixture, DiamondBarrierMasksAreCorrect) {
 
     // Sentinel awaits only D (the unique leaf).
     const rp1_node_t& sentinel = n[4];
-    EXPECT_EQ(sentinel.opcode, RP1_OP_SIGNAL);
+    EXPECT_EQ(rp1_node_get_opcode(&sentinel), RP1_OP_SIGNAL);
     EXPECT_EQ(sentinel.barrier_await_mask, nd->barrier_set_mask);
     EXPECT_EQ(sentinel.payload.signal.value, kDefaultSentinelValue);
     EXPECT_EQ(sentinel.payload.signal.target_slot, kDefaultSentinelSlot);
@@ -2151,7 +2371,7 @@ TEST_F(FpgaDeviceFixture, NonContiguousSystemMapOffsetsAreHonored) {
     plan->wait();
 
     const auto& kd = ddr_.nodes()[0].payload.kernel_dispatch;
-    EXPECT_EQ(ddr_.nodes()[0].opcode, RP1_OP_KERNEL_DISPATCH);
+    EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[0]), RP1_OP_KERNEL_DISPATCH);
     EXPECT_EQ(kd.kernel_base_addr, kKernelA_R5);
     // n(2) + in(2) + out(2) = 6 (reg_offset, value) pairs.
     EXPECT_EQ(kd.arg_count, 6u);
@@ -2346,8 +2566,8 @@ TEST_F(FpgaDeviceFixture, OutputScalarPortsEmitScalarRead) {
     ASSERT_NO_THROW(plan->launch());
     ASSERT_NO_THROW(plan->wait());
 
-    EXPECT_EQ(ddr_.nodes()[0].opcode, RP1_OP_KERNEL_DISPATCH);
-    EXPECT_EQ(ddr_.nodes()[1].opcode, RP1_OP_SCALAR_READ);
+    EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[0]), RP1_OP_KERNEL_DISPATCH);
+    EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[1]), RP1_OP_SCALAR_READ);
     EXPECT_EQ(ddr_.nodes()[1].payload.scalar_read.source_addr, kKernelA_R5 + 0x10u);
 }
 
@@ -2384,7 +2604,7 @@ TEST_F(FpgaDeviceFixture, PointerTypedOutputScalarUsesSystemMapOffset) {
     ASSERT_NO_THROW(plan->launch());
     ASSERT_NO_THROW(plan->wait());
 
-    ASSERT_EQ(ddr_.nodes()[1].opcode, RP1_OP_SCALAR_READ);
+    ASSERT_EQ(rp1_node_get_opcode(&ddr_.nodes()[1]), RP1_OP_SCALAR_READ);
     EXPECT_EQ(ddr_.nodes()[1].payload.scalar_read.source_addr,
               kKernelA_R5 + 0x24u);
 }
@@ -2457,15 +2677,15 @@ TEST_F(FpgaDeviceFixture, OutputScalarFeedsDownstreamKernelViaScalarCopy) {
     const rp1_node_t& scalarCopy = ddr_.nodes()[2];
     const rp1_node_t& dispatch = ddr_.nodes()[3];
 
-    ASSERT_EQ(scalarRead.opcode, RP1_OP_SCALAR_READ);
-    ASSERT_EQ(scalarCopy.opcode, RP1_OP_SCALAR_COPY);
+    ASSERT_EQ(rp1_node_get_opcode(&scalarRead), RP1_OP_SCALAR_READ);
+    ASSERT_EQ(rp1_node_get_opcode(&scalarCopy), RP1_OP_SCALAR_COPY);
     EXPECT_EQ(scalarCopy.payload.scalar_copy.source_slot,
               scalarRead.payload.scalar_read.target_slot);
     EXPECT_EQ(scalarCopy.payload.scalar_copy.dest_addr, kKernelB_R5 + 0x10u);
     EXPECT_EQ(scalarCopy.barrier_await_bucket, scalarRead.barrier_set_bucket);
     EXPECT_NE(scalarCopy.barrier_await_mask & scalarRead.barrier_set_mask, 0u);
 
-    ASSERT_EQ(dispatch.opcode, RP1_OP_KERNEL_DISPATCH);
+    ASSERT_EQ(rp1_node_get_opcode(&dispatch), RP1_OP_KERNEL_DISPATCH);
     EXPECT_EQ(dispatch.payload.kernel_dispatch.kernel_base_addr, kKernelB_R5);
     EXPECT_EQ(dispatch.payload.kernel_dispatch.arg_count, 0u);
     EXPECT_EQ(dispatch.barrier_await_bucket, scalarCopy.barrier_set_bucket);
@@ -2513,6 +2733,36 @@ TEST_F(FpgaDeviceFixture, DirectProgramRejectsSecondLiveExecutionAndReleasesLeas
     std::unique_ptr<IBackendExecutable> afterRelease =
         dev->compileProgram(program);
     EXPECT_NE(afterRelease, nullptr);
+}
+
+TEST_F(FpgaDeviceFixture, CompactDiagnosticFieldsPrintNumerically) {
+    auto dev = std::make_shared<FpgaDevice>(
+        "fpga:0", window_, makeDiamondLookup());
+    Rp1QueueProgram program;
+    program.device = DeviceId("fpga:0");
+    Rp1SignalCommand signal;
+    signal.id = "diagnostic_signal";
+    signal.deviceId = "fpga:0";
+    signal.slot = 200u;
+    signal.value = 0xFFFFFFFFu;
+    signal.operation = RP1_SIGOP_AND;
+    program.commands.emplace_back(signal);
+    auto plan = dev->compileProgram(program);
+
+    ASSERT_EQ(::setenv("VRT_RP1_DUMP", "1", 1), 0);
+    testing::internal::CaptureStderr();
+    std::exception_ptr launchError;
+    try {
+        plan->launch();
+        plan->wait();
+    } catch (...) {
+        launchError = std::current_exception();
+    }
+    const std::string output = testing::internal::GetCapturedStderr();
+    ::unsetenv("VRT_RP1_DUMP");
+
+    ASSERT_EQ(launchError, nullptr);
+    EXPECT_NE(output.find("sig[slot=200 op=3"), std::string::npos);
 }
 
 TEST_F(FpgaDeviceFixture, DirectProgramPinsItsDeviceLifetime) {
@@ -2572,7 +2822,7 @@ TEST_F(FpgaDeviceFixture, ReferencedSignalSlotsAreReservedForPlanScalars) {
 
     bool sawScalarRead = false;
     for (std::uint32_t i = 0; i < ddr_.ctrl().node_count; ++i) {
-        if (ddr_.nodes()[i].opcode != RP1_OP_SCALAR_READ) continue;
+        if (rp1_node_get_opcode(&ddr_.nodes()[i]) != RP1_OP_SCALAR_READ) continue;
         sawScalarRead = true;
         EXPECT_NE(ddr_.nodes()[i].payload.scalar_read.target_slot, 0u)
             << "plan-local scalar reads must not reuse a preassigned rendezvous slot";
@@ -2766,7 +3016,7 @@ TEST_F(FpgaDeviceFixture, FixedCountLoopLowersToLoopRerunImage) {
     const rp1_node_t* n = ddr_.nodes();
 
     // node 0: LOOP, body range [1,3], 3 iterations, clears the body bucket.
-    EXPECT_EQ(n[0].opcode, RP1_OP_LOOP);
+    EXPECT_EQ(rp1_node_get_opcode(&n[0]), RP1_OP_LOOP);
     EXPECT_EQ(n[0].payload.loop.body_start, 1u);
     EXPECT_EQ(n[0].payload.loop.body_end, 3u);
     EXPECT_EQ(n[0].payload.loop.max_iterations, 3u);
@@ -2777,21 +3027,21 @@ TEST_F(FpgaDeviceFixture, FixedCountLoopLowersToLoopRerunImage) {
     EXPECT_EQ(n[0].payload.loop.condition_value, 0u);
 
     // node 1: pre-test gate. Positive counts open the body; zero closes it.
-    EXPECT_EQ(n[1].opcode, RP1_OP_COND);
+    EXPECT_EQ(rp1_node_get_opcode(&n[1]), RP1_OP_COND);
     EXPECT_EQ(n[1].payload.cond.condition_op, RP1_COP_AND_Z);
     EXPECT_EQ(n[1].payload.cond.condition_value, 0u);
 
     // node 2: the body kernel, done-bit in the loop's body bucket (1).
-    EXPECT_EQ(n[2].opcode, RP1_OP_KERNEL_DISPATCH);
+    EXPECT_EQ(rp1_node_get_opcode(&n[2]), RP1_OP_KERNEL_DISPATCH);
     EXPECT_EQ(n[2].barrier_set_bucket, 1u);
 
     // node 3: RERUN re-arms the LOOP node (index 0), gated on the body bucket.
-    EXPECT_EQ(n[3].opcode, RP1_OP_RERUN);
+    EXPECT_EQ(rp1_node_get_opcode(&n[3]), RP1_OP_RERUN);
     EXPECT_EQ(n[3].payload.rerun.target_node, 0u);
     EXPECT_EQ(n[3].barrier_await_bucket, 1u);
 
     // node 4: sentinel SIGNAL gated on the loop's exit bit.
-    EXPECT_EQ(n[4].opcode, RP1_OP_SIGNAL);
+    EXPECT_EQ(rp1_node_get_opcode(&n[4]), RP1_OP_SIGNAL);
     EXPECT_EQ(n[4].barrier_set_mask, 1u << 31);
     EXPECT_EQ(n[4].barrier_await_mask, n[0].barrier_set_mask);
 }
@@ -2840,9 +3090,9 @@ TEST_F(FpgaDeviceFixture, RerunTargetsNonzeroLoopPacket) {
     plan->wait();
 
     const rp1_node_t* nodes = ddr_.nodes();
-    ASSERT_EQ(nodes[0].opcode, RP1_OP_KERNEL_DISPATCH);
-    ASSERT_EQ(nodes[1].opcode, RP1_OP_LOOP);
-    ASSERT_EQ(nodes[4].opcode, RP1_OP_RERUN);
+    ASSERT_EQ(rp1_node_get_opcode(&nodes[0]), RP1_OP_KERNEL_DISPATCH);
+    ASSERT_EQ(rp1_node_get_opcode(&nodes[1]), RP1_OP_LOOP);
+    ASSERT_EQ(rp1_node_get_opcode(&nodes[4]), RP1_OP_RERUN);
     EXPECT_EQ(nodes[4].payload.rerun.target_node, 1u);
 }
 
@@ -2889,14 +3139,15 @@ TEST_F(FpgaDeviceFixture, FixedCountLoopBodySpansMultipleBarrierBuckets) {
     plan->wait();
 
     const rp1_node_t* n = ddr_.nodes();
-    ASSERT_EQ(n[0].opcode, RP1_OP_LOOP);
+    ASSERT_EQ(rp1_node_get_opcode(&n[0]), RP1_OP_LOOP);
     EXPECT_EQ(n[0].payload.loop.bucket_clear_start, 1u);
     EXPECT_GT(n[0].payload.loop.bucket_clear_end, n[0].payload.loop.bucket_clear_start)
         << "40 body kernels should occupy more than one reset-domain bucket";
 
     bool sawSecondBodyBucket = false;
     for (std::uint32_t i = n[0].payload.loop.body_start; i <= n[0].payload.loop.body_end; ++i) {
-        if (n[i].opcode == RP1_OP_KERNEL_DISPATCH && n[i].barrier_set_bucket > 1u) {
+        if (rp1_node_get_opcode(&n[i]) == RP1_OP_KERNEL_DISPATCH &&
+            n[i].barrier_set_bucket > 1u) {
             sawSecondBodyBucket = true;
         }
     }
@@ -3513,7 +3764,7 @@ TEST(FpgaControlExecution, OutputScalarEmitsScalarReadInControlImage) {
     const std::uint32_t count = ddr.ctrl().node_count;
     bool foundRead = false;
     for (std::uint32_t i = 0; i < count; ++i) {
-        if (n[i].opcode == RP1_OP_SCALAR_READ &&
+        if (rp1_node_get_opcode(&n[i]) == RP1_OP_SCALAR_READ &&
             n[i].payload.scalar_read.source_addr == kProducerBase + 0x10u) {
             foundRead = true;
         }
@@ -3544,8 +3795,8 @@ TEST(FpgaCrossQueue, SignalWaitRendezvousAcrossConcurrentQueues) {
     auto mkNode = [](std::uint16_t opcode, std::uint8_t awB, std::uint32_t awM,
                      std::uint8_t stB, std::uint32_t stM) {
         rp1_node_t n{};
-        n.opcode               = opcode;
-        n.status               = RP1_NODE_PENDING;
+        rp1_node_set_opcode(&n, opcode);
+        rp1_node_set_status(&n, RP1_NODE_PENDING);
         n.barrier_await_bucket = awB;
         n.barrier_await_mask   = awM;
         n.barrier_set_bucket   = stB;
@@ -3554,7 +3805,6 @@ TEST(FpgaCrossQueue, SignalWaitRendezvousAcrossConcurrentQueues) {
     };
     auto submit = [](DdrView ddr, const std::vector<rp1_node_t>& ns) {
         auto& c = ddr.ctrl();
-        c.cq_size    = 64u;
         c.node_count = static_cast<std::uint32_t>(ns.size());
         for (std::size_t i = 0; i < ns.size(); ++i) ddr.nodes()[i] = ns[i];
         std::atomic_thread_fence(std::memory_order_seq_cst);
@@ -3629,8 +3879,8 @@ TEST(FpgaCrossQueue, PerIterationHandshakeOverNIterations) {
     auto node = [](std::uint16_t op, std::uint8_t awB, std::uint32_t awM,
                    std::uint8_t stB, std::uint32_t stM) {
         rp1_node_t n{};
-        n.opcode = op;
-        n.status = RP1_NODE_PENDING;
+        rp1_node_set_opcode(&n, op);
+        rp1_node_set_status(&n, RP1_NODE_PENDING);
         n.barrier_await_bucket = awB;
         n.barrier_await_mask = awM;
         n.barrier_set_bucket = stB;
@@ -3683,7 +3933,6 @@ TEST(FpgaCrossQueue, PerIterationHandshakeOverNIterations) {
     }
 
     auto& c = ddr.ctrl();
-    c.cq_size = 64u;
     c.node_count = static_cast<std::uint32_t>(q.size());
     for (std::size_t i = 0; i < q.size(); ++i) ddr.nodes()[i] = q[i];
 
@@ -3835,8 +4084,8 @@ TEST(FpgaCrossQueue, WhileLoopTerminatesOnBroadcastPredicate) {
     auto node = [](std::uint16_t op, std::uint8_t awB, std::uint32_t awM,
                    std::uint8_t stB, std::uint32_t stM) {
         rp1_node_t n{};
-        n.opcode = op;
-        n.status = RP1_NODE_PENDING;
+        rp1_node_set_opcode(&n, op);
+        rp1_node_set_status(&n, RP1_NODE_PENDING);
         n.barrier_await_bucket = awB;
         n.barrier_await_mask = awM;
         n.barrier_set_bucket = stB;
@@ -3888,7 +4137,6 @@ TEST(FpgaCrossQueue, WhileLoopTerminatesOnBroadcastPredicate) {
     }
 
     auto& c = ddr.ctrl();
-    c.cq_size = 64u;
     c.node_count = static_cast<std::uint32_t>(q.size());
     for (std::size_t i = 0; i < q.size(); ++i) ddr.nodes()[i] = q[i];
 
@@ -4043,7 +4291,7 @@ TEST_F(FpgaDeviceFixture,
     const rp1_node_t* followerLoop = std::find_if(
         ddr_.nodes(), ddr_.nodes() + ddr_.ctrl().node_count,
         [](const rp1_node_t& node) {
-            return node.opcode == RP1_OP_LOOP;
+            return rp1_node_get_opcode(&node) == RP1_OP_LOOP;
         });
     ASSERT_NE(
         followerLoop,

--- a/vrt/tests/rp1_bar_window_test.cpp
+++ b/vrt/tests/rp1_bar_window_test.cpp
@@ -66,12 +66,15 @@ class WindowFixture : public ::testing::Test {
 TEST(Rp1BarWindowProtocol, WireSizesMatchHeader) {
     // These are also asserted by RP1_STATIC_ASSERT in rp1_protocol.h, but
     // mirroring them in a runtime test makes regressions easy to spot in CI.
-    EXPECT_EQ(sizeof(rp1_node_t),        std::size_t{64});
+    EXPECT_EQ(sizeof(rp1_node_t),        std::size_t{32});
+    EXPECT_EQ(offsetof(rp1_node_t, payload), std::size_t{12});
     EXPECT_EQ(sizeof(rp1_ctrl_t),        std::size_t{0x1000});
+    EXPECT_EQ(sizeof(rp1_graph_result_t), std::size_t{64});
     EXPECT_EQ(sizeof(rp1_signal_slot_t), std::size_t{16});
-    EXPECT_EQ(sizeof(rp1_cq_entry_t),    std::size_t{16});
     EXPECT_EQ(sizeof(rp1_trace_entry_t), std::size_t{16});
-    EXPECT_EQ(RP1_PROTOCOL_VERSION, 4u);
+    EXPECT_EQ(RP1_PROTOCOL_VERSION, 6u);
+    EXPECT_EQ(RP1_MAX_NODES, 1024u);
+    EXPECT_EQ(RP1_SCALAR_WRITE_MAX, 2u);
     EXPECT_EQ(offsetof(rp1_ctrl_t, capabilities), std::size_t{0x64});
     EXPECT_EQ(offsetof(rp1_ctrl_t, pdi_ipi_platform_id),
               std::size_t{0x68});
@@ -81,6 +84,18 @@ TEST(Rp1BarWindowProtocol, WireSizesMatchHeader) {
               std::size_t{0x70});
     EXPECT_EQ(offsetof(rp1_ctrl_t, terminal_error_aux),
               std::size_t{0x74});
+    EXPECT_EQ(offsetof(rp1_ctrl_t, result), std::size_t{0x80});
+}
+
+TEST(Rp1BarWindowProtocol, PackedControlHelpersRoundTrip) {
+    rp1_node_t node{};
+    rp1_node_set_opcode(&node, RP1_OP_RERUN);
+    rp1_node_set_flags(&node, RP1_FLAG_INFINITE);
+    rp1_node_set_status(&node, RP1_NODE_WAITING);
+
+    EXPECT_EQ(rp1_node_get_opcode(&node), RP1_OP_RERUN);
+    EXPECT_EQ(rp1_node_get_flags(&node), RP1_FLAG_INFINITE);
+    EXPECT_EQ(rp1_node_get_status(&node), RP1_NODE_WAITING);
 }
 
 TEST_F(WindowFixture, MappedLengthAndWindowOffsetExposed) {
@@ -101,9 +116,7 @@ TEST_F(WindowFixture, ControlBlockReadWriteRoundTrip) {
     out.magic            = RP1_CTRL_MAGIC;
     out.version          = RP1_PROTOCOL_VERSION;
     out.node_count       = 5;
-    out.cq_size          = 64;
     out.node_base_lo     = 0x30001000u;
-    out.cq_base_lo       = 0x30041000u;
     out.arg_buf_base_lo  = 0x30051000u;
     out.sig_array_base_lo = 0x30151000u;
     out.graph_seq        = 1;
@@ -112,6 +125,9 @@ TEST_F(WindowFixture, ControlBlockReadWriteRoundTrip) {
     out.capabilities     = RP1_REQUIRED_CAPABILITIES;
     out.pdi_ipi_platform_id = RP1_PDI_IPI_PLATFORM_UNKNOWN;
     out.terminal_error_node = RP1_TERMINAL_ERROR_NODE_NONE;
+    out.result.magic = RP1_GRAPH_RESULT_MAGIC;
+    out.result.graph_seq = 1u;
+    out.result.outcome = RP1_GRAPH_RESULT_SUCCESS;
 
     window_->writeCtrl(out);
 
@@ -125,11 +141,13 @@ TEST_F(WindowFixture, ControlBlockReadWriteRoundTrip) {
     rp1_ctrl_t roundtrip{};
     window_->readCtrl(roundtrip);
     EXPECT_EQ(roundtrip.magic, RP1_CTRL_MAGIC);
-    EXPECT_EQ(roundtrip.cq_size, 64u);
     EXPECT_EQ(roundtrip.sig_array_base_lo, 0x30151000u);
     EXPECT_EQ(roundtrip.capabilities, RP1_REQUIRED_CAPABILITIES);
     EXPECT_EQ(roundtrip.terminal_error_node,
               RP1_TERMINAL_ERROR_NODE_NONE);
+    EXPECT_EQ(roundtrip.result.magic, RP1_GRAPH_RESULT_MAGIC);
+    EXPECT_EQ(roundtrip.result.outcome,
+              static_cast<std::uint32_t>(RP1_GRAPH_RESULT_SUCCESS));
 }
 
 TEST_F(WindowFixture, SingleWordHotPathAccessors) {
@@ -159,7 +177,8 @@ TEST_F(WindowFixture, SingleWordHotPathAccessors) {
 TEST_F(WindowFixture, WriteNodesUsesDefaultNodeArrayOffset) {
     constexpr std::size_t kCount = 3;
     rp1_node_t nodes[kCount] = {};
-    nodes[0].opcode               = RP1_OP_KERNEL_DISPATCH;
+    rp1_node_set_opcode(&nodes[0], RP1_OP_KERNEL_DISPATCH);
+    rp1_node_set_status(&nodes[0], RP1_NODE_PENDING);
     nodes[0].barrier_await_mask   = 0x1;
     nodes[0].barrier_set_mask     = 0x2;
     nodes[0].barrier_await_bucket = 0;
@@ -168,11 +187,13 @@ TEST_F(WindowFixture, WriteNodesUsesDefaultNodeArrayOffset) {
     nodes[0].payload.kernel_dispatch.arg_buffer_offset = 0;
     nodes[0].payload.kernel_dispatch.arg_count         = 3;
 
-    nodes[1].opcode = RP1_OP_SIGNAL;
+    rp1_node_set_opcode(&nodes[1], RP1_OP_SIGNAL);
+    rp1_node_set_status(&nodes[1], RP1_NODE_PENDING);
     nodes[1].payload.signal.target_slot = 1;
     nodes[1].payload.signal.value       = 0xCAFEBABE;
 
-    nodes[2].opcode = RP1_OP_NOP;
+    rp1_node_set_opcode(&nodes[2], RP1_OP_NOP);
+    rp1_node_set_status(&nodes[2], RP1_NODE_PENDING);
 
     window_->writeNodes(nodes, kCount);
 
@@ -180,10 +201,14 @@ TEST_F(WindowFixture, WriteNodesUsesDefaultNodeArrayOffset) {
     std::memcpy(echoed,
                 backing_.data() + kWindowOff + RP1_DEFAULT_NODE_ARRAY_OFFSET,
                 sizeof(echoed));
-    EXPECT_EQ(echoed[0].opcode, RP1_OP_KERNEL_DISPATCH);
+    EXPECT_EQ(rp1_node_get_opcode(&echoed[0]), RP1_OP_KERNEL_DISPATCH);
     EXPECT_EQ(echoed[0].payload.kernel_dispatch.kernel_base_addr, 0x88010000u);
     EXPECT_EQ(echoed[1].payload.signal.value, 0xCAFEBABE);
-    EXPECT_EQ(echoed[2].opcode, RP1_OP_NOP);
+    EXPECT_EQ(rp1_node_get_opcode(&echoed[2]), RP1_OP_NOP);
+    EXPECT_EQ(
+        reinterpret_cast<const std::byte*>(&echoed[1]) -
+            reinterpret_cast<const std::byte*>(&echoed[0]),
+        32);
 }
 
 TEST_F(WindowFixture, WriteArgsLandsAtDefaultArgBuffer) {
@@ -218,21 +243,30 @@ TEST_F(WindowFixture, ClearAndReadSignalSlot) {
     EXPECT_EQ(out.flags, 0u);
 }
 
-TEST_F(WindowFixture, ReadCqEntryAtIndex) {
-    rp1_cq_entry_t entry{};
-    entry.node_index   = 4;
-    entry.status       = RP1_CQ_OK;
-    entry.error_detail = 0;
-    entry.timestamp    = 0xABCDu;
-    std::memcpy(backing_.data() + kWindowOff + RP1_DEFAULT_CQ_OFFSET
-                    + 7 * sizeof(rp1_cq_entry_t),
-                &entry, sizeof(entry));
+TEST_F(WindowFixture, ReadGraphResultTakesOneTypedSnapshot) {
+    rp1_graph_result_t result{};
+    result.magic = RP1_GRAPH_RESULT_MAGIC;
+    result.graph_seq = 9u;
+    result.outcome = RP1_GRAPH_RESULT_FAILED;
+    result.flags = RP1_RESULT_RECOVERY_REQUIRED;
+    result.error_code = RP1_ERR_PDI_FAILED;
+    result.terminal_node = 4u;
+    result.terminal_opcode = RP1_OP_PDI_LOAD;
+    result.active_image_id = 2u;
+    result.image_state = RP1_IMAGE_STATE_KNOWN;
+    std::memcpy(
+        backing_.data() + kWindowOff + offsetof(rp1_ctrl_t, result),
+        &result, sizeof(result));
 
-    rp1_cq_entry_t out{};
-    window_->readCq(/*idx*/ 7, out);
-    EXPECT_EQ(out.node_index, 4u);
-    EXPECT_EQ(out.status,     static_cast<std::uint32_t>(RP1_CQ_OK));
-    EXPECT_EQ(out.timestamp,  0xABCDu);
+    rp1_graph_result_t out{};
+    window_->readGraphResult(out);
+    EXPECT_EQ(out.magic, RP1_GRAPH_RESULT_MAGIC);
+    EXPECT_EQ(out.graph_seq, 9u);
+    EXPECT_EQ(out.outcome,
+              static_cast<std::uint32_t>(RP1_GRAPH_RESULT_FAILED));
+    EXPECT_EQ(out.terminal_opcode,
+              static_cast<std::uint32_t>(RP1_OP_PDI_LOAD));
+    EXPECT_EQ(out.active_image_id, 2u);
 }
 
 TEST_F(WindowFixture, ReadTraceEntryAtIndex) {

--- a/vrt/tests/rp1_submitter_test.cpp
+++ b/vrt/tests/rp1_submitter_test.cpp
@@ -21,25 +21,25 @@
 /**
  * @file rp1_submitter_test.cpp
  *
- * Unit tests for vrt::graph::fpga::Rp1Submitter.
- *
- * Each test runs a background "fake RP1" thread that watches the same
- * heap-backed BAR buffer the submitter writes to and advances
- * graph_done_seq once it sees graph_seq increment.  No daemon, no
- * hardware.
+ * Protocol-v6 submitter tests use a heap-backed BAR and a fake RP1 publisher.
+ * The fake commits the result payload, magic, terminal state, and exact
+ * graph_done_seq in firmware order so publication and corruption paths can be
+ * exercised without vrtd or hardware.
  */
 
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <future>
+#include <iterator>
 #include <limits>
+#include <optional>
 #include <stdexcept>
-#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <slash/uapi/rp1_protocol.h>
@@ -48,820 +48,1019 @@
 
 using vrt::graph::fpga::Rp1BarWindow;
 using vrt::graph::fpga::Rp1GraphImage;
+using vrt::graph::fpga::Rp1GraphOutcome;
+using vrt::graph::fpga::Rp1ImageState;
 using vrt::graph::fpga::Rp1Submitter;
 using vrt::graph::fpga::Rp1TimeoutError;
+using vrt::graph::fpga::appendScalarWritePackets;
 
 namespace {
 
-constexpr std::size_t   kBarSize   = 128ULL << 20;
-constexpr std::uint64_t kWindowOff = 64ULL << 20;
+/// Size of the fake BAR mapping containing one 64 MiB RP1 window.
+constexpr std::size_t kBarSize = 128ULL << 20;
+/// BAR-relative origin of the fake RP1 window.
+constexpr std::uint64_t kWindowOffset = 64ULL << 20;
 
-/// Direct typed view of the shared DDR window (for the fake RP1 thread
-/// and for assertions).
+/**
+ * @brief Direct firmware-side view of the fake shared DDR window.
+ *
+ * The view does not own @c base; the fixture's backing vector outlives every
+ * fake publisher and host accessor using it.
+ */
 struct DdrView {
-    std::byte* base;
+    /// Start of the caller-owned fake BAR mapping.
+    std::byte* base = nullptr;
 
-    rp1_ctrl_t&        ctrl()      { return *reinterpret_cast<rp1_ctrl_t*>(base + kWindowOff); }
-    rp1_node_t*        nodes()     { return reinterpret_cast<rp1_node_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_NODE_ARRAY_OFFSET); }
-    rp1_cq_entry_t*    cq()        { return reinterpret_cast<rp1_cq_entry_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_CQ_OFFSET); }
-    std::uint32_t*     args()      { return reinterpret_cast<std::uint32_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_ARG_BUF_OFFSET); }
-    rp1_signal_slot_t* signals()   { return reinterpret_cast<rp1_signal_slot_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_SIG_ARRAY_OFFSET); }
-    rp1_trace_entry_t* trace()     { return reinterpret_cast<rp1_trace_entry_t*>(
-                                         base + kWindowOff + RP1_DEFAULT_TRACE_OFFSET); }
+    /// Return the shared RP1 control block.
+    rp1_ctrl_t& ctrl() const {
+        return *reinterpret_cast<rp1_ctrl_t*>(base + kWindowOffset);
+    }
+
+    /// Return the staged RP1 node array.
+    rp1_node_t* nodes() const {
+        return reinterpret_cast<rp1_node_t*>(
+            base + kWindowOffset + RP1_DEFAULT_NODE_ARRAY_OFFSET);
+    }
+
+    /// Return the staged RP1 argument buffer.
+    std::uint32_t* args() const {
+        return reinterpret_cast<std::uint32_t*>(
+            base + kWindowOffset + RP1_DEFAULT_ARG_BUF_OFFSET);
+    }
+
+    /// Return the shared RP1 signal array.
+    rp1_signal_slot_t* signals() const {
+        return reinterpret_cast<rp1_signal_slot_t*>(
+            base + kWindowOffset + RP1_DEFAULT_SIG_ARRAY_OFFSET);
+    }
+
+    /// Return the optional shared trace ring.
+    rp1_trace_entry_t* trace() const {
+        return reinterpret_cast<rp1_trace_entry_t*>(
+            base + kWindowOffset + RP1_DEFAULT_TRACE_OFFSET);
+    }
 };
 
-/// Bring the fake firmware up to RP1_STATE_READY with the canonical
-/// magic.  The submitter's first ensureReady() will then succeed.
+/**
+ * @brief Publish a complete protocol-v6 readiness contract.
+ */
 void primeAsReady(DdrView ddr) {
-    auto& c   = ddr.ctrl();
-    c.version      = RP1_PROTOCOL_VERSION;
-    c.capabilities = RP1_REQUIRED_CAPABILITIES;
-    c.pdi_ipi_platform_id = 0x51454D55u;
-    c.rp1_state    = RP1_STATE_READY;
-    c.heartbeat    = 1;
-    c.graph_seq      = 0;
-    c.graph_done_seq = 0;
-    c.magic          = RP1_CTRL_MAGIC;
+    rp1_ctrl_t& ctrl = ddr.ctrl();
+    ctrl.version = RP1_PROTOCOL_VERSION;
+    ctrl.capabilities = RP1_REQUIRED_CAPABILITIES;
+    ctrl.pdi_ipi_platform_id = 0x51454D55u;
+    ctrl.graph_seq = 0u;
+    ctrl.graph_done_seq = 0u;
+    ctrl.rp1_state = RP1_STATE_READY;
+    ctrl.heartbeat = 1u;
+    ctrl.magic = RP1_CTRL_MAGIC;
 }
 
-/// Worker that emulates the RP1 flat scanner just enough to make
-/// submitAndWait() return: watch graph_seq, then for each new graph,
-/// walk its node array, emit a CQ entry per node, write SIGNAL nodes'
-/// values into the signal array, set rp1_state appropriately, and
-/// finally bump graph_done_seq.
+/**
+ * @brief Wire fields and publication behavior selected for one fake result.
+ *
+ * Optional sequence/state overrides deliberately create corrupt terminal
+ * publications. @c publishDone false models an accepted graph that never
+ * reaches the protocol release point.
+ */
+struct FakeResultSpec {
+    /// Commit magic written before graph_done_seq.
+    std::uint32_t magic = RP1_GRAPH_RESULT_MAGIC;
+    /// Raw graph outcome, including invalid values used by corruption tests.
+    std::uint32_t outcome = RP1_GRAPH_RESULT_SUCCESS;
+    /// Raw result flags supplied by the fake.
+    std::uint32_t flags = 0u;
+    /// First terminal error code.
+    std::uint32_t errorCode = 0u;
+    /// Failing or HALT node.
+    std::uint32_t terminalNode = RP1_TERMINAL_ERROR_NODE_NONE;
+    /// Failing or HALT opcode.
+    std::uint32_t terminalOpcode = RP1_TERMINAL_OPCODE_NONE;
+    /// Error-specific primary detail.
+    std::uint32_t errorDetail = 0u;
+    /// Error-specific auxiliary detail.
+    std::uint32_t errorAux = 0u;
+    /// Final active-image id.
+    std::uint32_t activeImageId = 0u;
+    /// Raw final image state.
+    std::uint32_t imageState = RP1_IMAGE_STATE_NONE;
+    /// Optional successful-operation count override.
+    std::optional<std::uint32_t> completedOperations;
+    /// Graph work duration in protocol PMU ticks.
+    std::uint32_t graphElapsedTicks = 101u;
+    /// Full publication duration in protocol PMU ticks.
+    std::uint32_t publishElapsedTicks = 123u;
+    /// Packed terminal quiescence counters.
+    std::uint32_t quiescence = 0u;
+    /// Optional result sequence override.
+    std::optional<std::uint32_t> resultSequence;
+    /// Optional terminal-state override.
+    std::optional<std::uint32_t> terminalState;
+    /// Delay between terminal state and graph_done_seq publication.
+    std::chrono::milliseconds doneDelay{0};
+    /// Whether the fake publishes graph_done_seq.
+    bool publishDone = true;
+};
+
+/**
+ * @brief Minimal firmware publisher for one or more sequential graph images.
+ *
+ * Nodes execute synchronously. SIGNAL side effects and one optional trace entry
+ * are modeled; terminal classification comes from @c FakeResultSpec so host
+ * result validation can be tested independently from scanner behavior.
+ */
 class FakeRp1 {
    public:
-    FakeRp1(DdrView ddr, std::uint32_t cq_capacity)
-        : ddr_(ddr), cq_cap_(cq_capacity) {
-        thread_ = std::thread([this] { run(); });
-    }
+    /// Start the fake publisher over @p ddr using @p spec for every graph.
+    FakeRp1(DdrView ddr, FakeResultSpec spec = {})
+        : ddr_(ddr), spec_(std::move(spec)),
+          thread_([this] { run(); }) {}
+
+    /// Stop the publisher before its backing mapping is destroyed.
     ~FakeRp1() {
         stop_.store(true, std::memory_order_relaxed);
         if (thread_.joinable()) thread_.join();
     }
 
-    std::uint32_t graphsRun() const noexcept { return graphs_run_.load(); }
-
-    void setCqResult(std::uint32_t status, std::uint32_t detail) {
-        cq_status_.store(status, std::memory_order_relaxed);
-        cq_detail_.store(detail, std::memory_order_relaxed);
-    }
-
-    void setTerminalResult(std::uint32_t state, std::uint32_t code,
-                           std::uint32_t node, std::uint32_t detail,
-                           std::uint32_t aux,
-                           std::chrono::milliseconds publicationDelay = {}) {
-        terminal_state_.store(state, std::memory_order_relaxed);
-        terminal_code_.store(code, std::memory_order_relaxed);
-        terminal_node_.store(node, std::memory_order_relaxed);
-        terminal_detail_.store(detail, std::memory_order_relaxed);
-        terminal_aux_.store(aux, std::memory_order_relaxed);
-        terminal_delay_ms_.store(
-            static_cast<std::uint32_t>(publicationDelay.count()),
-            std::memory_order_relaxed);
+    /// Return the number of graph_done_seq values published by this fake.
+    std::uint32_t graphsRun() const noexcept {
+        return graphsRun_.load(std::memory_order_relaxed);
     }
 
    private:
+    /// Derive the control-block terminal state unless the test overrides it.
+    std::uint32_t terminalState() const {
+        if (spec_.terminalState) return *spec_.terminalState;
+        switch (spec_.outcome) {
+            case RP1_GRAPH_RESULT_FAILED: return RP1_STATE_ERROR;
+            case RP1_GRAPH_RESULT_HALTED: return RP1_STATE_HALTED;
+            default:                      return RP1_STATE_READY;
+        }
+    }
+
+    /// Execute immediate fake node effects and return the completion count.
+    std::uint32_t processGraph() {
+        rp1_ctrl_t& ctrl = ddr_.ctrl();
+        std::uint32_t completed = 0u;
+        ctrl.trace_write_idx = 0u;
+        for (std::uint32_t i = 0; i < ctrl.node_count; ++i) {
+            const rp1_node_t& node = ddr_.nodes()[i];
+            if (rp1_node_get_opcode(&node) == RP1_OP_SIGNAL) {
+                const auto& signal = node.payload.signal;
+                ddr_.signals()[signal.target_slot].value = signal.value;
+                ddr_.signals()[signal.target_slot].last_writer_node = i;
+            }
+            ++completed;
+        }
+        if (ctrl.trace_enable != 0u && ctrl.trace_size != 0u) {
+            rp1_trace_entry_t& entry = ddr_.trace()[0];
+            entry.timestamp = 17u;
+            entry.event = RP1_TRACE_GRAPH_DONE;
+            entry.node_index = 0xFFFFu;
+            entry.aux0 = spec_.outcome;
+            entry.aux1 = ctrl.graph_seq;
+            ctrl.trace_write_idx = 1u;
+        }
+        return completed;
+    }
+
+    /// Publish one committed result in the firmware's required write order.
+    void publishResult(std::uint32_t sequence,
+                       std::uint32_t completed) {
+        rp1_ctrl_t& ctrl = ddr_.ctrl();
+        rp1_graph_result_t& result = ctrl.result;
+        result.magic = 0u;
+        result.graph_seq =
+            spec_.resultSequence.value_or(sequence);
+        result.outcome = spec_.outcome;
+        result.flags = spec_.flags |
+            (ctrl.trace_enable != 0u ? RP1_RESULT_TRACE_ENABLED : 0u);
+        result.error_code = spec_.errorCode;
+        result.terminal_node = spec_.terminalNode;
+        result.terminal_opcode = spec_.terminalOpcode;
+        result.error_detail = spec_.errorDetail;
+        result.error_aux = spec_.errorAux;
+        result.active_image_id = spec_.activeImageId;
+        result.image_state = spec_.imageState;
+        result.completed_operations =
+            spec_.completedOperations.value_or(completed);
+        result.graph_elapsed_ticks = spec_.graphElapsedTicks;
+        result.publish_elapsed_ticks = spec_.publishElapsedTicks;
+        result.trace_write_idx = ctrl.trace_write_idx;
+        result.quiescence = spec_.quiescence;
+
+        ctrl.rp1_error_code = spec_.errorCode;
+        ctrl.terminal_error_node = spec_.terminalNode;
+        ctrl.terminal_error_detail = spec_.errorDetail;
+        ctrl.terminal_error_aux = spec_.errorAux;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        result.magic = spec_.magic;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        ctrl.rp1_state = terminalState();
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        if (spec_.doneDelay.count() != 0) {
+            std::this_thread::sleep_for(spec_.doneDelay);
+        }
+        if (spec_.publishDone) {
+            ctrl.graph_done_seq = sequence;
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            graphsRun_.fetch_add(1u, std::memory_order_relaxed);
+        }
+    }
+
+    /// Watch graph_seq and publish each newly accepted graph.
     void run() {
         while (!stop_.load(std::memory_order_relaxed)) {
-            auto& c = ddr_.ctrl();
-            const std::uint32_t seq      = c.graph_seq;
-            const std::uint32_t done_seq = c.graph_done_seq;
-            if (seq != done_seq &&
-                c.rp1_state != RP1_STATE_ERROR &&
-                c.rp1_state != RP1_STATE_HALTED) {
-                processGraph();
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                const std::uint32_t terminal =
-                    terminal_state_.load(std::memory_order_relaxed);
-                c.rp1_error_code =
-                    terminal_code_.load(std::memory_order_relaxed);
-                c.terminal_error_node =
-                    terminal_node_.load(std::memory_order_relaxed);
-                c.terminal_error_detail =
-                    terminal_detail_.load(std::memory_order_relaxed);
-                c.terminal_error_aux =
-                    terminal_aux_.load(std::memory_order_relaxed);
-                c.rp1_state = terminal;
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                const std::uint32_t delay =
-                    terminal_delay_ms_.load(std::memory_order_relaxed);
-                if (delay != 0u) {
-                    std::this_thread::sleep_for(
-                        std::chrono::milliseconds(delay));
-                }
-                c.graph_done_seq = seq;
-                std::atomic_thread_fence(std::memory_order_seq_cst);
-                graphs_run_.fetch_add(1);
+            rp1_ctrl_t& ctrl = ddr_.ctrl();
+            if (ctrl.graph_seq != ctrl.graph_done_seq &&
+                ctrl.rp1_state != RP1_STATE_ERROR &&
+                ctrl.rp1_state != RP1_STATE_HALTED) {
+                const std::uint32_t sequence = ctrl.graph_seq;
+                ctrl.rp1_state = RP1_STATE_RUNNING;
+                const std::uint32_t completed = processGraph();
+                publishResult(sequence, completed);
             }
-            // Cheap heartbeat tick.
-            c.heartbeat = c.heartbeat + 1;
-            std::this_thread::sleep_for(std::chrono::microseconds(200));
+            ctrl.heartbeat = ctrl.heartbeat + 1u;
+            std::this_thread::sleep_for(
+                std::chrono::microseconds(200));
         }
     }
 
-    void processGraph() {
-        auto&            c        = ddr_.ctrl();
-        const std::uint32_t count   = c.node_count;
-        const std::uint32_t cq_size = c.cq_size;
-        c.rp1_state = RP1_STATE_RUNNING;
-        c.trace_write_idx = 0;
-        emitTrace(RP1_TRACE_GRAPH_START, 0xFFFFu, c.graph_seq, count);
-
-        for (std::uint32_t i = 0; i < count; ++i) {
-            rp1_node_t& n = ddr_.nodes()[i];
-            emitTrace(RP1_TRACE_NODE_ACTIVATE, i, n.opcode, n.flags);
-            switch (n.opcode) {
-                case RP1_OP_SIGNAL: {
-                    const auto& pl = n.payload.signal;
-                    ddr_.signals()[pl.target_slot].value = pl.value;
-                    ddr_.signals()[pl.target_slot].last_writer_node = i;
-                    break;
-                }
-                case RP1_OP_KERNEL_DISPATCH: {
-                    // Pretend the kernel ran instantly.  Real firmware
-                    // would also propagate barrier_set_mask; we just
-                    // emit a CQ entry to keep counts honest.
-                    emitTrace(RP1_TRACE_KERNEL_LAUNCH, i,
-                              n.payload.kernel_dispatch.kernel_base_addr,
-                              n.payload.kernel_dispatch.arg_count);
-                    emitTrace(RP1_TRACE_KERNEL_DONE, i,
-                              n.payload.kernel_dispatch.kernel_base_addr, 0);
-                    break;
-                }
-                case RP1_OP_NOP:
-                default:
-                    break;
-            }
-            if ((n.flags & RP1_FLAG_SILENT) == 0u) {
-                while (!stop_.load(std::memory_order_relaxed) &&
-                       c.cq_write_idx - c.cq_read_idx == cq_size) {
-                    std::this_thread::sleep_for(
-                        std::chrono::microseconds(50));
-                }
-                if (stop_.load(std::memory_order_relaxed))
-                    return;
-                const std::uint32_t idx = c.cq_write_idx & (cq_size - 1u);
-                rp1_cq_entry_t& entry = ddr_.cq()[idx];
-                entry.node_index   = i;
-                entry.status       =
-                    cq_status_.load(std::memory_order_relaxed);
-                entry.error_detail =
-                    cq_detail_.load(std::memory_order_relaxed);
-                entry.timestamp    = 1000u + i;
-                ++c.cq_write_idx;
-            }
-            n.status = RP1_NODE_DONE;
-        }
-        emitTrace(RP1_TRACE_GRAPH_DONE, 0xFFFFu, 0, c.graph_seq);
-        // Use the limit-flag as a sentinel for the inflight cap; not
-        // exercised here.
-        (void)cq_cap_;
-    }
-
-    void emitTrace(std::uint16_t event, std::uint32_t node_index,
-                   std::uint32_t aux0, std::uint32_t aux1) {
-        auto& c = ddr_.ctrl();
-        if (c.trace_enable == 0 || c.trace_size == 0)
-            return;
-
-        const std::uint32_t idx = c.trace_write_idx % c.trace_size;
-        rp1_trace_entry_t& entry = ddr_.trace()[idx];
-        entry.timestamp  = 100u + c.trace_write_idx;
-        entry.event      = event;
-        entry.node_index = static_cast<std::uint16_t>(node_index);
-        entry.aux0       = aux0;
-        entry.aux1       = aux1;
-        ++c.trace_write_idx;
-    }
-
-    DdrView                 ddr_;
-    std::uint32_t           cq_cap_;
-    std::atomic<bool>       stop_{false};
-    std::atomic<std::uint32_t> graphs_run_{0};
-    std::atomic<std::uint32_t> cq_status_{RP1_CQ_OK};
-    std::atomic<std::uint32_t> cq_detail_{0};
-    std::atomic<std::uint32_t> terminal_state_{RP1_STATE_READY};
-    std::atomic<std::uint32_t> terminal_code_{0};
-    std::atomic<std::uint32_t> terminal_node_{
-        RP1_TERMINAL_ERROR_NODE_NONE};
-    std::atomic<std::uint32_t> terminal_detail_{0};
-    std::atomic<std::uint32_t> terminal_aux_{0};
-    std::atomic<std::uint32_t> terminal_delay_ms_{0};
-    std::thread             thread_;
+    /// Shared DDR view; non-owning.
+    DdrView ddr_;
+    /// Immutable result behavior for this fake instance.
+    FakeResultSpec spec_;
+    /// Cooperative thread-stop flag.
+    std::atomic<bool> stop_{false};
+    /// Count of completed result publications.
+    std::atomic<std::uint32_t> graphsRun_{0u};
+    /// Background firmware-emulation thread.
+    std::thread thread_;
 };
 
+/**
+ * @brief Common heap-backed submitter fixture with a successful fake RP1.
+ */
 class SubmitterFixture : public ::testing::Test {
    protected:
+    /// Allocate the BAR, publish readiness, and start the default fake.
     void SetUp() override {
         backing_.assign(kBarSize, std::byte{0});
         ddr_ = DdrView{backing_.data()};
         primeAsReady(ddr_);
-        window_   = std::make_unique<Rp1BarWindow>(backing_.data(), backing_.size(), kWindowOff);
+        window_ = std::make_unique<Rp1BarWindow>(
+            backing_.data(), backing_.size(), kWindowOffset);
         submitter_ = std::make_unique<Rp1Submitter>(*window_);
-        rp1_       = std::make_unique<FakeRp1>(ddr_, vrt::graph::fpga::kDefaultCqSize);
+        fake_ = std::make_unique<FakeRp1>(ddr_);
     }
 
+    /// Stop the fake before releasing its mapping and host accessors.
     void TearDown() override {
-        rp1_.reset();
+        fake_.reset();
         submitter_.reset();
         window_.reset();
     }
 
-    Rp1GraphImage makeSignalGraph(std::uint32_t slot, std::uint32_t value) {
-        Rp1GraphImage img;
-        img.nodes.resize(1);
-        auto& n = img.nodes[0];
-        n.opcode               = RP1_OP_SIGNAL;
-        n.flags                = 0;
-        n.barrier_await_mask   = 0;
-        n.barrier_set_mask     = 0x1;
-        n.barrier_await_bucket = 0;
-        n.barrier_set_bucket   = 0;
-        n.status               = RP1_NODE_PENDING;
-        n.payload.signal.target_slot = slot;
-        n.payload.signal.value       = value;
-        n.payload.signal.operation   = RP1_SIGOP_SET;
-        img.clear_signal_slots.push_back(slot);
-        return img;
+    /// Replace the fake before any graph is accepted in the current test.
+    void restartFake(FakeResultSpec spec) {
+        fake_.reset();
+        fake_ = std::make_unique<FakeRp1>(ddr_, std::move(spec));
     }
 
-    Rp1GraphImage makeDiamondImage() {
-        Rp1GraphImage img;
-        img.nodes.resize(5);
-
-        // Helper.
-        auto setHdr = [](rp1_node_t& n, std::uint16_t op,
-                         std::uint8_t aw_b, std::uint32_t aw_m,
-                         std::uint8_t st_b, std::uint32_t st_m) {
-            n.opcode               = op;
-            n.flags                = 0;
-            n.barrier_await_mask   = aw_m;
-            n.barrier_set_mask     = st_m;
-            n.barrier_await_bucket = aw_b;
-            n.barrier_set_bucket   = st_b;
-            n.status               = RP1_NODE_PENDING;
-        };
-
-        setHdr(img.nodes[0], RP1_OP_KERNEL_DISPATCH, 0, 0x0, 0, 0x1);
-        setHdr(img.nodes[1], RP1_OP_KERNEL_DISPATCH, 0, 0x1, 0, 0x2);
-        setHdr(img.nodes[2], RP1_OP_KERNEL_DISPATCH, 0, 0x1, 0, 0x4);
-        setHdr(img.nodes[3], RP1_OP_KERNEL_DISPATCH, 0, 0x6, 0, 0x8);
-        for (int i = 0; i < 4; ++i) {
-            auto& kd = img.nodes[i].payload.kernel_dispatch;
-            kd.kernel_base_addr  = 0x88010000u + 0x10000u * i;
-            kd.arg_buffer_offset = 0;
-            kd.arg_count         = 0;
-        }
-        setHdr(img.nodes[4], RP1_OP_SIGNAL, 0, 0x8, 0, 0x10);
-        img.nodes[4].payload.signal.target_slot = 0;
-        img.nodes[4].payload.signal.value       = 0xD1A1D0DDu;
-        img.nodes[4].payload.signal.operation   = RP1_SIGOP_SET;
-        img.clear_signal_slots.push_back(0);
-        return img;
+    /// Build one valid SIGNAL graph with a cleared output slot.
+    Rp1GraphImage makeSignalGraph(
+        std::uint32_t slot = 2u,
+        std::uint32_t value = 0xDEADBEEFu) {
+        Rp1GraphImage image;
+        image.nodes.resize(1u);
+        rp1_node_t& node = image.nodes.front();
+        rp1_node_set_opcode(&node, RP1_OP_SIGNAL);
+        rp1_node_set_status(&node, RP1_NODE_PENDING);
+        node.barrier_set_mask = 1u;
+        node.payload.signal.target_slot =
+            static_cast<std::uint8_t>(slot);
+        node.payload.signal.value = value;
+        node.payload.signal.operation = RP1_SIGOP_SET;
+        image.clear_signal_slots.push_back(slot);
+        return image;
     }
 
-    Rp1GraphImage makeNopGraph(std::size_t count) {
-        Rp1GraphImage img;
-        img.nodes.resize(count);
-        for (auto& node : img.nodes) {
-            node.opcode = RP1_OP_NOP;
-            node.status = RP1_NODE_PENDING;
-        }
-        return img;
+    /// Build one zero-initialized pending node with @p opcode.
+    Rp1GraphImage makeOpcodeGraph(std::uint16_t opcode) {
+        Rp1GraphImage image;
+        image.nodes.resize(1u);
+        rp1_node_set_opcode(&image.nodes.front(), opcode);
+        rp1_node_set_status(&image.nodes.front(), RP1_NODE_PENDING);
+        return image;
     }
 
-    std::vector<std::byte>        backing_;
-    DdrView                       ddr_{};
+    /// Caller-owned fake BAR storage.
+    std::vector<std::byte> backing_;
+    /// Firmware-side typed view of @c backing_.
+    DdrView ddr_;
+    /// Host-side typed BAR accessor.
     std::unique_ptr<Rp1BarWindow> window_;
+    /// Submitter under test.
     std::unique_ptr<Rp1Submitter> submitter_;
-    std::unique_ptr<FakeRp1>      rp1_;
+    /// Active fake firmware publisher.
+    std::unique_ptr<FakeRp1> fake_;
 };
 
 }  // namespace
 
-TEST_F(SubmitterFixture, EnsureReadyProgramsBaseAddresses) {
+TEST_F(SubmitterFixture, EnsureReadyProgramsV6Configuration) {
+    ddr_.ctrl()._reserved_cq_size = 64u;
+    ddr_.ctrl()._reserved_cq_base_lo = 0x30041000u;
+    ddr_.ctrl()._reserved_cq_base_hi = 1u;
+
     submitter_->ensureReady(std::chrono::milliseconds(500));
 
-    auto& c = ddr_.ctrl();
-    EXPECT_EQ(c.cq_size, vrt::graph::fpga::kDefaultCqSize);
-    EXPECT_EQ(c.node_base_lo,
-              static_cast<std::uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_NODE_ARRAY_OFFSET));
-    EXPECT_EQ(c.cq_base_lo,
-              static_cast<std::uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_CQ_OFFSET));
-    EXPECT_EQ(c.arg_buf_base_lo,
-              static_cast<std::uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_ARG_BUF_OFFSET));
-    EXPECT_EQ(c.sig_array_base_lo,
-              static_cast<std::uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_SIG_ARRAY_OFFSET));
-    EXPECT_EQ(c.trace_base_lo,
-              static_cast<std::uint32_t>(RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_TRACE_OFFSET));
-    EXPECT_EQ(c.trace_size, vrt::graph::fpga::kDefaultTraceSize);
-    EXPECT_EQ(c.trace_enable, 0u);
-    EXPECT_EQ(c.node_base_hi, 0u);
+    const rp1_ctrl_t& ctrl = ddr_.ctrl();
+    EXPECT_EQ(ctrl._reserved_cq_size, 0u);
+    EXPECT_EQ(ctrl._reserved_cq_base_lo, 0u);
+    EXPECT_EQ(ctrl._reserved_cq_base_hi, 0u);
+    EXPECT_EQ(
+        ctrl.node_base_lo,
+        static_cast<std::uint32_t>(
+            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_NODE_ARRAY_OFFSET));
+    EXPECT_EQ(
+        ctrl.arg_buf_base_lo,
+        static_cast<std::uint32_t>(
+            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_ARG_BUF_OFFSET));
+    EXPECT_EQ(
+        ctrl.sig_array_base_lo,
+        static_cast<std::uint32_t>(
+            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_SIG_ARRAY_OFFSET));
+    EXPECT_EQ(
+        ctrl.trace_base_lo,
+        static_cast<std::uint32_t>(
+            RP1_CTRL_PHYS_ADDR + RP1_DEFAULT_TRACE_OFFSET));
+    EXPECT_EQ(ctrl.trace_size, vrt::graph::fpga::kDefaultTraceSize);
+    EXPECT_EQ(ctrl.trace_enable, 0u);
 }
 
 TEST_F(SubmitterFixture, MissingMagicTimesOut) {
-    // Stamp something that isn't RP1_CTRL_MAGIC.
-    ddr_.ctrl().magic = 0;
-    EXPECT_THROW(submitter_->ensureReady(std::chrono::milliseconds(20)),
-                 Rp1TimeoutError);
+    ddr_.ctrl().magic = 0u;
+    EXPECT_THROW(
+        submitter_->ensureReady(std::chrono::milliseconds(20)),
+        Rp1TimeoutError);
 }
 
-TEST_F(SubmitterFixture, WrongProtocolVersionIsRejected) {
-    ddr_.ctrl().version = RP1_PROTOCOL_VERSION - 1u;
+TEST_F(SubmitterFixture, ProtocolV5FirmwareIsRejected) {
+    ddr_.ctrl().version = 5u;
     EXPECT_THROW(
         submitter_->ensureReady(std::chrono::milliseconds(20)),
         std::runtime_error);
 }
 
-TEST_F(SubmitterFixture, MissingRequiredCapabilityIsRejected) {
-    ddr_.ctrl().capabilities &=
-        ~RP1_CAP_LATCHED_TERMINAL_ERRORS;
+TEST_F(SubmitterFixture, GraphResultCapabilityIsRequired) {
+    ddr_.ctrl().capabilities &= ~RP1_CAP_GRAPH_RESULT;
     EXPECT_THROW(
         submitter_->ensureReady(std::chrono::milliseconds(20)),
         std::runtime_error);
 }
 
-TEST_F(SubmitterFixture, UnknownPlatformConfigIsRejected) {
-    ddr_.ctrl().pdi_ipi_platform_id = RP1_PDI_IPI_PLATFORM_UNKNOWN;
+TEST_F(SubmitterFixture, CachedReadinessRevalidatesCapabilities) {
+    ASSERT_NO_THROW(
+        submitter_->ensureReady(std::chrono::milliseconds(500)));
+    ddr_.ctrl().capabilities &= ~RP1_CAP_GRAPH_RESULT;
     EXPECT_THROW(
         submitter_->ensureReady(std::chrono::milliseconds(20)),
         std::runtime_error);
 }
 
-TEST_F(SubmitterFixture, EmptyGraphIsRejected) {
-    submitter_->ensureReady(std::chrono::milliseconds(500));
-    Rp1GraphImage img;
-    EXPECT_THROW(submitter_->submitAndWait(img), std::logic_error);
+TEST_F(SubmitterFixture, UnknownPdiPlatformIsRejected) {
+    ddr_.ctrl().pdi_ipi_platform_id =
+        RP1_PDI_IPI_PLATFORM_UNKNOWN;
+    EXPECT_THROW(
+        submitter_->ensureReady(std::chrono::milliseconds(20)),
+        std::runtime_error);
 }
 
-TEST_F(SubmitterFixture, SignalGraphRoundTrip) {
-    auto img = makeSignalGraph(/*slot*/ 2, /*value*/ 0xDEADBEEFu);
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
+TEST_F(SubmitterFixture, SuccessReturnsTypedResult) {
+    FakeResultSpec spec;
+    spec.activeImageId = 7u;
+    spec.imageState = RP1_IMAGE_STATE_KNOWN;
+    spec.completedOperations = 19u;
+    spec.graphElapsedTicks = 200u;
+    spec.publishElapsedTicks = 240u;
+    restartFake(spec);
 
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+
+    EXPECT_TRUE(result.succeeded());
+    EXPECT_EQ(result.outcome, Rp1GraphOutcome::Success);
+    EXPECT_EQ(result.sequence, 1u);
+    EXPECT_FALSE(result.terminal.has_value());
+    EXPECT_EQ(result.imageState, Rp1ImageState::Known);
+    EXPECT_EQ(result.activeImageId, 7u);
+    EXPECT_EQ(result.completedOperations, 19u);
+    EXPECT_EQ(result.graphElapsedTicks, 200u);
+    EXPECT_EQ(result.publishElapsedTicks, 240u);
+    EXPECT_EQ(result.quiescence.finiteDone, 0u);
+    EXPECT_EQ(result.quiescence.finiteTimeout, 0u);
+    EXPECT_EQ(result.quiescence.infinite, 0u);
     EXPECT_EQ(ddr_.signals()[2].value, 0xDEADBEEFu);
-    EXPECT_EQ(submitter_->lastGraphSeq(), 1u);
-    EXPECT_EQ(rp1_->graphsRun(), 1u);
-
-    auto cq = submitter_->drainCq();
-    ASSERT_EQ(cq.size(), 1u);
-    EXPECT_EQ(cq[0].node_index, 0u);
-    EXPECT_EQ(cq[0].status, static_cast<std::uint32_t>(RP1_CQ_OK));
-    EXPECT_EQ(submitter_->readSignalValue(2), 0xDEADBEEFu);
-}
-
-TEST_F(SubmitterFixture, NonOkCompletionEntryIsRejected) {
-    rp1_->setCqResult(RP1_CQ_TIMEOUT, 0x1234u);
-    submitter_->submitAndWait(
-        makeSignalGraph(2, 0xDEADBEEFu),
-        std::chrono::milliseconds(500));
-
-    EXPECT_THROW(
-        {
-            auto cq = submitter_->drainCq();
-            (void)cq;
-        },
-        std::runtime_error);
-    EXPECT_EQ(ddr_.ctrl().cq_read_idx, ddr_.ctrl().cq_write_idx);
-}
-
-TEST_F(SubmitterFixture, RawDrainPreservesLaterErrorEvidence) {
-    rp1_->setCqResult(RP1_CQ_TIMEOUT, 0x1234u);
-    submitter_->submitAndWait(
-        makeSignalGraph(2, 0xDEADBEEFu),
-        std::chrono::milliseconds(500));
-
-    const auto cq = submitter_->drainCqRaw();
-    ASSERT_EQ(cq.size(), 1u);
     EXPECT_EQ(
-        cq.front().status,
-        static_cast<std::uint32_t>(RP1_CQ_TIMEOUT));
-    EXPECT_EQ(cq.front().error_detail, 0x1234u);
+        rp1_node_get_status(&ddr_.nodes()[0]),
+        RP1_NODE_PENDING);
+    EXPECT_EQ(submitter_->lastGraphSeq(), 1u);
+    EXPECT_EQ(submitter_->submissionSerial(), 1u);
+}
+
+TEST_F(SubmitterFixture, FailedResultIsReturnedWithTerminalRecord) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_FAILED;
+    spec.flags = RP1_RESULT_RECOVERY_REQUIRED |
+                 RP1_RESULT_EFFECTS_MAY_BE_PARTIAL |
+                 RP1_RESULT_UNREACHED_NODES;
+    spec.errorCode = RP1_ERR_PDI_FAILED;
+    spec.terminalNode = 4u;
+    spec.terminalOpcode = RP1_OP_PDI_LOAD;
+    spec.errorDetail = 0x1234u;
+    spec.errorAux = 0x5678u;
+    spec.imageState = RP1_IMAGE_STATE_UNKNOWN;
+    spec.quiescence = RP1_QUIESCE_PACK(3u, 0u, 0u);
+    restartFake(spec);
+
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+
+    EXPECT_EQ(result.outcome, Rp1GraphOutcome::Failed);
+    EXPECT_FALSE(result.succeeded());
+    ASSERT_TRUE(result.terminal.has_value());
+    EXPECT_EQ(result.terminal->code, RP1_ERR_PDI_FAILED);
+    EXPECT_EQ(result.terminal->node, 4u);
+    EXPECT_EQ(result.terminal->opcode,
+              static_cast<std::uint32_t>(RP1_OP_PDI_LOAD));
+    EXPECT_EQ(result.terminal->detail, 0x1234u);
+    EXPECT_EQ(result.terminal->aux, 0x5678u);
+    EXPECT_TRUE(result.hasFlags(RP1_RESULT_RECOVERY_REQUIRED));
+    EXPECT_EQ(result.imageState, Rp1ImageState::Unknown);
+    EXPECT_EQ(result.quiescence.finiteDone, 3u);
+    EXPECT_TRUE(submitter_->poisoned());
+    EXPECT_THROW(submitter_->clearSignalSlots({2u}), std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, InfiniteWorkResultPoisonsLaterSubmission) {
+    FakeResultSpec spec;
+    spec.flags = RP1_RESULT_INFINITE_WORK_REMAINS;
+    restartFake(spec);
+
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+
+    EXPECT_TRUE(result.succeeded());
+    EXPECT_TRUE(result.hasFlags(RP1_RESULT_INFINITE_WORK_REMAINS));
+    EXPECT_TRUE(submitter_->poisoned());
     EXPECT_THROW(
-        Rp1Submitter::validateCq(cq),
-        std::runtime_error);
-}
-
-TEST_F(SubmitterFixture, CompletionQueueOverflowIsRejected) {
-    submitter_->submitAndWait(
-        makeSignalGraph(2, 0xDEADBEEFu),
-        std::chrono::milliseconds(500));
-    ddr_.ctrl().cq_write_idx =
-        ddr_.ctrl().cq_write_idx +
-        vrt::graph::fpga::kDefaultCqSize + 1u;
-
-    EXPECT_THROW(
-        {
-            auto cq = submitter_->drainCq();
-            (void)cq;
-        },
-        std::runtime_error);
-}
-
-TEST_F(SubmitterFixture, CompletionQueueBackpressureDrainsIncrementally) {
-    rp1_.reset();
-    submitter_.reset();
-    primeAsReady(ddr_);
-    submitter_ = std::make_unique<Rp1Submitter>(*window_, 4u);
-    rp1_ = std::make_unique<FakeRp1>(ddr_, 4u);
-
-    rp1_cq_entry_t& canary = ddr_.cq()[4];
-    canary.node_index = 0xA1A2A3A4u;
-    canary.status = 0xB1B2B3B4u;
-    canary.error_detail = 0xC1C2C3C4u;
-    canary.timestamp = 0xD1D2D3D4u;
-
-    submitter_->submitAndWait(
-        makeNopGraph(20), std::chrono::milliseconds(500));
-    const auto cq = submitter_->drainCq();
-
-    ASSERT_EQ(cq.size(), 20u);
-    for (std::uint32_t i = 0; i < cq.size(); ++i) {
-        EXPECT_EQ(cq[i].node_index, i);
-    }
-    EXPECT_EQ(canary.node_index, 0xA1A2A3A4u);
-    EXPECT_EQ(canary.status, 0xB1B2B3B4u);
-    EXPECT_EQ(canary.error_detail, 0xC1C2C3C4u);
-    EXPECT_EQ(canary.timestamp, 0xD1D2D3D4u);
-}
-
-TEST_F(SubmitterFixture, CompletionQueueCursorWrapIsLossless) {
-    rp1_.reset();
-    submitter_.reset();
-    ddr_.ctrl().cq_write_idx =
-        std::numeric_limits<std::uint32_t>::max() - 1u;
-    ddr_.ctrl().cq_read_idx = ddr_.ctrl().cq_write_idx;
-    submitter_ = std::make_unique<Rp1Submitter>(*window_, 4u);
-    rp1_ = std::make_unique<FakeRp1>(ddr_, 4u);
-
-    submitter_->submitAndWait(
-        makeNopGraph(3), std::chrono::milliseconds(500));
-    const auto cq = submitter_->drainCq();
-
-    ASSERT_EQ(cq.size(), 3u);
-    EXPECT_EQ(cq[0].node_index, 0u);
-    EXPECT_EQ(cq[1].node_index, 1u);
-    EXPECT_EQ(cq[2].node_index, 2u);
-    EXPECT_EQ(ddr_.ctrl().cq_write_idx, 1u);
-    EXPECT_EQ(ddr_.ctrl().cq_read_idx, 1u);
-}
-
-TEST_F(SubmitterFixture, GraphSequenceWrapUsesEquality) {
-    rp1_.reset();
-    submitter_.reset();
-    ddr_.ctrl().graph_seq = std::numeric_limits<std::uint32_t>::max();
-    ddr_.ctrl().graph_done_seq = ddr_.ctrl().graph_seq;
-    submitter_ = std::make_unique<Rp1Submitter>(*window_);
-    rp1_ = std::make_unique<FakeRp1>(
-        ddr_, vrt::graph::fpga::kDefaultCqSize);
-
-    submitter_->submitAndWait(
-        makeNopGraph(1), std::chrono::milliseconds(500));
-    EXPECT_EQ(submitter_->lastGraphSeq(), 0u);
-    EXPECT_EQ(ddr_.ctrl().graph_done_seq, 0u);
-    EXPECT_EQ(submitter_->drainCq().size(), 1u);
-}
-
-TEST_F(SubmitterFixture, TraceDisabledByDefaultDrainsEmpty) {
-    auto img = makeSignalGraph(/*slot*/ 2, /*value*/ 0xDEADBEEFu);
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    auto trace = submitter_->drainTrace();
-    EXPECT_EQ(trace.written, 0u);
-    EXPECT_FALSE(trace.overflow);
-    EXPECT_TRUE(trace.entries.empty());
-}
-
-TEST_F(SubmitterFixture, DiamondImageEmitsFiveCqEntries) {
-    auto img = makeDiamondImage();
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    EXPECT_EQ(ddr_.signals()[0].value, 0xD1A1D0DDu);
-
-    auto cq = submitter_->drainCq();
-    ASSERT_EQ(cq.size(), 5u);
-    for (std::uint32_t i = 0; i < 5; ++i) {
-        EXPECT_EQ(cq[i].node_index, i) << "CQ entry " << i;
-        EXPECT_EQ(cq[i].status, static_cast<std::uint32_t>(RP1_CQ_OK));
-    }
-    EXPECT_EQ(submitter_->lastCqStart() - cq.size(), 0u);
-}
-
-TEST_F(SubmitterFixture, TraceEnabledCapturesGraphEventsAndPreservesCq) {
-    auto img = makeDiamondImage();
-    img.trace_enable = true;
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    auto trace = submitter_->drainTrace();
-    ASSERT_FALSE(trace.overflow);
-    ASSERT_EQ(trace.written, trace.entries.size());
-    ASSERT_GE(trace.entries.size(), 2u);
-    EXPECT_EQ(trace.entries.front().event, static_cast<std::uint16_t>(RP1_TRACE_GRAPH_START));
-    EXPECT_EQ(trace.entries.front().node_index, 0xFFFFu);
-    EXPECT_EQ(trace.entries.back().event, static_cast<std::uint16_t>(RP1_TRACE_GRAPH_DONE));
-
-    std::uint32_t launch_count = 0;
-    std::uint32_t done_count = 0;
-    for (const auto& e : trace.entries) {
-        if (e.event == RP1_TRACE_KERNEL_LAUNCH) ++launch_count;
-        if (e.event == RP1_TRACE_KERNEL_DONE) ++done_count;
-    }
-    EXPECT_EQ(launch_count, 4u);
-    EXPECT_EQ(done_count, 4u);
-
-    auto cq = submitter_->drainCq();
-    ASSERT_EQ(cq.size(), 5u);
-    EXPECT_EQ(cq[0].status, static_cast<std::uint32_t>(RP1_CQ_OK));
-}
-
-TEST_F(SubmitterFixture, TinyTraceRingReportsOverflow) {
-    auto img = makeDiamondImage();
-    img.trace_enable = true;
-    img.trace_size_override = 4;
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    auto trace = submitter_->drainTrace();
-    EXPECT_TRUE(trace.overflow);
-    EXPECT_GT(trace.written, trace.entries.size());
-    ASSERT_EQ(trace.entries.size(), 4u);
-    EXPECT_EQ(trace.entries.back().event, static_cast<std::uint16_t>(RP1_TRACE_GRAPH_DONE));
-}
-
-TEST_F(SubmitterFixture, SilentNodesDoNotProduceCqEntries) {
-    auto img = makeSignalGraph(/*slot*/ 1, /*value*/ 0xCAFEBABE);
-    img.nodes[0].flags |= RP1_FLAG_SILENT;
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    auto cq = submitter_->drainCq();
-    EXPECT_TRUE(cq.empty());
-    EXPECT_EQ(ddr_.signals()[1].value, 0xCAFEBABE);
-}
-
-TEST_F(SubmitterFixture,
-       BackToBackSubmissionsRetainOnlyLatestCqEvidence) {
-    submitter_->submitAndWait(makeSignalGraph(0, 0x1111), std::chrono::milliseconds(500));
-    submitter_->submitAndWait(makeSignalGraph(0, 0x2222), std::chrono::milliseconds(500));
-    submitter_->submitAndWait(makeSignalGraph(0, 0x3333), std::chrono::milliseconds(500));
-
-    EXPECT_EQ(submitter_->lastGraphSeq(), 3u);
-    EXPECT_EQ(rp1_->graphsRun(), 3u);
-    EXPECT_EQ(ddr_.signals()[0].value, 0x3333u);
-
-    auto cq = submitter_->drainCq();
-    ASSERT_EQ(cq.size(), 1u);
-    EXPECT_EQ(cq.front().node_index, 0u);
-}
-
-TEST_F(SubmitterFixture, ArgBufferIsStaged) {
-    Rp1GraphImage img;
-    img.arg_buf = {0x11, 0x22, 0x33, 0x44};
-    img.nodes.resize(1);
-    auto& n = img.nodes[0];
-    n.opcode               = RP1_OP_KERNEL_DISPATCH;
-    n.flags                = 0;
-    n.barrier_await_mask   = 0;
-    n.barrier_set_mask     = 0x1;
-    n.barrier_await_bucket = 0;
-    n.barrier_set_bucket   = 0;
-    n.payload.kernel_dispatch.kernel_base_addr  = 0x88010000u;
-    n.payload.kernel_dispatch.arg_buffer_offset = 0;
-    n.payload.kernel_dispatch.arg_count         = 2;
-
-    submitter_->submitAndWait(img, std::chrono::milliseconds(500));
-
-    auto* args = ddr_.args();
-    EXPECT_EQ(args[0], 0x11u);
-    EXPECT_EQ(args[1], 0x22u);
-    EXPECT_EQ(args[2], 0x33u);
-    EXPECT_EQ(args[3], 0x44u);
-}
-
-TEST_F(SubmitterFixture, FirmwareErrorIsSurfacedAfterSubmission) {
-    // Stop the fake firmware and stamp an ERROR state.  Submitter
-    // should observe it after timing out (or, if graph_done_seq has
-    // already been bumped, immediately on next status check).
-    rp1_.reset();
-
-    submitter_->ensureReady(std::chrono::milliseconds(500));
-    // After ensureReady, fake state is READY but with no worker; set
-    // it to ERROR and pre-bump graph_done_seq so submitAndWait returns
-    // and then inspects the state.
-    ddr_.ctrl().graph_done_seq = ddr_.ctrl().graph_seq + 1;
-    ddr_.ctrl().rp1_state      = RP1_STATE_ERROR;
-    ddr_.ctrl().rp1_error_code = 1;  // ERR_INFLIGHT_FULL
-
-    auto img = makeSignalGraph(/*slot*/ 0, /*value*/ 0xDEADBEEFu);
-    EXPECT_THROW(submitter_->submitAndWait(img, std::chrono::milliseconds(100)),
-                 std::runtime_error);
-}
-
-TEST_F(SubmitterFixture, TerminalErrorSurfacesBeforeDoneWithFullRecord) {
-    rp1_->setCqResult(RP1_CQ_ERROR, 0x80002001u);
-    rp1_->setTerminalResult(
-        RP1_STATE_ERROR,
-        RP1_ERR_PDI_FAILED | RP1_ERR_RECOVERY_REQUIRED,
-        0u, 0x80002001u, 0xDEADCAFEu,
-        std::chrono::milliseconds(200));
-
-    try {
         submitter_->submitAndWait(
-            makeSignalGraph(2, 0xDEADBEEFu),
-            std::chrono::milliseconds(500));
-        FAIL() << "terminal firmware error was not surfaced";
-    } catch (const std::runtime_error& error) {
-        const std::string message = error.what();
-        EXPECT_NE(message.find("node=0"), std::string::npos);
-        EXPECT_NE(message.find("detail=2147491841"), std::string::npos);
-        EXPECT_NE(message.find("aux=3735931646"), std::string::npos);
-        EXPECT_NE(message.find("recovery_required=1"), std::string::npos);
-    }
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
 
-    EXPECT_EQ(ddr_.ctrl().rp1_state, RP1_STATE_ERROR);
-    EXPECT_NE(ddr_.ctrl().graph_done_seq, submitter_->lastGraphSeq())
-        << "host should observe terminal state before delayed done publication";
-    const auto evidence = submitter_->drainCqRaw();
-    ASSERT_EQ(evidence.size(), 1u);
-    EXPECT_EQ(evidence[0].error_detail, 0x80002001u);
+TEST_F(SubmitterFixture, FiniteTimeoutEvidencePoisonsWithoutHazardFlag) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_FAILED;
+    spec.errorCode = RP1_ERR_KERNEL_TIMEOUT;
+    spec.terminalNode = 0u;
+    spec.terminalOpcode = RP1_OP_KERNEL_DISPATCH;
+    spec.quiescence = RP1_QUIESCE_PACK(0u, 1u, 0u);
+    restartFake(spec);
 
     EXPECT_THROW(
         submitter_->submitAndWait(
-            makeSignalGraph(2, 1u), std::chrono::milliseconds(50)),
+            makeSignalGraph(), std::chrono::milliseconds(500)),
         std::runtime_error);
-    EXPECT_EQ(rp1_->graphsRun(), 0u)
-        << "terminal fake firmware has not accepted a later graph";
-}
-
-TEST_F(SubmitterFixture, NoCompletionTimesOut) {
-    rp1_.reset();  // no worker → graph_done_seq stays put forever
-    auto img = makeSignalGraph(/*slot*/ 0, /*value*/ 0xDEADBEEFu);
-    EXPECT_THROW(submitter_->submitAndWait(img, std::chrono::milliseconds(30)),
-                 Rp1TimeoutError);
     EXPECT_TRUE(submitter_->poisoned());
 }
 
-TEST_F(SubmitterFixture, OverlappingSubmissionIsRejected) {
-    rp1_.reset();
-    auto first = std::async(
-        std::launch::async, [&] {
-            submitter_->submitAndWait(
-                makeSignalGraph(0, 0x1111u),
-                std::chrono::milliseconds(200));
-        });
-
-    const auto deadline =
-        std::chrono::steady_clock::now() +
-        std::chrono::seconds(1);
-    while (submitter_->submissionSerial() == 0u &&
-           std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::yield();
-    }
-    ASSERT_EQ(submitter_->submissionSerial(), 1u);
-
-    try {
-        submitter_->submitAndWait(
-            makeSignalGraph(0, 0x2222u),
-            std::chrono::milliseconds(30));
-        FAIL() << "overlapping submission was accepted";
-    } catch (const std::runtime_error& error) {
-        EXPECT_NE(
-            std::string(error.what()).find(
-                "submission is already active"),
-            std::string::npos);
-    }
-    EXPECT_THROW(first.get(), Rp1TimeoutError);
-}
-
-TEST_F(SubmitterFixture,
-       LateCqAfterTimeoutCannotCrossSubmissionBoundary) {
-    rp1_.reset();
-    auto first =
-        makeSignalGraph(/*slot*/ 0, /*value*/ 0x1111u);
-    EXPECT_THROW(
-        submitter_->submitAndWait(
-            first, std::chrono::milliseconds(30)),
-        Rp1TimeoutError);
-    ASSERT_TRUE(submitter_->poisoned());
-    const std::uint32_t timedOutSequence =
-        ddr_.ctrl().graph_seq;
-
-    const std::uint32_t write = ddr_.ctrl().cq_write_idx;
-    rp1_cq_entry_t& late =
-        ddr_.cq()[write &
-                  (vrt::graph::fpga::kDefaultCqSize - 1u)];
-    late.node_index = 0u;
-    late.status = RP1_CQ_OK;
-    late.error_detail = 0xA11CEu;
-    late.timestamp = 1234u;
-    ddr_.ctrl().cq_write_idx = write + 1u;
+TEST_F(SubmitterFixture, InfiniteQuiescenceRequiresBothHazardFlags) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_FAILED;
+    spec.errorCode = RP1_ERR_KERNEL_TIMEOUT;
+    spec.terminalNode = 0u;
+    spec.terminalOpcode = RP1_OP_KERNEL_DISPATCH;
+    spec.flags = RP1_RESULT_RECOVERY_REQUIRED;
+    spec.quiescence = RP1_QUIESCE_PACK(0u, 0u, 1u);
+    restartFake(spec);
 
     EXPECT_THROW(
         submitter_->submitAndWait(
-            makeSignalGraph(0, 0x2222u),
-            std::chrono::milliseconds(30)),
+            makeSignalGraph(), std::chrono::milliseconds(500)),
         std::runtime_error);
-    EXPECT_EQ(ddr_.ctrl().graph_seq, timedOutSequence)
-        << "a poisoned submitter must not ring a second doorbell";
-
-    const auto evidence = submitter_->drainCqRaw();
-    ASSERT_EQ(evidence.size(), 1u);
-    EXPECT_EQ(evidence.front().error_detail, 0xA11CEu);
+    EXPECT_TRUE(submitter_->poisoned());
 }
 
-TEST_F(SubmitterFixture, TooManyNodesIsRejected) {
-    submitter_->ensureReady(std::chrono::milliseconds(500));
-    Rp1GraphImage img;
-    img.nodes.resize(RP1_MAX_NODES + 1);
-    for (auto& n : img.nodes) {
-        n.opcode = RP1_OP_NOP;
-        n.status = RP1_NODE_PENDING;
-    }
-    EXPECT_THROW(submitter_->submitAndWait(img), std::logic_error);
+TEST_F(SubmitterFixture, HaltedResultIsReturnedWithHaltNode) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_HALTED;
+    spec.terminalNode = 2u;
+    spec.terminalOpcode = RP1_OP_HALT;
+    restartFake(spec);
+
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+
+    EXPECT_EQ(result.outcome, Rp1GraphOutcome::Halted);
+    ASSERT_TRUE(result.terminal.has_value());
+    EXPECT_EQ(result.terminal->code, 0u);
+    EXPECT_EQ(result.terminal->node, 2u);
+    EXPECT_EQ(result.terminal->opcode,
+              static_cast<std::uint32_t>(RP1_OP_HALT));
 }
 
-TEST_F(SubmitterFixture, EverySignalBearingPacketValidatesItsSlot) {
-    const std::vector<std::uint16_t> opcodes = {
-        RP1_OP_SIGNAL,
-        RP1_OP_WAIT,
-        RP1_OP_SCALAR_READ,
-        RP1_OP_SCALAR_COPY,
-        RP1_OP_LOOP,
-        RP1_OP_COND,
-    };
-    for (std::uint16_t opcode : opcodes) {
-        Rp1GraphImage img;
-        img.nodes.resize(1);
-        rp1_node_t& node = img.nodes[0];
-        node.opcode = opcode;
-        node.status = RP1_NODE_PENDING;
-        switch (opcode) {
-            case RP1_OP_SIGNAL:
-                node.payload.signal.target_slot = RP1_MAX_SIGNALS;
-                node.payload.signal.operation = RP1_SIGOP_SET;
-                break;
-            case RP1_OP_WAIT:
-                node.payload.wait.condition_signal = RP1_MAX_SIGNALS;
-                node.payload.wait.condition_op = RP1_COP_EQ;
-                break;
-            case RP1_OP_SCALAR_READ:
-                node.payload.scalar_read.target_slot = RP1_MAX_SIGNALS;
-                break;
-            case RP1_OP_SCALAR_COPY:
-                node.payload.scalar_copy.source_slot = RP1_MAX_SIGNALS;
-                break;
-            case RP1_OP_LOOP:
-                node.payload.loop.condition_signal = RP1_MAX_SIGNALS;
-                node.payload.loop.condition_op = RP1_COP_EQ;
-                node.payload.loop.body_start = 0;
-                node.payload.loop.body_end = 0;
-                break;
-            case RP1_OP_COND:
-                node.payload.cond.condition_signal = RP1_MAX_SIGNALS;
-                node.payload.cond.condition_op = RP1_COP_EQ;
-                node.payload.cond.body_start = 1;
-                node.payload.cond.body_end = 0;
-                node.payload.cond.bucket_clear_start = 1;
-                node.payload.cond.bucket_clear_end = 0;
-                break;
-            default:
-                break;
-        }
-        EXPECT_THROW(
-            submitter_->submitAndWait(
-                img, std::chrono::milliseconds(50)),
-            std::logic_error)
-            << "opcode " << opcode;
-    }
-    EXPECT_EQ(rp1_->graphsRun(), 0u);
+TEST_F(SubmitterFixture, TerminalStateDoesNotBeatDelayedDonePublication) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_FAILED;
+    spec.errorCode = RP1_ERR_KERNEL_TIMEOUT;
+    spec.terminalNode = 0u;
+    spec.terminalOpcode = RP1_OP_KERNEL_DISPATCH;
+    spec.doneDelay = std::chrono::milliseconds(50);
+    restartFake(spec);
+
+    const auto start = std::chrono::steady_clock::now();
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(result.outcome, Rp1GraphOutcome::Failed);
+    EXPECT_GE(
+        elapsed,
+        std::chrono::milliseconds(40));
 }
 
-TEST_F(SubmitterFixture, SilentPdiIsRejectedWithoutActivation) {
-    Rp1GraphImage img;
-    img.nodes.resize(1);
-    img.nodes[0].opcode = RP1_OP_PDI_LOAD;
-    img.nodes[0].flags = RP1_FLAG_SILENT;
-    img.nodes[0].status = RP1_NODE_PENDING;
-    EXPECT_THROW(submitter_->submitAndWait(img), std::logic_error);
-    EXPECT_EQ(rp1_->graphsRun(), 0u);
+TEST_F(SubmitterFixture, SequenceWrapUsesExactEquality) {
+    ddr_.ctrl().graph_seq =
+        std::numeric_limits<std::uint32_t>::max();
+    ddr_.ctrl().graph_done_seq =
+        std::numeric_limits<std::uint32_t>::max();
+
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+
+    EXPECT_EQ(result.sequence, 0u);
+    EXPECT_EQ(ddr_.ctrl().graph_done_seq, 0u);
+    EXPECT_EQ(submitter_->lastGraphSeq(), 0u);
 }
 
-TEST_F(SubmitterFixture, OversizeCqOverrideIsRejected) {
-    auto img = makeSignalGraph(0, 1u);
-    img.cq_size_override = RP1_MAX_CQ_ENTRIES * 2u;
-    EXPECT_THROW(submitter_->submitAndWait(img), std::invalid_argument);
-}
+TEST_F(SubmitterFixture, HostTimeoutPoisonsAllLaterMutation) {
+    fake_.reset();
 
-TEST(Rp1SubmitterCtor, NonPowerOfTwoCqSizeIsRejected) {
-    std::vector<std::byte> backing(kBarSize, std::byte{0});
-    Rp1BarWindow window(backing.data(), backing.size(), kWindowOff);
-    EXPECT_THROW(Rp1Submitter(window, /*cq_size*/ 5), std::invalid_argument);
-    EXPECT_THROW(Rp1Submitter(window, /*cq_size*/ 0), std::invalid_argument);
     EXPECT_THROW(
-        Rp1Submitter(window, /*cq_size*/ RP1_MAX_CQ_ENTRIES + 1u),
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(20)),
+        Rp1TimeoutError);
+    EXPECT_TRUE(submitter_->poisoned());
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(20)),
+        std::runtime_error);
+    EXPECT_THROW(
+        submitter_->clearSignalSlots({2u}),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, CorruptResultMagicIsRejected) {
+    FakeResultSpec spec;
+    spec.magic = 0u;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+    EXPECT_FALSE(submitter_->poisoned());
+}
+
+TEST_F(SubmitterFixture, StaleResultSequenceIsRejected) {
+    FakeResultSpec spec;
+    spec.resultSequence = 99u;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, NonTerminalOutcomeIsRejected) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_NONE;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, OutcomeAndTerminalStateMustAgree) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_SUCCESS;
+    spec.terminalState = RP1_STATE_ERROR;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, InvalidImageStateIsRejected) {
+    FakeResultSpec spec;
+    spec.imageState = 99u;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, KnownImageRequiresNonzeroId) {
+    FakeResultSpec spec;
+    spec.imageState = RP1_IMAGE_STATE_KNOWN;
+    spec.activeImageId = 0u;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, NonKnownImageRejectsActiveId) {
+    FakeResultSpec spec;
+    spec.imageState = RP1_IMAGE_STATE_UNKNOWN;
+    spec.activeImageId = 1u;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, SuccessCannotCarryTerminalErrorCode) {
+    FakeResultSpec spec;
+    spec.errorCode = RP1_ERR_INVALID_NODE;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, SuccessCannotRequireRecovery) {
+    FakeResultSpec spec;
+    spec.flags = RP1_RESULT_RECOVERY_REQUIRED;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+    EXPECT_TRUE(submitter_->poisoned());
+}
+
+TEST_F(SubmitterFixture, SuccessPreservesUnreachedNodesFlag) {
+    FakeResultSpec spec;
+    spec.flags = RP1_RESULT_UNREACHED_NODES;
+    restartFake(spec);
+    const auto result = submitter_->submitAndWait(
+        makeSignalGraph(), std::chrono::milliseconds(500));
+    EXPECT_TRUE(result.succeeded());
+    EXPECT_TRUE(result.hasFlags(RP1_RESULT_UNREACHED_NODES));
+}
+
+TEST_F(SubmitterFixture, FailedOutcomeRequiresErrorCode) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_FAILED;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, HaltedOutcomeRequiresHaltOpcode) {
+    FakeResultSpec spec;
+    spec.outcome = RP1_GRAPH_RESULT_HALTED;
+    spec.terminalNode = 0u;
+    spec.terminalOpcode = RP1_OP_NOP;
+    restartFake(spec);
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+}
+
+TEST_F(SubmitterFixture, OverlappingSubmissionIsRejected) {
+    FakeResultSpec spec;
+    spec.doneDelay = std::chrono::milliseconds(75);
+    restartFake(spec);
+
+    auto first = std::async(std::launch::async, [this] {
+        return submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500));
+    });
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+    while (ddr_.ctrl().graph_seq == 0u &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_THROW(
+        submitter_->submitAndWait(
+            makeSignalGraph(), std::chrono::milliseconds(500)),
+        std::runtime_error);
+    EXPECT_TRUE(first.get().succeeded());
+}
+
+TEST_F(SubmitterFixture, EmptyGraphIsRejectedBeforeDoorbell) {
+    Rp1GraphImage image;
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+    EXPECT_EQ(submitter_->submissionSerial(), 0u);
+}
+
+TEST_F(SubmitterFixture, Exactly1024NodesAreAccepted) {
+    static_assert(RP1_MAX_NODES == 1024u);
+    Rp1GraphImage image;
+    image.nodes.resize(RP1_MAX_NODES);
+
+    const auto result = submitter_->submitAndWait(
+        image, std::chrono::milliseconds(500));
+
+    EXPECT_TRUE(result.succeeded());
+    EXPECT_EQ(ddr_.ctrl().node_count, 1024u);
+}
+
+TEST_F(SubmitterFixture, GraphWith1025NodesIsRejectedBeforeDoorbell) {
+    static_assert(RP1_MAX_NODES == 1024u);
+    Rp1GraphImage image;
+    image.nodes.resize(1025u);
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, AllProtocolV6OpcodesStageWithCompactPayloads) {
+    constexpr rp1_opcode_t opcodes[] = {
+        RP1_OP_NOP, RP1_OP_WAIT, RP1_OP_SIGNAL,
+        RP1_OP_KERNEL_DISPATCH, RP1_OP_SCALAR_WRITE,
+        RP1_OP_SCALAR_READ, RP1_OP_SCALAR_COPY, RP1_OP_DMA_COPY,
+        RP1_OP_DMA_FILL, RP1_OP_PDI_LOAD, RP1_OP_LOOP, RP1_OP_COND,
+        RP1_OP_RERUN, RP1_OP_HALT};
+    Rp1GraphImage image;
+    image.nodes.resize(std::size(opcodes));
+    for (std::size_t i = 0; i < std::size(opcodes); ++i) {
+        rp1_node_set_opcode(&image.nodes[i], opcodes[i]);
+        rp1_node_set_status(&image.nodes[i], RP1_NODE_PENDING);
+    }
+
+    image.nodes[1].payload.wait.condition_signal = 255u;
+    image.nodes[1].payload.wait.condition_op = RP1_COP_EQ;
+    image.nodes[2].payload.signal.target_slot = 254u;
+    image.nodes[2].payload.signal.operation = RP1_SIGOP_SET;
+    image.nodes[3].payload.kernel_dispatch.kernel_base_addr =
+        0x88010000u;
+    image.nodes[3].payload.kernel_dispatch.arg_count = 1u;
+    image.arg_buf = {0x10u, 0x1234u};
+    image.nodes[4].payload.scalar_write.writes[0] =
+        rp1_write_pair_t{0x88010010u, 7u};
+    image.nodes[5].payload.scalar_read.source_addr = 0x88010010u;
+    image.nodes[5].payload.scalar_read.target_slot = 253u;
+    image.nodes[6].payload.scalar_copy.dest_addr = 0x88020010u;
+    image.nodes[6].payload.scalar_copy.source_slot = 253u;
+    image.nodes[7].payload.dma_copy.length_types =
+        rp1_dma_pack(4096u, 0u, 0u);
+    image.nodes[8].payload.dma_fill.length = 4u;
+    image.nodes[10].payload.loop.body_start = 0u;
+    image.nodes[10].payload.loop.body_end = 0u;
+    image.nodes[10].payload.loop.condition_signal = 252u;
+    image.nodes[10].payload.loop.condition_op = RP1_COP_AND_Z;
+    image.nodes[11].payload.cond.body_start = 1u;
+    image.nodes[11].payload.cond.body_end = 0u;
+    image.nodes[11].payload.cond.condition_signal = 251u;
+    image.nodes[11].payload.cond.condition_op = RP1_COP_NE;
+    image.nodes[11].payload.cond.bucket_clear_start = 1u;
+    image.nodes[11].payload.cond.bucket_clear_end = 0u;
+    image.nodes[12].payload.rerun.target_node = 0u;
+
+    EXPECT_NO_THROW(
+        submitter_->submitAndWait(
+            image, std::chrono::milliseconds(500)));
+    ASSERT_EQ(ddr_.ctrl().node_count, std::size(opcodes));
+    for (std::size_t i = 0; i < std::size(opcodes); ++i) {
+        EXPECT_EQ(rp1_node_get_opcode(&ddr_.nodes()[i]), opcodes[i]);
+    }
+    EXPECT_EQ(ddr_.nodes()[1].payload.wait.condition_signal, 255u);
+    EXPECT_EQ(ddr_.nodes()[10].payload.loop.body_end, 0u);
+    EXPECT_EQ(
+        rp1_dma_get_length(
+            ddr_.nodes()[7].payload.dma_copy.length_types),
+        4096u);
+}
+
+TEST_F(SubmitterFixture, ScalarWritesSplitWithoutDroppingPairs) {
+    const std::vector<rp1_write_pair_t> writes = {
+        {0x88010010u, 1u}, {0x88010014u, 2u},
+        {0x88010018u, 3u}, {0x8801001Cu, 4u},
+        {0x88010020u, 5u}};
+    Rp1GraphImage image;
+    appendScalarWritePackets(
+        image, writes, /*awaitBucket=*/2u, /*awaitMask=*/0x10u,
+        /*setBucket=*/3u, /*setMask=*/0x20u);
+
+    ASSERT_EQ(image.nodes.size(), 3u);
+    std::vector<rp1_write_pair_t> lowered;
+    for (std::size_t i = 0; i < image.nodes.size(); ++i) {
+        const rp1_node_t& node = image.nodes[i];
+        EXPECT_EQ(rp1_node_get_opcode(&node), RP1_OP_SCALAR_WRITE);
+        EXPECT_EQ(node.barrier_await_bucket, 2u);
+        EXPECT_EQ(node.barrier_await_mask, 0x10u);
+        EXPECT_EQ(node.barrier_set_mask, i == 2u ? 0x20u : 0u);
+        for (const rp1_write_pair_t& write :
+             node.payload.scalar_write.writes) {
+            if (write.addr != 0u) lowered.push_back(write);
+        }
+    }
+    ASSERT_EQ(lowered.size(), writes.size());
+    for (std::size_t i = 0; i < writes.size(); ++i) {
+        EXPECT_EQ(lowered[i].addr, writes[i].addr);
+        EXPECT_EQ(lowered[i].value, writes[i].value);
+    }
+    EXPECT_NO_THROW(
+        submitter_->submitAndWait(
+            image, std::chrono::milliseconds(500)));
+}
+
+TEST_F(SubmitterFixture, OversizedArgumentBufferIsRejectedBeforeBarMutation) {
+    auto image = makeSignalGraph();
+    constexpr std::size_t capacityWords =
+        (RP1_DEFAULT_SIG_ARRAY_OFFSET - RP1_DEFAULT_ARG_BUF_OFFSET) /
+        sizeof(std::uint32_t);
+    image.arg_buf.resize(capacityWords + 1u, 0xA5A5A5A5u);
+    ddr_.ctrl()._reserved_cq_size = 0x55u;
+    ddr_.args()[0] = 0x12345678u;
+
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+    EXPECT_EQ(ddr_.ctrl()._reserved_cq_size, 0x55u);
+    EXPECT_EQ(ddr_.args()[0], 0x12345678u);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+    EXPECT_EQ(submitter_->submissionSerial(), 0u);
+}
+
+TEST_F(SubmitterFixture, InvalidBarrierBucketIsRejected) {
+    auto image = makeSignalGraph();
+    image.nodes.front().barrier_set_bucket = RP1_MAX_BUCKETS;
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, NonPendingInitialStatusIsRejected) {
+    auto image = makeSignalGraph();
+    rp1_node_set_status(&image.nodes.front(), RP1_NODE_DONE);
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, HighestPackedSignalSlotIsAccepted) {
+    auto image = makeSignalGraph();
+    image.nodes.front().payload.signal.target_slot =
+        static_cast<std::uint8_t>(RP1_MAX_SIGNALS - 1u);
+    EXPECT_NO_THROW(
+        submitter_->submitAndWait(
+            image, std::chrono::milliseconds(500)));
+}
+
+TEST_F(SubmitterFixture, InvalidClearSlotIsRejected) {
+    auto image = makeSignalGraph();
+    image.clear_signal_slots.push_back(RP1_MAX_SIGNALS);
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, InvalidTraceSizeIsRejectedBeforeDoorbell) {
+    auto image = makeSignalGraph();
+    image.trace_size_override = 3u;
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
         std::invalid_argument);
-    EXPECT_NO_THROW(Rp1Submitter(window, /*cq_size*/ 64));
-    EXPECT_NO_THROW(Rp1Submitter(window, RP1_MAX_CQ_ENTRIES));
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, ReservedNodeFlagsAreRejectedByHostValidation) {
+    auto image = makeSignalGraph();
+    rp1_node_set_flags(&image.nodes.front(), 0x2u);
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, ReservedControlBitsAreRejectedByHostValidation) {
+    auto image = makeSignalGraph();
+    rp1_node_set_control(
+        &image.nodes.front(),
+        rp1_node_get_control(&image.nodes.front()) |
+            RP1_NODE_RESERVED_MASK);
+    EXPECT_THROW(
+        submitter_->submitAndWait(image),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, Phase1DmaCopyRejectsUnsupportedEndpoints) {
+    auto image = makeOpcodeGraph(RP1_OP_DMA_COPY);
+    auto& dma = image.nodes.front().payload.dma_copy;
+    dma.src_addr_lo = 0x1000u;
+    dma.dst_addr_lo = 0x2000u;
+    dma.length_types = rp1_dma_pack(8u, 0u, 0u);
+
+    dma.src_addr_hi = 1u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    dma.src_addr_hi = 0u;
+
+    dma.length_types = rp1_dma_pack(8u, 1u, 0u);
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    dma.length_types = rp1_dma_pack(8u, 0u, 0u);
+
+    dma.src_addr_lo = 0xFFFFFFFCu;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    dma.src_addr_lo = 0x1002u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, Phase1DmaFillRejectsUnsupportedEndpoint) {
+    auto image = makeOpcodeGraph(RP1_OP_DMA_FILL);
+    auto& dma = image.nodes.front().payload.dma_fill;
+    dma.dst_addr_lo = 0x2000u;
+    dma.length = 8u;
+
+    dma.dst_addr_hi = 1u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    dma.dst_addr_hi = 0u;
+
+    dma.dst_type = 1u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    dma.dst_type = 0u;
+
+    dma.dst_addr_lo = 0xFFFFFFFCu;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, DispatchControlFlagsAreRejected) {
+    auto image = makeOpcodeGraph(RP1_OP_KERNEL_DISPATCH);
+    auto& dispatch = image.nodes.front().payload.kernel_dispatch;
+    dispatch.kernel_base_addr = 0x88010000u;
+    dispatch.ctrl_flags = 1u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, UnknownRerunFlagsAreRejected) {
+    auto image = makeOpcodeGraph(RP1_OP_RERUN);
+    image.nodes.front().payload.rerun.target_node = 0u;
+    image.nodes.front().payload.rerun.rerun_flags = 0x2u;
+    EXPECT_THROW(submitter_->submitAndWait(image), std::logic_error);
+    EXPECT_EQ(ddr_.ctrl().graph_seq, 0u);
+}
+
+TEST_F(SubmitterFixture, TraceCaptureUsesFinalProducerCursor) {
+    auto image = makeSignalGraph();
+    image.trace_enable = true;
+    image.trace_size_override = 8u;
+
+    const auto result = submitter_->submitAndWait(
+        image, std::chrono::milliseconds(500));
+    const auto trace = submitter_->drainTrace();
+
+    EXPECT_TRUE(result.hasFlags(RP1_RESULT_TRACE_ENABLED));
+    EXPECT_EQ(result.traceWriteIndex, 1u);
+    EXPECT_EQ(trace.written, 1u);
+    EXPECT_FALSE(trace.overflow);
+    ASSERT_EQ(trace.entries.size(), 1u);
+    EXPECT_EQ(trace.entries.front().event,
+              static_cast<std::uint16_t>(RP1_TRACE_GRAPH_DONE));
+}
+
+TEST_F(SubmitterFixture, ClearAndReadSignalHelpersRetainBoundsChecks) {
+    ddr_.signals()[3].value = 42u;
+    submitter_->clearSignalSlots({3u});
+    EXPECT_EQ(submitter_->readSignalValue(3u), 0u);
+    EXPECT_THROW(
+        submitter_->readSignalValue(RP1_MAX_SIGNALS),
+        std::logic_error);
+}
+
+TEST_F(SubmitterFixture, ClearSignalSlotsValidatesBeforeMutation) {
+    ddr_.signals()[2].value = 0xA5A5A5A5u;
+    EXPECT_THROW(
+        submitter_->clearSignalSlots({2u, RP1_MAX_SIGNALS}),
+        std::logic_error);
+    EXPECT_EQ(ddr_.signals()[2].value, 0xA5A5A5A5u);
 }


### PR DESCRIPTION
## Summary

Add the RP1 fixes, optimizations, and measurement tools developed after the initial Graph API merge.

## Changes

This change improves RP1 completion reporting and error diagnostics, reduces firmware scheduling overhead, and fixes sparse IPI dispatch in the custom PLM. It also adds latency benchmarks and acceptance tooling for measuring RP1 execution and comparing it with the host-driven VRT path.

The firmware and host runtime move together to protocol v6. Dense graphs that exceed the optimized scheduler's TCM capacity continue to use the existing scanner fallback.

## Draft

The changes were tested, but have been cherry-picked into the pr branch and need to be tested again.