### PR TITLE
vrtd headers: Check for __STDC_VERSION_STDBIT_H__ when importing stdbit.h

### DIFF
--- a/vrt/vrtd/src/utils.h
+++ b/vrt/vrtd/src/utils.h
@@ -104,7 +104,7 @@ void vrtd_log(int priority, const char *fmt, ...)
  */
 const char *uid_to_username(uid_t uid, char *buf, size_t bufsz);
 
-#if defined(__has_include)
+#if !defined(__cplusplus) && defined(__has_include)
 #  if __has_include(<stdbit.h>)
 #    include <stdbit.h>
 #    define HAVE_STDBIT 1

--- a/vrt/vrtd/src/utils.h
+++ b/vrt/vrtd/src/utils.h
@@ -136,7 +136,7 @@ static inline uint64_t bit_ceil_u64(uint64_t n) {
  * @return Smallest power of two >= n, or 0 if not representable.
  */
 static inline uint32_t bit_ceil_u32(uint32_t n) {
-    if (n == 0) return 1u;
+    if (n <= 1) return 1u;
     if (n > 0x80000000u) return 0u;                 // not representable
     return 1u << (32 - __builtin_clz(n - 1));       // GCC/Clang
 }
@@ -146,7 +146,7 @@ static inline uint32_t bit_ceil_u32(uint32_t n) {
  * @return Smallest power of two >= n, or 0 if not representable.
  */
 static inline uint64_t bit_ceil_u64(uint64_t n) {
-    if (n == 0) return 1ull;
+    if (n <= 1) return 1ull;
     if (n > 0x8000000000000000ull) return 0ull;     // not representable
     return 1ull << (64 - __builtin_clzll(n - 1));
 }

--- a/vrt/vrtd/src/utils.h
+++ b/vrt/vrtd/src/utils.h
@@ -104,10 +104,15 @@ void vrtd_log(int priority, const char *fmt, ...)
  */
 const char *uid_to_username(uid_t uid, char *buf, size_t bufsz);
 
-#if !defined(__cplusplus) && defined(__has_include)
+#define HAVE_STDBIT 0
+
+#if defined(__has_include)
 #  if __has_include(<stdbit.h>)
 #    include <stdbit.h>
-#    define HAVE_STDBIT 1
+#    if defined(__STDC_VERSION_STDBIT_H__) && __STDC_VERSION_STDBIT_H__ >= 202311L
+#      undef HAVE_STDBIT
+#      define HAVE_STDBIT 1
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
Standard C/C++ allows `stdbit.h` to be importable but not define anything (this occurs in the default C++ compiler on Ubuntu 26.04).

Therefore, checking for the header is not enough to decide on whether to use these features or fallback to the manual implementation. `__STDC_VERSION_STDBIT_H__` must be defined and have a particular value for the features to exist.

This PR also fixes a bug in the fallback code for bit_ceil when `n == 1`.